### PR TITLE
Update default server port and pagination limit documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ cd cycles-admin-service/cycles-admin-service-api
 mvn spring-boot:run
 ```
 
-The server starts at `http://localhost:8080`. Swagger UI is available at `/swagger-ui.html`.
+The server starts at `http://localhost:7979`. Swagger UI is available at `/swagger-ui.html`.
 
 ### Run with Integration Tests
 
@@ -298,7 +298,7 @@ All list endpoints use **cursor-based pagination**:
 | Parameter | Description |
 |-----------|-------------|
 | `cursor` | Opaque cursor from previous response's `next_cursor` |
-| `limit` | Page size (default: 50, max: 100) |
+| `limit` | Page size (default: 50, max: 200) |
 
 Responses include `next_cursor` and `has_more` fields.
 


### PR DESCRIPTION
## Summary
Updated configuration and API documentation to reflect changes in the server port and pagination limits.

## Key Changes
- Changed default server startup port from `8080` to `7979` in the README
- Updated maximum pagination limit from `100` to `200` in the API documentation

## Details
These changes update the documentation to match the actual application configuration and API behavior. The server port change reflects the configured port in the application properties, and the pagination limit increase allows for larger page sizes in list endpoint responses.

https://claude.ai/code/session_01V4QiiG3XgZ9ALnf3gCaBUw