### PR TITLE
Move tenant validation into atomic Lua scripts for consistency

### DIFF
--- a/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/ApiKeyRepository.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/ApiKeyRepository.java
@@ -18,16 +18,26 @@ public class ApiKeyRepository {
     private static final List<String> DEFAULT_PERMISSIONS = List.of(
         "reservations:create", "reservations:commit", "reservations:release",
         "reservations:extend", "reservations:list", "balances:read");
-    // Lua script for atomic API key creation: SET key + SADD index + SET lookup in one call
+    // Lua script for atomic API key creation with tenant validation.
+    // Validates tenant exists and is ACTIVE atomically, then creates key + index + lookup.
+    // KEYS[1] = apikey:<keyId>, KEYS[2] = apikeys:<tenantId>, KEYS[3] = apikey:lookup:<prefix>,
+    // KEYS[4] = tenant:<tenantId>
+    // ARGV[1] = key JSON, ARGV[2] = keyId
+    // Returns: {'CREATED'}, {'TENANT_NOT_FOUND'}, or {'TENANT_INACTIVE', status}
     private static final String CREATE_KEY_LUA =
+        "local tenant_json = redis.call('GET', KEYS[4])\n" +
+        "if not tenant_json then return {'TENANT_NOT_FOUND'} end\n" +
+        "local tenant = cjson.decode(tenant_json)\n" +
+        "local tenant_status = tenant['status'] or 'ACTIVE'\n" +
+        "if tenant_status ~= 'ACTIVE' then return {'TENANT_INACTIVE', tenant_status} end\n" +
         "redis.call('SET', KEYS[1], ARGV[1])\n" +
         "redis.call('SADD', KEYS[2], ARGV[2])\n" +
         "redis.call('SET', KEYS[3], ARGV[2])\n" +
-        "return 1\n";
+        "return {'CREATED'}\n";
 
     // Lua script for atomic API key revocation: reads, checks state, sets revoked fields in one call.
     // KEYS[1] = apikey:<keyId>
-    // ARGV[1] = reason, ARGV[2] = now_ms
+    // ARGV[1] = reason, ARGV[2] = now_iso (ISO-8601 timestamp, must match Jackson serialization format)
     // Returns: {'OK', updated_json} or {'NOT_FOUND'} or {'ALREADY_REVOKED', existing_json}
     private static final String REVOKE_KEY_LUA =
         "local json = redis.call('GET', KEYS[1])\n" +
@@ -41,26 +51,7 @@ public class ApiKeyRepository {
         "redis.call('SET', KEYS[1], updated)\n" +
         "return {'OK', updated}\n";
     public ApiKeyCreateResponse create(ApiKeyCreateRequest request) {
-        // Validate tenant exists and is active before creating key
         try (Jedis jedis = jedisPool.getResource()) {
-            String tenantData = jedis.get("tenant:" + request.getTenantId());
-            if (tenantData == null) {
-                throw GovernanceException.tenantNotFound(request.getTenantId());
-            }
-            try {
-                @SuppressWarnings("unchecked")
-                Map<String, Object> tenantMap = objectMapper.readValue(tenantData, Map.class);
-                String tenantStatus = (String) tenantMap.get("status");
-                if ("SUSPENDED".equals(tenantStatus) || "CLOSED".equals(tenantStatus)) {
-                    throw new GovernanceException(
-                        io.runcycles.admin.model.shared.ErrorCode.INVALID_REQUEST,
-                        "Tenant is " + tenantStatus + ": " + request.getTenantId(), 400);
-                }
-            } catch (GovernanceException e) {
-                throw e;
-            } catch (Exception e) {
-                LOG.warn("Failed to parse tenant data for validation", e);
-            }
             String keyId = "key_" + UUID.randomUUID().toString().substring(0, 16);
             String keySecret = keyService.generateKeySecret("cyc_live");
             String keyPrefix = keyService.extractPrefix(keySecret);
@@ -82,11 +73,22 @@ public class ApiKeyRepository {
                 .expiresAt(expiresAt)
                 .metadata(request.getMetadata())
                 .build();
-            // Atomic create: SET key + SADD index + SET lookup in one Lua call
+            // Atomic create with tenant validation: check tenant + SET key + SADD index + SET lookup
             String json = objectMapper.writeValueAsString(apiKey);
-            jedis.eval(CREATE_KEY_LUA,
-                List.of("apikey:" + keyId, "apikeys:" + request.getTenantId(), "apikey:lookup:" + keyPrefix),
+            @SuppressWarnings("unchecked")
+            List<String> result = (List<String>) jedis.eval(CREATE_KEY_LUA,
+                List.of("apikey:" + keyId, "apikeys:" + request.getTenantId(),
+                         "apikey:lookup:" + keyPrefix, "tenant:" + request.getTenantId()),
                 List.of(json, keyId));
+            String status = result.get(0);
+            if ("TENANT_NOT_FOUND".equals(status)) {
+                throw GovernanceException.tenantNotFound(request.getTenantId());
+            }
+            if ("TENANT_INACTIVE".equals(status)) {
+                throw new GovernanceException(
+                    io.runcycles.admin.model.shared.ErrorCode.INVALID_REQUEST,
+                    "Tenant is " + result.get(1) + ": " + request.getTenantId(), 400);
+            }
             return ApiKeyCreateResponse.builder()
                 .keyId(keyId)
                 .keySecret(keySecret)
@@ -136,12 +138,12 @@ public class ApiKeyRepository {
     }
     public ApiKey revoke(String keyId, String reason) {
         try (Jedis jedis = jedisPool.getResource()) {
-            String nowMs = String.valueOf(Instant.now().toEpochMilli());
+            String nowIso = Instant.now().toString();
 
             @SuppressWarnings("unchecked")
             List<String> result = (List<String>) jedis.eval(REVOKE_KEY_LUA,
                 List.of("apikey:" + keyId),
-                List.of(reason != null ? reason : "", nowMs));
+                List.of(reason != null ? reason : "", nowIso));
 
             String status = result.get(0);
             if ("NOT_FOUND".equals(status)) {

--- a/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/TenantRepository.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/TenantRepository.java
@@ -17,13 +17,21 @@ public class TenantRepository {
     private static final Logger LOG = LoggerFactory.getLogger(TenantRepository.class);
     @Autowired private JedisPool jedisPool;
     @Autowired private ObjectMapper objectMapper;
-    // Lua script for atomic tenant creation: returns existing JSON if exists, otherwise creates
+    // Lua script for atomic tenant creation with conflict detection.
+    // Returns {'CREATED'} if new, {'EXISTS', json} if idempotent replay (same name),
+    // or {'CONFLICT', json} if tenant_id exists with a different name (spec: 409).
+    // KEYS[1] = tenant key, KEYS[2] = tenants index set
+    // ARGV[1] = new tenant JSON, ARGV[2] = tenant_id, ARGV[3] = request name for conflict check
     private static final String CREATE_TENANT_LUA =
         "local existing = redis.call('GET', KEYS[1])\n" +
-        "if existing then return existing end\n" +
+        "if existing then\n" +
+        "  local tenant = cjson.decode(existing)\n" +
+        "  if tenant['name'] ~= ARGV[3] then return {'CONFLICT', existing} end\n" +
+        "  return {'EXISTS', existing}\n" +
+        "end\n" +
         "redis.call('SET', KEYS[1], ARGV[1])\n" +
         "redis.call('SADD', KEYS[2], ARGV[2])\n" +
-        "return nil\n";
+        "return {'CREATED'}\n";
 
     // Lua script for atomic tenant update: reads, validates status transition, and writes in one step.
     // Prevents lost-update race conditions from concurrent read-modify-write cycles.
@@ -31,7 +39,7 @@ public class TenantRepository {
     // ARGV[1] = new_name (empty string = no change)
     // ARGV[2] = new_status (empty string = no change)
     // ARGV[3] = new_metadata_json (empty string = no change)
-    // ARGV[4] = now_ms (epoch millis for timestamps)
+    // ARGV[4] = now_iso (ISO-8601 timestamp, must match Jackson serialization format)
     // Returns: {'OK', updated_json} on success, or {'ERROR', error_message} on failure
     private static final String UPDATE_TENANT_LUA =
         "local json = redis.call('GET', KEYS[1])\n" +
@@ -40,7 +48,7 @@ public class TenantRepository {
         "local new_name = ARGV[1]\n" +
         "local new_status = ARGV[2]\n" +
         "local new_metadata = ARGV[3]\n" +
-        "local now_ms = ARGV[4]\n" +
+        "local now_iso = ARGV[4]\n" +
         // Apply name change
         "if new_name ~= '' then tenant['name'] = new_name end\n" +
         // Validate and apply status transition
@@ -54,12 +62,12 @@ public class TenantRepository {
         "    return {'INVALID_TRANSITION', 'Invalid status transition: ' .. old_status .. ' -> ' .. new_status}\n" +
         "  end\n" +
         "  tenant['status'] = new_status\n" +
-        "  if new_status == 'SUSPENDED' then tenant['suspended_at'] = now_ms end\n" +
-        "  if new_status == 'CLOSED' then tenant['closed_at'] = now_ms end\n" +
+        "  if new_status == 'SUSPENDED' then tenant['suspended_at'] = now_iso end\n" +
+        "  if new_status == 'CLOSED' then tenant['closed_at'] = now_iso end\n" +
         "end\n" +
         // Apply metadata change
         "if new_metadata ~= '' then tenant['metadata'] = cjson.decode(new_metadata) end\n" +
-        "tenant['updated_at'] = now_ms\n" +
+        "tenant['updated_at'] = now_iso\n" +
         "local updated = cjson.encode(tenant)\n" +
         "redis.call('SET', KEYS[1], updated)\n" +
         "return {'OK', updated}\n";
@@ -83,15 +91,24 @@ public class TenantRepository {
                 .createdAt(Instant.now())
                 .build();
             String json = objectMapper.writeValueAsString(tenant);
-            Object result = jedis.eval(CREATE_TENANT_LUA,
+            @SuppressWarnings("unchecked")
+            List<String> result = (List<String>) jedis.eval(CREATE_TENANT_LUA,
                 List.of(key, "tenants"),
-                List.of(json, request.getTenantId()));
-            if (result != null) {
-                // Tenant already exists — return it (idempotent 200)
-                Tenant existing = objectMapper.readValue((String) result, Tenant.class);
+                List.of(json, request.getTenantId(), request.getName()));
+            String status = result.get(0);
+            if ("CONFLICT".equals(status)) {
+                // Same tenant_id but different name → spec requires 409
+                throw GovernanceException.duplicateResource("Tenant", request.getTenantId());
+            }
+            if ("EXISTS".equals(status)) {
+                // Idempotent replay (same tenant_id and name) → 200
+                Tenant existing = objectMapper.readValue(result.get(1), Tenant.class);
                 return new TenantCreateResult(existing, false);
             }
+            // CREATED
             return new TenantCreateResult(tenant, true);
+        } catch (GovernanceException e) {
+            throw e;
         } catch (Exception e) {
             throw new RuntimeException("Failed to create tenant", e);
         }
@@ -140,7 +157,7 @@ public class TenantRepository {
     public Tenant update(String tenantId, TenantUpdateRequest request) {
         try (Jedis jedis = jedisPool.getResource()) {
             String key = "tenant:" + tenantId;
-            String nowMs = String.valueOf(Instant.now().toEpochMilli());
+            String nowIso = Instant.now().toString();
 
             @SuppressWarnings("unchecked")
             List<String> result = (List<String>) jedis.eval(UPDATE_TENANT_LUA,
@@ -149,7 +166,7 @@ public class TenantRepository {
                     request.getName() != null ? request.getName() : "",
                     request.getStatus() != null ? request.getStatus().name() : "",
                     request.getMetadata() != null ? objectMapper.writeValueAsString(request.getMetadata()) : "",
-                    nowMs
+                    nowIso
                 ));
 
             String status = result.get(0);

--- a/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/ApiKeyRepositoryTest.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/ApiKeyRepositoryTest.java
@@ -49,12 +49,11 @@ class ApiKeyRepositoryTest {
 
     @Test
     void create_validRequest_returnsApiKeyCreateResponse() throws Exception {
-        // Tenant exists and is active
-        when(jedis.get("tenant:test-tenant")).thenReturn("{\"status\":\"ACTIVE\",\"tenant_id\":\"test-tenant\"}");
         when(keyService.generateKeySecret("cyc_live")).thenReturn("cyc_live_abc123def456ghi");
         when(keyService.extractPrefix("cyc_live_abc123def456ghi")).thenReturn("cyc_live_abc12");
         when(keyService.hashKey("cyc_live_abc123def456ghi")).thenReturn("$2a$12$hashvalue");
-        when(jedis.eval(anyString(), anyList(), anyList())).thenReturn(1L);
+        // Lua now validates tenant atomically and returns status list
+        when(jedis.eval(anyString(), anyList(), anyList())).thenReturn(List.of("CREATED"));
 
         ApiKeyCreateRequest request = new ApiKeyCreateRequest();
         request.setTenantId("test-tenant");
@@ -70,36 +69,53 @@ class ApiKeyRepositoryTest {
 
     @Test
     void create_tenantNotFound_throwsException() {
-        when(jedis.get("tenant:missing")).thenReturn(null);
+        when(keyService.generateKeySecret("cyc_live")).thenReturn("cyc_live_abc123def456ghi");
+        when(keyService.extractPrefix(anyString())).thenReturn("cyc_live_abc12");
+        when(keyService.hashKey(anyString())).thenReturn("$2a$12$hash");
+        // Lua returns TENANT_NOT_FOUND when tenant key doesn't exist in Redis
+        when(jedis.eval(anyString(), anyList(), anyList())).thenReturn(List.of("TENANT_NOT_FOUND"));
 
         ApiKeyCreateRequest request = new ApiKeyCreateRequest();
         request.setTenantId("missing");
         request.setName("Test Key");
 
         assertThatThrownBy(() -> repository.create(request))
-                .isInstanceOf(RuntimeException.class);
+                .isInstanceOf(GovernanceException.class)
+                .satisfies(e -> {
+                    GovernanceException ge = (GovernanceException) e;
+                    assertThat(ge.getErrorCode()).isEqualTo(ErrorCode.TENANT_NOT_FOUND);
+                    assertThat(ge.getHttpStatus()).isEqualTo(404);
+                });
     }
 
     @Test
     void create_tenantSuspended_throwsException() {
-        when(jedis.get("tenant:suspended")).thenReturn("{\"status\":\"SUSPENDED\",\"tenant_id\":\"suspended\"}");
+        when(keyService.generateKeySecret("cyc_live")).thenReturn("cyc_live_abc123def456ghi");
+        when(keyService.extractPrefix(anyString())).thenReturn("cyc_live_abc12");
+        when(keyService.hashKey(anyString())).thenReturn("$2a$12$hash");
+        // Lua returns TENANT_INACTIVE with status when tenant is not ACTIVE
+        when(jedis.eval(anyString(), anyList(), anyList())).thenReturn(List.of("TENANT_INACTIVE", "SUSPENDED"));
 
         ApiKeyCreateRequest request = new ApiKeyCreateRequest();
         request.setTenantId("suspended");
         request.setName("Test Key");
 
         assertThatThrownBy(() -> repository.create(request))
-                .isInstanceOf(RuntimeException.class);
+                .isInstanceOf(GovernanceException.class)
+                .satisfies(e -> {
+                    GovernanceException ge = (GovernanceException) e;
+                    assertThat(ge.getErrorCode()).isEqualTo(ErrorCode.INVALID_REQUEST);
+                    assertThat(ge.getHttpStatus()).isEqualTo(400);
+                });
     }
 
     @Test
     void create_withCustomExpiry_usesProvidedExpiry() throws Exception {
         Instant customExpiry = Instant.now().plusSeconds(3600);
-        when(jedis.get("tenant:test-tenant")).thenReturn("{\"status\":\"ACTIVE\",\"tenant_id\":\"test-tenant\"}");
         when(keyService.generateKeySecret("cyc_live")).thenReturn("cyc_live_abc123def456ghi");
         when(keyService.extractPrefix(anyString())).thenReturn("cyc_live_abc12");
         when(keyService.hashKey(anyString())).thenReturn("$2a$12$hash");
-        when(jedis.eval(anyString(), anyList(), anyList())).thenReturn(1L);
+        when(jedis.eval(anyString(), anyList(), anyList())).thenReturn(List.of("CREATED"));
 
         ApiKeyCreateRequest request = new ApiKeyCreateRequest();
         request.setTenantId("test-tenant");

--- a/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/TenantRepositoryTest.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/TenantRepositoryTest.java
@@ -45,7 +45,7 @@ class TenantRepositoryTest {
 
     @Test
     void create_newTenant_returnsCreatedTrue() {
-        when(jedis.eval(anyString(), anyList(), anyList())).thenReturn(null);
+        when(jedis.eval(anyString(), anyList(), anyList())).thenReturn(List.of("CREATED"));
 
         TenantCreateRequest request = new TenantCreateRequest();
         request.setTenantId("test-tenant");
@@ -62,10 +62,10 @@ class TenantRepositoryTest {
     @Test
     void create_existingTenant_returnsCreatedFalse() throws Exception {
         Tenant existing = Tenant.builder()
-                .tenantId("test-tenant").name("Existing").status(TenantStatus.ACTIVE)
+                .tenantId("test-tenant").name("Test Tenant").status(TenantStatus.ACTIVE)
                 .createdAt(Instant.now()).build();
         String json = objectMapper.writeValueAsString(existing);
-        when(jedis.eval(anyString(), anyList(), anyList())).thenReturn(json);
+        when(jedis.eval(anyString(), anyList(), anyList())).thenReturn(List.of("EXISTS", json));
 
         TenantCreateRequest request = new TenantCreateRequest();
         request.setTenantId("test-tenant");
@@ -74,7 +74,27 @@ class TenantRepositoryTest {
         var result = repository.create(request);
 
         assertThat(result.created()).isFalse();
-        assertThat(result.tenant().getName()).isEqualTo("Existing");
+        assertThat(result.tenant().getName()).isEqualTo("Test Tenant");
+    }
+
+    @Test
+    void create_conflictingTenant_throws409() {
+        Tenant existing = Tenant.builder()
+                .tenantId("test-tenant").name("Original Name").status(TenantStatus.ACTIVE)
+                .createdAt(Instant.now()).build();
+        when(jedis.eval(anyString(), anyList(), anyList())).thenReturn(List.of("CONFLICT", "{}"));
+
+        TenantCreateRequest request = new TenantCreateRequest();
+        request.setTenantId("test-tenant");
+        request.setName("Different Name");
+
+        assertThatThrownBy(() -> repository.create(request))
+                .isInstanceOf(GovernanceException.class)
+                .satisfies(e -> {
+                    GovernanceException ge = (GovernanceException) e;
+                    assertThat(ge.getErrorCode()).isEqualTo(ErrorCode.DUPLICATE_RESOURCE);
+                    assertThat(ge.getHttpStatus()).isEqualTo(409);
+                });
     }
 
     @Test


### PR DESCRIPTION
## Summary
Refactored tenant validation logic from Java application code into atomic Lua scripts executed in Redis. This ensures tenant state checks are performed atomically with resource creation/updates, eliminating race conditions and improving consistency across the codebase.

## Key Changes

- **ApiKeyRepository**: Moved tenant existence and status validation into the `CREATE_KEY_LUA` script. The Lua script now atomically validates that the tenant exists and is ACTIVE before creating the API key, returning status indicators (`CREATED`, `TENANT_NOT_FOUND`, `TENANT_INACTIVE`) instead of numeric codes.

- **TenantRepository**: Enhanced `CREATE_TENANT_LUA` script to detect conflicts between idempotent replays (same tenant_id and name) and actual conflicts (same tenant_id but different name), returning appropriate status indicators (`CREATED`, `EXISTS`, `CONFLICT`) for proper HTTP response codes (200 vs 409).

- **Timestamp Format Standardization**: Changed all timestamp parameters in Lua scripts from epoch milliseconds (`now_ms`) to ISO-8601 format (`now_iso` via `Instant.now().toString()`) to match Jackson serialization format and improve consistency across the system.

- **Test Updates**: Updated unit tests to reflect the new Lua script return values (status lists instead of raw data or numeric codes) and added new test case for tenant creation conflict detection (409 response).

## Notable Implementation Details

- Lua scripts now return structured status lists (e.g., `{'CREATED'}`, `{'TENANT_NOT_FOUND'}`, `{'TENANT_INACTIVE', status}`) for clear, type-safe result handling in Java
- Tenant validation in API key creation is now atomic with key creation, preventing TOCTOU (time-of-check-time-of-use) vulnerabilities
- Conflict detection in tenant creation properly distinguishes between idempotent replays (200) and actual conflicts (409) per API specification
- All timestamp fields now use ISO-8601 format consistently across both repositories

https://claude.ai/code/session_01Wu9HPZeSuXcF8iu3FvA6c5