### PR TITLE
Add Docker quick start guide to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,32 @@ cycles-admin-service/
 - **API Docs:** SpringDoc OpenAPI (Swagger UI)
 - **Testing:** JUnit 5 + TestContainers (Redis)
 
-## Prerequisites
+## Quick Start with Docker
+
+The fastest way to run the admin server — no Java or Maven required:
+
+```bash
+# Using pre-built image from GHCR
+docker compose -f docker-compose.prod.yml up -d
+```
+
+The server starts at `http://localhost:7979`. Swagger UI: http://localhost:7979/swagger-ui.html
+
+To run the full stack (Admin Server + Runtime Server + Redis):
+
+```bash
+docker compose -f docker-compose.full-stack.prod.yml up -d
+```
+
+> For the complete deployment walkthrough including tenant setup, API key creation, and budget allocation, see the [full stack deployment guide](https://runcycles.github.io/docs/quickstart/deploying-the-full-cycles-stack).
+
+## Prerequisites (for building from source)
 
 - Java 21+
 - Maven 3.9+
 - Redis 7+ (or Docker for TestContainers)
 
-## Getting Started
+## Building from Source
 
 ### Build
 


### PR DESCRIPTION
## Summary
Updated the README to provide Docker-based quick start instructions, making it easier for users to get the admin server running without requiring Java or Maven installation.

## Key Changes
- Added new "Quick Start with Docker" section with instructions for running pre-built Docker images from GHCR
- Provided commands for running the admin server standalone and the full stack (Admin Server + Runtime Server + Redis)
- Added link to comprehensive full stack deployment guide
- Reorganized prerequisites section to clarify they are only needed for building from source
- Renamed "Getting Started" section to "Building from Source" for clarity

## Notable Details
- Docker quick start is positioned prominently before prerequisites to encourage the easiest path to getting started
- Includes direct links to Swagger UI and deployment documentation
- Maintains existing build-from-source instructions while making Docker the primary recommendation

https://claude.ai/code/session_01L6csPLeJCTVKdoGSkwm93i