### PR TITLE
Add CI workflow for automated testing on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Run unit tests
+        run: mvn -B test --file cycles-admin-service/pom.xml


### PR DESCRIPTION
## Summary
This PR introduces a GitHub Actions CI workflow to automatically run unit tests on push and pull request events targeting the main branch.

## Key Changes
- Added `.github/workflows/ci.yml` workflow configuration that:
  - Triggers on pushes to main and pull requests against main
  - Sets up JDK 21 (Temurin distribution) with Maven caching for faster builds
  - Runs Maven unit tests for the cycles-admin-service module

## Implementation Details
The workflow uses:
- `actions/checkout@v4` for repository access
- `actions/setup-java@v4` with Maven cache enabled to optimize build times
- Maven's batch mode (`-B` flag) for non-interactive test execution
- Targets the `cycles-admin-service/pom.xml` module specifically

https://claude.ai/code/session_01QMAXC8BGpmHdXCT5LS7Zam