### PR TITLE
Update ErrorCode audit documentation to reflect 23 total values

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -115,7 +115,7 @@ Note: The spec also defines `POST /v1/reservations`, `POST /v1/reservations/{id}
 |---|---|---|---|
 | `UnitEnum` | `UnitEnum` | `USD_MICROCENTS`, `TOKENS`, `CREDITS`, `RISK_POINTS` | PASS |
 | `CommitOveragePolicy` | `CommitOveragePolicy` | `REJECT`, `ALLOW_IF_AVAILABLE`, `ALLOW_WITH_OVERDRAFT` | PASS |
-| `ErrorCode` | `ErrorCode` | All 22 spec values (12 runtime + 10 admin-specific) | PASS |
+| `ErrorCode` | `ErrorCode` | All 23 spec values (12 runtime + 11 admin-specific) | PASS |
 | `TenantStatus` | `TenantStatus` | `ACTIVE`, `SUSPENDED`, `CLOSED` | PASS |
 | `ApiKeyStatus` | `ApiKeyStatus` | `ACTIVE`, `REVOKED`, `EXPIRED` | PASS |
 | `PolicyStatus` | `PolicyStatus` | `ACTIVE`, `DISABLED` | PASS |


### PR DESCRIPTION
## Summary
Updated the AUDIT.md documentation to reflect an increase in the total number of ErrorCode enum values from 22 to 23, with the additional value being an admin-specific error code.

## Changes
- Updated ErrorCode audit entry from "All 22 spec values (12 runtime + 10 admin-specific)" to "All 23 spec values (12 runtime + 11 admin-specific)"
- This reflects the addition of one new admin-specific error code to the specification

## Notes
This is a documentation-only change to the audit trail, indicating that a new admin-specific ErrorCode value has been added to the API specification and implementation.

https://claude.ai/code/session_01A5WPQ44yajxzxWk6fpqYgW