### PR TITLE
Implement CI-friendly Maven versioning with flatten-maven-plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Extract version from POM
         id: version
         run: |
-          VERSION=$(sed -n '/<parent>/,/<\/parent>/d; s/.*<version>\(.*\)<\/version>.*/\1/p' cycles-admin-service/pom.xml | head -1 | tr -d ' ')
+          VERSION=$(sed -n 's/.*<revision>\(.*\)<\/revision>.*/\1/p' cycles-admin-service/pom.xml | tr -d ' ')
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Detected version: $VERSION"
 

--- a/cycles-admin-service/cycles-admin-service-api/pom.xml
+++ b/cycles-admin-service/cycles-admin-service-api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.runcycles</groupId>
         <artifactId>cycles-admin-service</artifactId>
-        <version>0.1.23</version>
+        <version>${revision}</version>
     </parent>
     <artifactId>cycles-admin-service-api</artifactId>
     <name>Cycles Admin Service API</name>
@@ -13,12 +13,12 @@
         <dependency>
             <groupId>io.runcycles</groupId>
             <artifactId>cycles-admin-service-model</artifactId>
-            <version>0.1.23</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.runcycles</groupId>
             <artifactId>cycles-admin-service-data</artifactId>
-            <version>0.1.23</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/cycles-admin-service/cycles-admin-service-data/pom.xml
+++ b/cycles-admin-service/cycles-admin-service-data/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.runcycles</groupId>
         <artifactId>cycles-admin-service</artifactId>
-        <version>0.1.23</version>
+        <version>${revision}</version>
     </parent>
     <artifactId>cycles-admin-service-data</artifactId>
     <name>Cycles Admin Service Data</name>
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.runcycles</groupId>
             <artifactId>cycles-admin-service-model</artifactId>
-            <version>0.1.23</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>redis.clients</groupId>

--- a/cycles-admin-service/cycles-admin-service-model/pom.xml
+++ b/cycles-admin-service/cycles-admin-service-model/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.runcycles</groupId>
         <artifactId>cycles-admin-service</artifactId>
-        <version>0.1.23</version>
+        <version>${revision}</version>
     </parent>
     <artifactId>cycles-admin-service-model</artifactId>
     <name>Cycles Admin Service Model</name>

--- a/cycles-admin-service/pom.xml
+++ b/cycles-admin-service/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>io.runcycles</groupId>
     <artifactId>cycles-admin-service</artifactId>
-    <version>0.1.23</version>
+    <version>${revision}</version>
     <packaging>pom</packaging>
     <name>Cycles Admin Service</name>
     <description>Cycles Admin Service API v0.1.23</description>
@@ -18,6 +18,7 @@
         <module>cycles-admin-service-api</module>
     </modules>
     <properties>
+        <revision>0.1.23</revision>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
@@ -50,6 +51,31 @@
     </dependencyManagement>
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>


### PR DESCRIPTION
## Summary
This PR refactors the Maven build configuration to use CI-friendly versioning practices by introducing the `flatten-maven-plugin` and centralizing version management through a `${revision}` property.

## Key Changes
- **Centralized version management**: Moved hardcoded version `0.1.23` from individual `pom.xml` files to a single `<revision>` property in the parent `pom.xml`
- **Updated all module references**: Changed version declarations in parent and child modules to use `${revision}` placeholder
- **Internal dependency versioning**: Updated inter-module dependencies to use `${project.version}` for consistency
- **Added flatten-maven-plugin**: Integrated `org.codehaus.mojo:flatten-maven-plugin` (v1.6.0) with:
  - `resolveCiFriendliesOnly` mode to resolve `${revision}` placeholders during build
  - Automatic POM flattening in `process-resources` phase
  - Clean phase integration for build artifact cleanup
- **Updated CI/CD pipeline**: Modified GitHub Actions release workflow to extract version from the new `<revision>` property location instead of parsing the parent version tag

## Implementation Details
The flatten-maven-plugin will automatically resolve the `${revision}` property during the Maven build process, ensuring that published artifacts contain concrete version numbers while the source POM files remain flexible for CI/CD environments. This approach follows Maven best practices for CI-friendly builds and simplifies version management across the multi-module project structure.

https://claude.ai/code/session_01KFNMuBGFnqrDs1AFjm2QLF