### PR TITLE
fix: allow %2F-encoded scopes in budget endpoint URL paths

### DIFF
--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/config/TomcatConfig.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/config/TomcatConfig.java
@@ -1,0 +1,30 @@
+package io.runcycles.admin.api.config;
+
+import org.apache.catalina.connector.Connector;
+import org.apache.coyote.http11.AbstractHttp11Protocol;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configures Tomcat to allow %2F (encoded forward slash) in URL paths.
+ *
+ * Budget, policy, and other endpoints use scope as a path variable (e.g.
+ * /v1/admin/budgets/{scope}/{unit}/fund). Scopes like "tenant:acme/workspace:prod"
+ * contain a forward slash that must be URL-encoded as %2F. Tomcat's default behavior
+ * rejects %2F in paths with HTTP 400 to prevent directory traversal. Setting
+ * encodedSolidusHandling to PASSTHROUGH keeps %2F as a literal in the raw path so
+ * Spring's PathPatternParser treats it as part of a single path segment, then
+ * URL-decodes it when extracting the @PathVariable value.
+ */
+@Configuration
+public class TomcatConfig {
+
+    @Bean
+    public WebServerFactoryCustomizer<TomcatServletWebServerFactory> encodedSlashCustomizer() {
+        return factory -> factory.addConnectorCustomizers(connector ->
+            connector.setEncodedSolidusHandling("passthrough")
+        );
+    }
+}

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BudgetControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BudgetControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import redis.clients.jedis.JedisPool;
 
+import java.net.URI;
 import java.time.Instant;
 import java.util.List;
 
@@ -453,6 +454,52 @@ class BudgetControllerTest {
                         .content("{\"operation\":\"CREDIT\",\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":1000}}"))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.error").value("BUDGET_CLOSED"));
+    }
+
+    @Test
+    void fundBudget_workspaceScopeWithEncodedSlash_returns200() throws Exception {
+        setupApiKeyAuth();
+        BudgetFundingResponse funding = BudgetFundingResponse.builder()
+                .operation(FundingOperation.CREDIT)
+                .previousAllocated(new Amount(UnitEnum.USD_MICROCENTS, 0L))
+                .newAllocated(new Amount(UnitEnum.USD_MICROCENTS, 500000L))
+                .previousRemaining(new Amount(UnitEnum.USD_MICROCENTS, 0L))
+                .newRemaining(new Amount(UnitEnum.USD_MICROCENTS, 500000L))
+                .timestamp(Instant.now()).build();
+        when(budgetRepository.fund(eq("t1"), eq("tenant:acme/workspace:prod"), eq(UnitEnum.USD_MICROCENTS), any()))
+                .thenReturn(funding);
+
+        mockMvc.perform(post(new URI("/v1/admin/budgets/tenant:acme%2Fworkspace:prod/USD_MICROCENTS/fund"))
+                        .header("X-Cycles-API-Key", "valid-api-key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"operation\":\"CREDIT\",\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":500000}}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.operation").value("CREDIT"))
+                .andExpect(jsonPath("$.new_allocated.amount").value(500000));
+
+        verify(budgetRepository).fund(eq("t1"), eq("tenant:acme/workspace:prod"), eq(UnitEnum.USD_MICROCENTS), any());
+    }
+
+    @Test
+    void updateBudget_workspaceScopeWithEncodedSlash_returns200() throws Exception {
+        setupApiKeyAuth();
+        BudgetLedger ledger = BudgetLedger.builder()
+                .ledgerId("led-1").scope("tenant:acme/workspace:prod").unit(UnitEnum.USD_MICROCENTS)
+                .allocated(new Amount(UnitEnum.USD_MICROCENTS, 1000000L))
+                .remaining(new Amount(UnitEnum.USD_MICROCENTS, 500000L))
+                .overdraftLimit(new Amount(UnitEnum.USD_MICROCENTS, 50000L))
+                .status(BudgetStatus.ACTIVE).createdAt(Instant.now()).build();
+        when(budgetRepository.update(eq("t1"), eq("tenant:acme/workspace:prod"), eq(UnitEnum.USD_MICROCENTS), any()))
+                .thenReturn(ledger);
+
+        mockMvc.perform(patch(new URI("/v1/admin/budgets/tenant:acme%2Fworkspace:prod/USD_MICROCENTS"))
+                        .header("X-Cycles-API-Key", "valid-api-key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"overdraft_limit\":{\"unit\":\"USD_MICROCENTS\",\"amount\":50000}}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.scope").value("tenant:acme/workspace:prod"));
+
+        verify(budgetRepository).update(eq("t1"), eq("tenant:acme/workspace:prod"), eq(UnitEnum.USD_MICROCENTS), any());
     }
 
     // ========== PATCH /v1/admin/budgets/{scope}/{unit} ==========


### PR DESCRIPTION
Tomcat rejects %2F (encoded forward slash) in URL paths by default, returning HTTP 400 before Spring processes the request. Workspace, app, agent, and workflow scopes contain / which must be URL-encoded in path-based endpoints (fund, patch). Add TomcatConfig to set encodedSolidusHandling to PASSTHROUGH so %2F is treated as part of the path segment, not a separator.

Add tests verifying workspace-scoped fund and patch with %2F.

https://claude.ai/code/session_01WeUFfwYKWvpCXPUYsZLqUa