### PR TITLE
fix: align spec and code — listBudgets tenant_id optional, policy pat…

### DIFF
--- a/complete-budget-governance-v0.1.24.yaml
+++ b/complete-budget-governance-v0.1.24.yaml
@@ -1123,7 +1123,11 @@ paths:
       parameters:
         - name: tenant_id
           in: query
-          required: true
+          required: false
+          description: >-
+            Ignored when using ApiKeyAuth — the authenticated tenant from the
+            API key is always used for scoping.  Accepted for backwards
+            compatibility but has no effect.
           schema:
             type: string
         - name: scope_prefix

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/PolicyController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/PolicyController.java
@@ -30,8 +30,8 @@ public class PolicyController {
             .build());
         return ResponseEntity.status(201).body(policy);
     }
-    @PatchMapping("/{policyId}") @Operation(operationId = "updatePolicy")
-    public ResponseEntity<Policy> update(@PathVariable String policyId, @Valid @RequestBody PolicyUpdateRequest request, HttpServletRequest httpRequest) {
+    @PatchMapping("/{policy_id}") @Operation(operationId = "updatePolicy")
+    public ResponseEntity<Policy> update(@PathVariable("policy_id") String policyId, @Valid @RequestBody PolicyUpdateRequest request, HttpServletRequest httpRequest) {
         String tenantId = (String) httpRequest.getAttribute("authenticated_tenant_id");
         Policy policy = repository.update(tenantId, policyId, request);
         auditRepository.log(buildAuditEntry(httpRequest)


### PR DESCRIPTION
…h variable naming

1. OpenAPI spec: mark listBudgets tenant_id as required: false with documentation that authenticated tenant is always used for scoping. Code already ignores user-supplied tenant_id for security.

2. PolicyController: rename path variable from {policyId} to {policy_id} to match the OpenAPI spec convention used by all other controllers.

https://claude.ai/code/session_01WeUFfwYKWvpCXPUYsZLqUa