### PR TITLE
Fix CI: exclude integration tests that require Docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,3 +11,4 @@ jobs:
     uses: runcycles/.github/.github/workflows/ci-java.yml@main
     with:
       pom-file: cycles-admin-service/pom.xml
+      maven-args: "-Dtest=!*IntegrationTest -Dsurefire.failIfNoSpecifiedTests=false"


### PR DESCRIPTION
RedisIntegrationTest uses Testcontainers which requires Docker, not available in GitHub Actions runners. Exclude *IntegrationTest via the new maven-args input on the reusable workflow.