### PR TITLE
fix: use IANA reserved domain in WebhookUrlValidatorTest for CI

### DIFF
--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookUrlValidatorTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookUrlValidatorTest.java
@@ -131,8 +131,8 @@ class WebhookUrlValidatorTest {
     void validate_noAllowedPatterns_doesNotFilter() {
         when(configRepository.get()).thenReturn(configNoCidrBlock(false));
 
-        // Should not throw — no patterns means allow all
-        urlValidator.validate("https://any-domain.com/webhook");
+        // Should not throw — no patterns means allow all (use example.com — IANA reserved, always resolves)
+        urlValidator.validate("https://example.com/webhook");
     }
 
     @Test


### PR DESCRIPTION
any-domain.com does not resolve in GitHub Actions CI runners. Use example.com which is IANA-reserved and guaranteed to resolve.

## Summary

<!-- What does this PR do? Why? -->

## Checklist

- [x] Tests added/updated for new behavior
- [ ] `AUDIT.md` updated (if protocol surface changed)
- [ ] `README.md` updated (if public API changed)
- [ ] Lint and test suite passes locally

## Test plan

<!-- How was this tested? What commands were run? -->
