### PR TITLE
fix: spec compliance — limit clamping, README corrections

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,8 +1,35 @@
 # Complete Budget Governance v0.1.25 — Admin Server Audit
 
-**Date:** 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
+**Date:** 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
 **Spec:** `complete-budget-governance-v0.1.25.yaml` (OpenAPI 3.1.0, v0.1.25)
 **Server:** Spring Boot 3.5.11 / Java 21 / Redis
+
+### 2026-04-01 — Spec Compliance Review: README, Pagination, Error Codes
+
+Full review of code, README, and spec compliance against `complete-budget-governance-v0.1.25.yaml`.
+
+**Spec compliance fixes:**
+
+| Issue | Fix |
+|-------|-----|
+| Pillar 4 list endpoints (webhooks, events) missing `limit` clamping | Added `Math.max(1, Math.min(limit, 100))` to 6 controller methods per spec `maximum: 100` |
+| `WebhookUpdateRequest.status` accepted `DISABLED` | Already validated in `WebhookService.update()` — confirmed spec-compliant (only `ACTIVE`/`PAUSED` allowed) |
+
+**README fixes:**
+
+| Issue | Fix |
+|-------|-----|
+| Pagination `max: 200` incorrect | Changed to `max: 100` per spec |
+| 5 governance error codes missing | Added `BUDGET_CLOSED`, `WEBHOOK_NOT_FOUND`, `WEBHOOK_URL_INVALID`, `EVENT_NOT_FOUND`, `REPLAY_IN_PROGRESS` |
+| 4 environment variables undocumented | Added `LOG_LEVEL`, `SWAGGER_ENABLED`, `EVENT_TTL_DAYS`, `DELIVERY_TTL_DAYS` to env var table |
+
+**Tests added:** 6 new tests verifying limit clamping on all Pillar 4 list endpoints (WebhookAdminController, WebhookTenantController, EventAdminController, EventTenantController). Total: 331 tests, 0 failures.
+
+**Confirmed correct:**
+- All 27 ErrorCode enum values match spec
+- All 40 EventType values match spec
+- All 38 admin endpoints implemented with correct paths, methods, auth schemes
+- Auth routing (AdminKeyAuth vs ApiKeyAuth) matches spec for all endpoints
 
 ### 2026-04-01 — Release Prep: Docker + Docs
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ API keys use the format `cyc_live_{random}` (production) or `cyc_test_{random}` 
 | `REDIS_PASSWORD` | Yes | — | Redis password (empty for no auth) |
 | `ADMIN_API_KEY` | Yes | — | Master admin API key for `X-Admin-API-Key` header |
 | `WEBHOOK_SECRET_ENCRYPTION_KEY` | No | (empty) | AES-256-GCM encryption key for webhook signing secrets at rest. Base64-encoded 32 bytes. If empty, secrets stored in plaintext (dev mode). |
+| `LOG_LEVEL` | No | `INFO` | Application logging level (`DEBUG`, `INFO`, `WARN`, `ERROR`) |
+| `SWAGGER_ENABLED` | No | `false` | Enable Swagger UI at `/swagger-ui.html` |
+| `EVENT_TTL_DAYS` | No | `90` | Event retention in Redis (days) |
+| `DELIVERY_TTL_DAYS` | No | `14` | Webhook delivery retention in Redis (days) |
 
 ### Webhook Secret Encryption
 
@@ -462,7 +466,7 @@ All list endpoints use **cursor-based pagination**:
 | Parameter | Description |
 |-----------|-------------|
 | `cursor` | Opaque cursor from previous response's `next_cursor` |
-| `limit` | Page size (default: 50, max: 200) |
+| `limit` | Page size (default: 50, max: 100) |
 
 Responses include `next_cursor` and `has_more` fields.
 
@@ -483,7 +487,7 @@ All errors return a standard `ErrorResponse`:
 `INVALID_REQUEST`, `UNAUTHORIZED`, `FORBIDDEN`, `NOT_FOUND`, `BUDGET_EXCEEDED`, `RESERVATION_EXPIRED`, `RESERVATION_FINALIZED`, `IDEMPOTENCY_MISMATCH`, `UNIT_MISMATCH`, `OVERDRAFT_LIMIT_EXCEEDED`, `DEBT_OUTSTANDING`, `INTERNAL_ERROR`
 
 **Governance error codes:**
-`TENANT_NOT_FOUND`, `TENANT_SUSPENDED`, `TENANT_CLOSED`, `BUDGET_NOT_FOUND`, `BUDGET_FROZEN`, `POLICY_VIOLATION`, `INSUFFICIENT_PERMISSIONS`, `KEY_REVOKED`, `KEY_EXPIRED`, `DUPLICATE_RESOURCE`
+`TENANT_NOT_FOUND`, `TENANT_SUSPENDED`, `TENANT_CLOSED`, `BUDGET_NOT_FOUND`, `BUDGET_FROZEN`, `BUDGET_CLOSED`, `POLICY_VIOLATION`, `INSUFFICIENT_PERMISSIONS`, `KEY_REVOKED`, `KEY_EXPIRED`, `DUPLICATE_RESOURCE`, `WEBHOOK_NOT_FOUND`, `WEBHOOK_URL_INVALID`, `EVENT_NOT_FOUND`, `REPLAY_IN_PROGRESS`
 
 ## Deployment Models
 

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/EventAdminController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/EventAdminController.java
@@ -25,6 +25,7 @@ public class EventAdminController {
             @RequestParam(required = false) Instant to,
             @RequestParam(required = false) String cursor,
             @RequestParam(defaultValue = "50") int limit) {
+        limit = Math.max(1, Math.min(limit, 100));
         return ResponseEntity.ok(eventService.list(tenant_id, event_type, category, scope,
             correlation_id, from, to, cursor, limit));
     }

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/EventTenantController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/EventTenantController.java
@@ -49,6 +49,7 @@ public class EventTenantController {
             throw new GovernanceException(ErrorCode.INVALID_REQUEST,
                 "Category " + category + " is admin-only; tenants can query budget, reservation, tenant only", 400);
         }
+        limit = Math.max(1, Math.min(limit, 100));
         return ResponseEntity.ok(eventService.list(tenantId, event_type, category, scope,
             correlation_id, from, to, cursor, limit));
     }

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/WebhookAdminController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/WebhookAdminController.java
@@ -37,6 +37,7 @@ public class WebhookAdminController {
             @RequestParam(required = false) String event_type,
             @RequestParam(required = false) String cursor,
             @RequestParam(defaultValue = "50") int limit) {
+        limit = Math.max(1, Math.min(limit, 100));
         return ResponseEntity.ok(webhookService.listAll(tenant_id, status, event_type, cursor, limit));
     }
 
@@ -76,6 +77,7 @@ public class WebhookAdminController {
             @RequestParam(required = false) Instant to,
             @RequestParam(required = false) String cursor,
             @RequestParam(defaultValue = "50") int limit) {
+        limit = Math.max(1, Math.min(limit, 100));
         return ResponseEntity.ok(webhookService.listDeliveries(subscriptionId, status, from, to, cursor, limit));
     }
 

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/WebhookTenantController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/WebhookTenantController.java
@@ -35,6 +35,7 @@ public class WebhookTenantController {
             @RequestParam(defaultValue = "50") int limit,
             HttpServletRequest httpRequest) {
         String tenantId = getAuthenticatedTenantId(httpRequest);
+        limit = Math.max(1, Math.min(limit, 100));
         return ResponseEntity.ok(webhookService.listByTenant(tenantId, status, null, cursor, limit));
     }
 
@@ -91,6 +92,7 @@ public class WebhookTenantController {
         String tenantId = getAuthenticatedTenantId(httpRequest);
         WebhookSubscription existing = webhookService.get(subscriptionId);
         enforceTenantOwnership(existing, tenantId);
+        limit = Math.max(1, Math.min(limit, 100));
         return ResponseEntity.ok(webhookService.listDeliveries(subscriptionId, status, from, to, cursor, limit));
     }
 

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/EventAdminControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/EventAdminControllerTest.java
@@ -85,6 +85,21 @@ class EventAdminControllerTest {
     }
 
     @Test
+    void listEvents_clampsLimitTo100() throws Exception {
+        EventListResponse response = EventListResponse.builder()
+            .events(List.of()).hasMore(false).build();
+        when(eventService.list(any(), any(), any(), any(), any(), any(), any(), any(), eq(100)))
+            .thenReturn(response);
+
+        mockMvc.perform(get("/v1/admin/events")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .param("limit", "999"))
+                .andExpect(status().isOk());
+
+        verify(eventService).list(any(), any(), any(), any(), any(), any(), any(), any(), eq(100));
+    }
+
+    @Test
     void getEvent_notFound_returns404() throws Exception {
         when(eventService.findById("evt_missing"))
             .thenThrow(GovernanceException.eventNotFound("evt_missing"));

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/EventTenantControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/EventTenantControllerTest.java
@@ -76,6 +76,22 @@ class EventTenantControllerTest {
     }
 
     @Test
+    void listEvents_clampsLimitTo100() throws Exception {
+        setupApiKeyAuth();
+        EventListResponse response = EventListResponse.builder()
+            .events(List.of()).hasMore(false).build();
+        when(eventService.list(eq("t1"), any(), any(), any(), any(), any(), any(), any(), eq(100)))
+            .thenReturn(response);
+
+        mockMvc.perform(get("/v1/events")
+                        .header("X-Cycles-API-Key", "valid-api-key")
+                        .param("limit", "999"))
+                .andExpect(status().isOk());
+
+        verify(eventService).list(eq("t1"), any(), any(), any(), any(), any(), any(), any(), eq(100));
+    }
+
+    @Test
     void listEvents_adminOnlyEventType_returns400() throws Exception {
         setupApiKeyAuth();
 

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookAdminControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookAdminControllerTest.java
@@ -162,6 +162,35 @@ class WebhookAdminControllerTest {
     }
 
     @Test
+    void listWebhooks_clampsLimitTo100() throws Exception {
+        WebhookListResponse response = WebhookListResponse.builder()
+            .subscriptions(List.of()).hasMore(false).build();
+        when(webhookService.listAll(any(), any(), any(), any(), eq(100))).thenReturn(response);
+
+        mockMvc.perform(get("/v1/admin/webhooks")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .param("limit", "999"))
+                .andExpect(status().isOk());
+
+        verify(webhookService).listAll(any(), any(), any(), any(), eq(100));
+    }
+
+    @Test
+    void listDeliveries_clampsLimitTo100() throws Exception {
+        WebhookDeliveryListResponse response = WebhookDeliveryListResponse.builder()
+            .deliveries(List.of()).hasMore(false).build();
+        when(webhookService.listDeliveries(eq("whsub_1"), any(), any(), any(), any(), eq(100)))
+            .thenReturn(response);
+
+        mockMvc.perform(get("/v1/admin/webhooks/whsub_1/deliveries")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .param("limit", "999"))
+                .andExpect(status().isOk());
+
+        verify(webhookService).listDeliveries(eq("whsub_1"), any(), any(), any(), any(), eq(100));
+    }
+
+    @Test
     void replay_returns202() throws Exception {
         ReplayResponse response = ReplayResponse.builder()
             .replayId("replay_1").eventsQueued(5).estimatedCompletionSeconds(10).build();

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookTenantControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookTenantControllerTest.java
@@ -236,6 +236,41 @@ class WebhookTenantControllerTest {
     }
 
     @Test
+    void listWebhooks_clampsLimitTo100() throws Exception {
+        setupApiKeyAuth();
+        WebhookListResponse response = WebhookListResponse.builder()
+            .subscriptions(List.of()).hasMore(false).build();
+        when(webhookService.listByTenant(eq("t1"), any(), any(), any(), eq(100))).thenReturn(response);
+
+        mockMvc.perform(get("/v1/webhooks")
+                        .header("X-Cycles-API-Key", "valid-api-key")
+                        .param("limit", "999"))
+                .andExpect(status().isOk());
+
+        verify(webhookService).listByTenant(eq("t1"), any(), any(), any(), eq(100));
+    }
+
+    @Test
+    void listDeliveries_clampsLimitTo100() throws Exception {
+        setupApiKeyAuth();
+        WebhookSubscription sub = WebhookSubscription.builder()
+            .subscriptionId("whsub_1").tenantId("t1").url("https://example.com/wh")
+            .status(WebhookStatus.ACTIVE).createdAt(Instant.now()).build();
+        when(webhookService.get("whsub_1")).thenReturn(sub);
+        WebhookDeliveryListResponse response = WebhookDeliveryListResponse.builder()
+            .deliveries(List.of()).hasMore(false).build();
+        when(webhookService.listDeliveries(eq("whsub_1"), any(), any(), any(), any(), eq(100)))
+            .thenReturn(response);
+
+        mockMvc.perform(get("/v1/webhooks/whsub_1/deliveries")
+                        .header("X-Cycles-API-Key", "valid-api-key")
+                        .param("limit", "999"))
+                .andExpect(status().isOk());
+
+        verify(webhookService).listDeliveries(eq("whsub_1"), any(), any(), any(), any(), eq(100));
+    }
+
+    @Test
     void listWebhooks_returns200() throws Exception {
         setupApiKeyAuth();
         WebhookListResponse response = WebhookListResponse.builder()


### PR DESCRIPTION
## Summary

- **Limit clamping**: Added `Math.max(1, Math.min(limit, 100))` to 6 Pillar 4 list endpoints (webhooks + events controllers) per spec `maximum: 100`
- **README fixes**: Pagination max 200→100, added 5 missing governance error codes (`BUDGET_CLOSED`, `WEBHOOK_NOT_FOUND`, `WEBHOOK_URL_INVALID`, `EVENT_NOT_FOUND`, `REPLAY_IN_PROGRESS`), added 4 undocumented env vars (`LOG_LEVEL`, `SWAGGER_ENABLED`, `EVENT_TTL_DAYS`, `DELIVERY_TTL_DAYS`)
- **Tests**: 6 new controller tests verifying limit clamping via Mockito `eq(100)` verification

## Test plan

- [x] `mvn -B verify` — 331 tests, 0 failures, all JaCoCo coverage checks pass
- [ ] Verify README env var table matches `application.properties` defaults
- [ ] Verify governance error codes list matches `ErrorCode.java` enum
- [ ] Confirm Pillar 4 list endpoints reject `limit=999` by clamping to 100