### PR TITLE
fix: lowercase scope values on budget create/update/fund

### DIFF
--- a/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/BudgetRepository.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/BudgetRepository.java
@@ -18,6 +18,16 @@ import java.util.*;
 @Repository
 public class BudgetRepository {
     private static final Logger LOG = LoggerFactory.getLogger(BudgetRepository.class);
+
+    /**
+     * Normalize scope values to lowercase to match the runtime server's
+     * ScopeDerivationService which lowercases all scope segments.
+     * Preserves the "level:value" structure but lowercases the values.
+     */
+    private static String normalizeScope(String scope) {
+        if (scope == null) return null;
+        return scope.toLowerCase();
+    }
     @Autowired private JedisPool jedisPool;
     @Autowired private ObjectMapper objectMapper;
 
@@ -116,15 +126,16 @@ public class BudgetRepository {
         "return 1\n";
 
     public BudgetLedger create(String tenantId, BudgetCreateRequest request) {
-        LOG.info("Creating budget: scope={}, unit={}", request.getScope(), request.getUnit());
+        String normalizedScope = normalizeScope(request.getScope());
+        LOG.info("Creating budget: scope={}, unit={}", normalizedScope, request.getUnit());
         try (Jedis jedis = jedisPool.getResource()) {
-            String key = "budget:" + request.getScope() + ":" + request.getUnit();
+            String key = "budget:" + normalizedScope + ":" + request.getUnit();
             String indexKey = "budgets:" + tenantId;
 
             BudgetLedger ledger = BudgetLedger.builder()
                 .ledgerId(UUID.randomUUID().toString())
                 .tenantId(tenantId)
-                .scope(request.getScope())
+                .scope(normalizedScope)
                 .unit(request.getUnit())
                 .allocated(request.getAllocated())
                 .remaining(request.getAllocated())
@@ -226,6 +237,7 @@ public class BudgetRepository {
         "return {'OK'}\n";
 
     public BudgetLedger update(String tenantId, String scope, UnitEnum unit, BudgetUpdateRequest request) {
+        scope = normalizeScope(scope);
         LOG.info("Updating budget: scope={}, unit={}", scope, unit);
         try (Jedis jedis = jedisPool.getResource()) {
             String key = "budget:" + scope + ":" + unit;
@@ -305,6 +317,7 @@ public class BudgetRepository {
     }
 
     public BudgetFundingResponse fund(String tenantId, String scope, UnitEnum unit, BudgetFundingRequest request) {
+        scope = normalizeScope(scope);
         LOG.info("Funding budget: scope={}, unit={}, op={}, tenant={}", scope, unit, request.getOperation(), tenantId);
         try (Jedis jedis = jedisPool.getResource()) {
             String key = "budget:" + scope + ":" + unit;

--- a/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/BudgetRepositoryTest.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/BudgetRepositoryTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.runcycles.admin.data.exception.GovernanceException;
 import io.runcycles.admin.model.budget.*;
+import io.runcycles.admin.model.budget.FundingOperation;
 import io.runcycles.admin.model.shared.Amount;
 import io.runcycles.admin.model.shared.ErrorCode;
 import io.runcycles.admin.model.shared.UnitEnum;
@@ -742,5 +743,36 @@ class BudgetRepositoryTest {
 
         verify(jedis).eval(anyString(), anyList(), argThat((List<String> args) ->
                 args.get(2).equals("ALLOW_WITH_OVERDRAFT")));
+    }
+
+    @Test
+    void create_lowercasesMixedCaseScope() {
+        when(jedis.eval(anyString(), anyList(), anyList())).thenReturn(1L);
+
+        BudgetCreateRequest request = new BudgetCreateRequest();
+        request.setScope("tenant:Rider/app:riderApp");
+        request.setUnit(UnitEnum.USD_MICROCENTS);
+        request.setAllocated(new Amount(UnitEnum.USD_MICROCENTS, 1000000L));
+
+        BudgetLedger result = repository.create("tenant1", request);
+
+        assertThat(result.getScope()).isEqualTo("tenant:rider/app:riderapp");
+    }
+
+    @Test
+    void fund_lowercasesMixedCaseScope() {
+        when(jedis.eval(anyString(), anyList(), anyList()))
+                .thenReturn(Arrays.asList("OK", "1000000", "2000000", "0", "0", "0", "0", "false"));
+
+        BudgetFundingRequest request = new BudgetFundingRequest();
+        request.setOperation(FundingOperation.CREDIT);
+        request.setAmount(new Amount(UnitEnum.USD_MICROCENTS, 1000000L));
+
+        repository.fund("tenant1", "tenant:Rider/app:RiderApp", UnitEnum.USD_MICROCENTS, request);
+
+        // Verify the Redis key uses lowercased scope
+        verify(jedis).eval(anyString(),
+                argThat((List<String> keys) -> keys.get(0).equals("budget:tenant:rider/app:riderapp:USD_MICROCENTS")),
+                anyList());
     }
 }

--- a/cycles-admin-service/pom.xml
+++ b/cycles-admin-service/pom.xml
@@ -18,7 +18,7 @@
         <module>cycles-admin-service-api</module>
     </modules>
     <properties>
-        <revision>0.1.25.1</revision>
+        <revision>0.1.25.2</revision>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>


### PR DESCRIPTION
## Summary

Fixes runcycles/cycles-openclaw-budget-guard#70 — the admin API stored scope values verbatim while the runtime server's `ScopeDerivationService` lowercases them. Budgets created with mixed-case scopes (e.g. `app:riderApp`) could not be found by `GET /v1/balances` which queries with lowercased values.

### Root cause

- **Runtime server** (`ScopeDerivationService.java:75`): `segments.add(level.name() + ":" + value.toLowerCase())`
- **Admin server** (`BudgetRepository.java:121`): `String key = "budget:" + request.getScope() + ":" + ...` — no lowercasing

### Fix

Added `normalizeScope()` helper to `BudgetRepository` that lowercases the scope string. Applied in `create()`, `update()`, and `fund()` methods.

### Changes
- `BudgetRepository.java`: `normalizeScope()` + applied in 3 methods
- `BudgetRepositoryTest.java`: 2 new tests verifying mixed-case scope is lowercased

### Test plan
- [x] 276 unit tests pass (1 integration test skipped — requires Docker)
- [x] New test: `create_lowercasesMixedCaseScope` — `tenant:Rider/app:riderApp` → `tenant:rider/app:riderapp`
- [x] New test: `fund_lowercasesMixedCaseScope` — Redis key uses lowercased scope