### PR TITLE
fix: force HTTP/1.1 on webhook test client

### DIFF
--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookService.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookService.java
@@ -20,7 +20,10 @@ import java.util.*;
 public class WebhookService {
     private static final Logger LOG = LoggerFactory.getLogger(WebhookService.class);
     private static final SecureRandom RANDOM = new SecureRandom();
+    // Force HTTP/1.1 — webhook receivers are standard HTTP/1.1 endpoints.
+    // Default (HTTP/2) sends Upgrade: h2c header on HTTP URLs which many receivers reject.
     private static final java.net.http.HttpClient HTTP_CLIENT = java.net.http.HttpClient.newBuilder()
+        .version(java.net.http.HttpClient.Version.HTTP_1_1)
         .connectTimeout(java.time.Duration.ofSeconds(5))
         .build();
     private final WebhookRepository webhookRepository;

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookServiceTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookServiceTest.java
@@ -591,4 +591,14 @@ class WebhookServiceTest {
                 new NullPointerException()))
                 .isEqualTo("NullPointerException");
     }
+
+    @Test
+    void httpClient_usesHttp1_1() throws Exception {
+        // Webhook receivers are standard HTTP/1.1 endpoints — HTTP/2 upgrade
+        // requests (Upgrade: h2c) break on many receivers.
+        java.lang.reflect.Field field = WebhookService.class.getDeclaredField("HTTP_CLIENT");
+        field.setAccessible(true);
+        java.net.http.HttpClient client = (java.net.http.HttpClient) field.get(null);
+        assertThat(client.version()).isEqualTo(java.net.http.HttpClient.Version.HTTP_1_1);
+    }
 }

--- a/cycles-admin-service/pom.xml
+++ b/cycles-admin-service/pom.xml
@@ -18,7 +18,7 @@
         <module>cycles-admin-service-api</module>
     </modules>
     <properties>
-        <revision>0.1.25.7</revision>
+        <revision>0.1.25.8</revision>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>


### PR DESCRIPTION
## Summary
Java's `HttpClient` defaults to HTTP/2. For HTTP URLs this triggers an `Upgrade: h2c` request (HTTP/2 cleartext upgrade), which many webhook receivers don't support and reject or handle incorrectly.

## Fix
Force HTTP/1.1 on the static `HTTP_CLIENT` used by the webhook test endpoint. Webhook receivers are standard HTTP/1.1 endpoints — there's no benefit to HTTP/2 negotiation and real downside (broken test calls).

```java
private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
    .version(HttpClient.Version.HTTP_1_1)  // was: default HTTP/2
    .connectTimeout(Duration.ofSeconds(5))
    .build();
```

## Test plan
- [x] `mvn verify` — 420 tests (1 new), 0 failures
- [x] New test `httpClient_usesHttp1_1` reflects on the static client to verify version

## Note
The actual webhook delivery dispatcher lives in `cycles-server-events` (separate repo). That service may need the same fix independently.