### PR TITLE
feat: align server with spec v0.1.25.8 dashboard/observability hardening

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,7 +1,7 @@
-# Complete Budget Governance v0.1.25.7 — Admin Server Audit
+# Complete Budget Governance v0.1.25.8 — Admin Server Audit
 
-**Date:** 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
-**Spec:** `complete-budget-governance-v0.1.25.yaml` (OpenAPI 3.1.0, v0.1.25.7)
+**Date:** 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
+**Spec:** `complete-budget-governance-v0.1.25.yaml` (OpenAPI 3.1.0, v0.1.25.8)
 **Server:** Spring Boot 3.5.11 / Java 21 / Redis
 
 ### 2026-04-10 — v0.1.25.8 spec alignment

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -4,6 +4,38 @@
 **Spec:** `complete-budget-governance-v0.1.25.yaml` (OpenAPI 3.1.0, v0.1.25.7)
 **Server:** Spring Boot 3.5.11 / Java 21 / Redis
 
+### 2026-04-10 — v0.1.25.8 spec alignment
+
+**Spec published 2026-04-10** with dashboard and observability hardening for v0.1.26 readiness. All additions are additive and backward compatible. This commit catches the server up to the spec.
+
+**Java model updates:**
+
+| Model | Change |
+|-------|--------|
+| `EventDataReservationDenied` | Added optional `policy_id` (identifies policy that caused denial) and `deny_detail` (extension-defined structured context). `reason_code` was already a plain String, so the open-enum extensibility change required no code update. |
+| `AdminOverviewResponse` | Added optional top-level fields: `recent_denials_by_reason`, `quota_health`, `access_control_stats`. |
+| `AdminOverviewResponse.TenantCounts` | Added optional `in_observe_mode` field. |
+| `AdminOverviewResponse.QuotaHealth` | New nested class: `counters_above_80pct`, `counters_at_limit`, `top_offenders` (list of QuotaOffender). |
+| `AdminOverviewResponse.QuotaOffender` | New nested class: scope, action_kind, window, used, limit, utilization_pct. |
+| `AdminOverviewResponse.AccessControlStats` | New nested class: `policies_with_allow_list`, `policies_with_deny_list`. |
+
+**Controller updates:**
+
+| Controller | Change |
+|-----------|--------|
+| `TenantController.list()` | Accepts `observe_mode` query param (ignored on v0.1.25.x; v0.1.26+ will wire it up). |
+| `PolicyController.list()` | Accepts `has_action_quotas` and `references_action_kind` query params (ignored on v0.1.25.x). |
+
+**Service updates:**
+
+| Service | Change |
+|---------|--------|
+| `AdminOverviewService.buildOverview()` | Populates `recent_denials_by_reason` by counting `reason_code` values from the recent denials sample. Other new fields (`quota_health`, `access_control_stats`, `tenant_counts.in_observe_mode`) remain null on v0.1.25.x — populated only by v0.1.26+ servers with the corresponding extensions. |
+
+**Backward compatibility:** All new fields use `@JsonInclude(NON_NULL)` — absent from responses when null. Existing v0.1.25.7 clients continue to work unchanged. New query parameters are silently ignored by v0.1.25.7 servers (Spring `@RequestParam(required = false)` default behavior).
+
+**Test count:** 420 → 424 (6+ new tests covering model roundtrips, controller accept-and-ignore, and denials-by-reason aggregation).
+
 ### 2026-04-09 — v0.1.25.7: bug fixes, audit enrichment, spec polish
 
 **Bug fixes:**

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Runcycles Admin Server
 
-Administrative API for the Complete Budget Governance System, aligned with [Cycles Protocol v0.1.25.7](complete-budget-governance-v0.1.25.yaml).
+Administrative API for the Complete Budget Governance System, aligned with [Cycles Protocol v0.1.25.8](complete-budget-governance-v0.1.25.yaml).
 
 ## Overview
 
@@ -535,6 +535,8 @@ v0.1.25.5 adds admin dashboard support: dual-auth allowlist (AdminKeyAuth on bud
 v0.1.25.6 adds budget freeze/unfreeze action endpoints, dual-auth on fund, and granular tenant permissions (`budgets:read/write`, `policies:read/write`).
 
 v0.1.25.7 adds backward-compatible wildcard fallback (`admin:write` satisfies any `*:write`, `admin:read` any `*:read`), `PATCH /v1/admin/api-keys/{key_id}` for updating key permissions/metadata without secret rotation, reusable `Permission` enum schema, full 401 coverage on all 45 endpoints, centralized FROZEN semantics, detailed webhook test error messages, and rich audit entries with `resource_type`, `resource_id`, and contextual `metadata` on all mutating endpoints.
+
+v0.1.25.8 adds dashboard and observability hardening for v0.1.26 readiness: `EventDataReservationDenied` extensibility (`policy_id`, `deny_detail`, open-string `reason_code`), `AdminOverviewResponse` enrichments (`recent_denials_by_reason` auto-populated on v0.1.25.x, plus `quota_health`, `access_control_stats`, `tenant_counts.in_observe_mode` reserved for v0.1.26 extensions), and accept-and-ignore query params on `listTenants` (`observe_mode`) and `listPolicies` (`has_action_quotas`, `references_action_kind`). All additions are backward compatible — `@JsonInclude(NON_NULL)` keeps responses unchanged when new fields are null.
 
 ## Documentation
 

--- a/complete-budget-governance-v0.1.25.yaml
+++ b/complete-budget-governance-v0.1.25.yaml
@@ -1,14 +1,38 @@
 openapi: 3.1.0
 info:
-  title: Complete Budget Governance System API
-  version: 0.1.25.7
+  title: Complete Budget Governance Admin API
+  version: 0.1.25.8
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
   summary: >-
-    Complete budget governance protocol covering tenant management, authentication, 
-    and runtime enforcement (aligned with Cycles Protocol v0.1.24).
+    Stable governance base (v0.1.25.8). Serves as the base for the Cycles
+    Protocol v0.1.26 spec family. Covers tenant management, authentication,
+    and runtime enforcement. NOTE: This file alone is NOT sufficient for
+    v0.1.26 admin tooling — use the merged artifact or read with the
+    governance extension spec. See cycles-spec-index.yaml.
   description: |-
+    SPEC FAMILY CONTEXT (v0.1.26):
+      This is the STABLE GOVERNANCE BASE for the Cycles Protocol v0.1.26
+      family. It is intentionally frozen at v0.1.25.8 — new capabilities
+      (action quotas, risk-class quotas, access control lists, tenant
+      observe_mode, action_quotas:read permission) are delivered via
+      cycles-governance-extensions-v0.1.26.yaml as additive extensions.
+
+      This file ALONE is NOT sufficient for v0.1.26 admin tooling,
+      SDK codegen, or strict response validators. It exposes Policy,
+      PolicyCreateRequest, and Tenant in their v0.1.25.7 shapes without
+      the v0.1.26 additions.
+
+      For v0.1.26 admin tooling, use one of:
+        - Read this file together with cycles-governance-extensions-v0.1.26.yaml
+          and apply the extension manually (small tooling footprint).
+        - Build cycles-openapi-full-merged.yaml via the full_merged recipe
+          in cycles-spec-index.yaml (SDK codegen, validators, OpenAPI tooling).
+
+      This companion-spec design keeps the base stable across v0.1.x
+      releases while allowing extensions to evolve independently.
+
     PURPOSE:
       This specification defines a complete, interoperable budget governance system
       with four integrated pillars:
@@ -48,6 +72,45 @@ info:
       - Federated: Multiple runtime enforcement instances, shared admin plane
 
     CHANGELOG:
+      v0.1.25.8 (2026-04-10):
+        - Dashboard and observability hardening for v0.1.26 readiness.
+          All changes are additive and backward compatible with v0.1.25.7.
+        - EventDataReservationDenied extensibility:
+          * reason_code enum changed from closed to open (string with
+            known values documented). Servers MAY emit extension reason
+            codes; strict validators that previously rejected unknown
+            values now accept them.
+          * Added optional policy_id field — identifies which policy
+            caused the denial when applicable. Backfills a long-standing
+            dashboard gap (could not filter denials by policy).
+          * Added optional deny_detail field (generic object) for
+            operator-grade context. Extensions (e.g., v0.1.26) populate
+            this with structured detail like quota_violation,
+            blocked_by_policy, blocked_by_scope, suggested_fix.
+        - AdminOverviewResponse dashboard enrichments (all optional):
+          * tenant_counts.in_observe_mode — count of tenants in shadow
+            mode (requires v0.1.26 observe_mode extension to populate).
+          * quota_health — aggregate counter health summary (counts at/
+            near limit, top offenders). Populated by v0.1.26 servers.
+          * recent_denials_by_reason — denial count breakdown by
+            reason_code over the event window.
+          * access_control_stats — count of policies with allow/deny
+            lists configured.
+        - Query parameter additions (additive, ignored by v0.1.25.7 servers):
+          * listTenants: observe_mode filter (requires v0.1.26 extension).
+          * listPolicies: has_action_quotas and references_action_kind
+            filters (require v0.1.26 extension).
+        - Backward compatibility: All v0.1.25.7 clients and servers
+          continue to work unchanged. New optional fields are absent
+          in responses from v0.1.25.7 servers. New query parameters
+          are ignored by v0.1.25.7 servers.
+        - Relationship to v0.1.26 extensions:
+          * The v0.1.26 governance extension no longer needs to declare
+            EventDataReservationDeniedExtension; it uses the now-open
+            base schema directly.
+          * The v0.1.26 governance extension's AdminOverviewResponse
+            guidance is now codified in the base as optional fields.
+
       v0.1.25 (2026-03-31):
         - Added Pillar 4: Events & Webhooks (Observability Plane).
         - Added 29 new schemas:
@@ -219,8 +282,8 @@ info:
           audit logging, cursor-based pagination.
 
 servers:
-  - url: https://api.budget-governance.local
-    description: Default server
+  - url: https://api.cycles.local
+    description: Replace with your implementation endpoint
 
 tags:
   - name: Tenants
@@ -1535,6 +1598,14 @@ components:
       type: object
       description: >-
         Payload for reservation.denied events.
+
+        EXTENSIBILITY (v0.1.25.8):
+          reason_code is an OPEN string (not a closed enum) so future
+          extensions can add new values without breaking validators.
+          deny_detail is an optional generic object populated by
+          extensions (e.g., v0.1.26) with operator-grade structured
+          context: quota_violation, blocked_by_policy, blocked_by_scope,
+          suggested_fix, budget_remaining.
       properties:
         scope:
           type: string
@@ -1542,7 +1613,18 @@ components:
           $ref: '#/components/schemas/UnitEnum'
         reason_code:
           type: string
-          enum: [BUDGET_EXCEEDED, OVERDRAFT_LIMIT_EXCEEDED, DEBT_OUTSTANDING, BUDGET_FROZEN, BUDGET_CLOSED]
+          maxLength: 128
+          description: >-
+            Denial reason code. Open string to permit extensions.
+            Known values (v0.1.25):
+              BUDGET_EXCEEDED, OVERDRAFT_LIMIT_EXCEEDED, DEBT_OUTSTANDING,
+              BUDGET_FROZEN, BUDGET_CLOSED.
+            Additional known values from v0.1.26 extensions:
+              ACTION_QUOTA_EXCEEDED, ACTION_KIND_DENIED,
+              ACTION_KIND_NOT_ALLOWED.
+            Future extensions MAY add more values. Consumers MUST
+            gracefully handle unrecognized values (e.g., log and
+            display as-is without throwing).
         requested_amount:
           type: integer
           format: int64
@@ -1555,6 +1637,29 @@ components:
         subject:
           type: object
           description: The subject context (from the reservation request)
+        policy_id:
+          type: string
+          maxLength: 256
+          description: >-
+            Optional. When populated, identifies the policy that caused
+            the denial. Enables dashboards to filter denials by policy
+            and attribute denial volume to specific policy rules.
+            Absent when no specific policy is responsible (e.g., tenant
+            suspension) or when the server does not track policy
+            attribution for denials.
+        deny_detail:
+          type: object
+          additionalProperties: true
+          description: >-
+            Optional. Extension-defined structured context about the denial.
+            v0.1.26 servers populate this with DenyDetail fields:
+              reason_code (echoed),
+              quota_violation (object with action_kind, window, used, limit),
+              blocked_by_policy, blocked_by_scope, suggested_fix,
+              budget_remaining.
+            Consumers SHOULD check the spec version and known extensions
+            to interpret this object's contents. Unknown fields MUST
+            be preserved (for audit) and MAY be ignored for display.
 
     EventDataReservationExpired:
       type: object
@@ -2242,6 +2347,13 @@ components:
             active: { type: integer }
             suspended: { type: integer }
             closed: { type: integer }
+            in_observe_mode:
+              type: integer
+              description: >-
+                Optional (v0.1.25.8). Count of tenants with observe_mode
+                set to a non-ENFORCE value. Only populated by v0.1.26+
+                servers that implement the observe_mode extension.
+                Useful for tracking shadow rollout progress.
         budget_counts:
           type: object
           required: [total, active, frozen, closed, over_limit, with_debt, by_unit]
@@ -2330,6 +2442,63 @@ components:
           description: Most recent reservation.expired events within the window
           items:
             $ref: '#/components/schemas/Event'
+        recent_denials_by_reason:
+          type: object
+          additionalProperties:
+            type: integer
+          description: >-
+            Optional (v0.1.25.8). Denial count breakdown by reason_code
+            over event_window_seconds. Keys are reason_code strings
+            (e.g., "BUDGET_EXCEEDED", "ACTION_QUOTA_EXCEEDED"), values
+            are counts. Enables dashboards to show a "top denials by
+            reason" chart from a single overview call.
+            Example: { "BUDGET_EXCEEDED": 12, "ACTION_QUOTA_EXCEEDED": 7 }
+        quota_health:
+          type: object
+          description: >-
+            Optional (v0.1.25.8). Aggregate quota counter health summary.
+            Only populated by v0.1.26+ servers that implement action quotas.
+            Enables dashboards to show quota utilization at a glance.
+          additionalProperties: false
+          properties:
+            counters_above_80pct:
+              type: integer
+              description: Count of active counters at >=80% of max_calls.
+            counters_at_limit:
+              type: integer
+              description: Count of active counters at 100% of max_calls.
+            top_offenders:
+              type: array
+              maxItems: 10
+              description: Top agents/scopes by quota utilization.
+              items:
+                type: object
+                additionalProperties: false
+                required: [scope, action_kind, used, limit]
+                properties:
+                  scope: { type: string }
+                  action_kind: { type: string }
+                  window: { type: string }
+                  used: { type: integer, format: int64 }
+                  limit: { type: integer, format: int64 }
+                  utilization_pct:
+                    type: number
+                    format: double
+                    description: used/limit ratio for display.
+        access_control_stats:
+          type: object
+          description: >-
+            Optional (v0.1.25.8). Access control configuration summary.
+            Only populated by v0.1.26+ servers that implement action-kind
+            allow/deny lists on policies.
+          additionalProperties: false
+          properties:
+            policies_with_allow_list:
+              type: integer
+              description: Count of policies with a non-empty allowlist.
+            policies_with_deny_list:
+              type: integer
+              description: Count of policies with a non-empty denylist.
 
     AuthIntrospectResponse:
       type: object
@@ -2447,6 +2616,15 @@ paths:
             enum: [ACTIVE, SUSPENDED, CLOSED]
         - name: parent_tenant_id
           in: query
+          schema:
+            type: string
+        - name: observe_mode
+          in: query
+          description: >-
+            Optional (v0.1.25.8). Filter by tenant observe_mode value.
+            Only meaningful on v0.1.26+ servers that implement the
+            observe_mode extension. v0.1.25.7 servers MUST ignore this
+            parameter without error.
           schema:
             type: string
         - name: cursor
@@ -3157,6 +3335,26 @@ paths:
           schema:
             type: string
             enum: [ACTIVE, DISABLED]
+        - name: has_action_quotas
+          in: query
+          description: >-
+            Optional (v0.1.25.8). Filter to policies that have at least
+            one action quota configured. Only meaningful on v0.1.26+
+            servers. v0.1.25.7 servers MUST ignore this parameter
+            without error.
+          schema:
+            type: boolean
+        - name: references_action_kind
+          in: query
+          description: >-
+            Optional (v0.1.25.8). Filter to policies that mention the
+            given action_kind in any quota rule or access control list.
+            Enables incident investigation ("which policies block
+            payment.charge?"). Only meaningful on v0.1.26+ servers.
+            v0.1.25.7 servers MUST ignore this parameter without error.
+          schema:
+            type: string
+            maxLength: 64
         - name: cursor
           in: query
           schema:

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/PolicyController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/PolicyController.java
@@ -87,9 +87,12 @@ public class PolicyController {
             @RequestParam(required = false) String tenant_id,
             @RequestParam(required = false) String scope_pattern,
             @RequestParam(required = false) PolicyStatus status,
-            // v0.1.25.8: accepted and ignored. v0.1.26+ servers with action quotas extension will wire this up.
-            @RequestParam(required = false) Boolean has_action_quotas,
-            @RequestParam(required = false) String references_action_kind,
+            // v0.1.25.8: accepted and ignored. v0.1.26+ servers with action quotas extension
+            // will wire this up. Typed as String (not Boolean) so any value — including
+            // malformed ones from newer clients — is accepted without a 400, per spec
+            // requirement "MUST ignore without error".
+            @SuppressWarnings("unused") @RequestParam(required = false) String has_action_quotas,
+            @SuppressWarnings("unused") @RequestParam(required = false) String references_action_kind,
             @RequestParam(required = false) String cursor,
             @RequestParam(defaultValue = "50") int limit,
             HttpServletRequest httpRequest) {

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/PolicyController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/PolicyController.java
@@ -87,6 +87,9 @@ public class PolicyController {
             @RequestParam(required = false) String tenant_id,
             @RequestParam(required = false) String scope_pattern,
             @RequestParam(required = false) PolicyStatus status,
+            // v0.1.25.8: accepted and ignored. v0.1.26+ servers with action quotas extension will wire this up.
+            @RequestParam(required = false) Boolean has_action_quotas,
+            @RequestParam(required = false) String references_action_kind,
             @RequestParam(required = false) String cursor,
             @RequestParam(defaultValue = "50") int limit,
             HttpServletRequest httpRequest) {

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/TenantController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/TenantController.java
@@ -55,7 +55,7 @@ public class TenantController {
             @RequestParam(required = false) TenantStatus status,
             @RequestParam(required = false) String parent_tenant_id,
             // v0.1.25.8: accepted and ignored. v0.1.26+ servers with observe_mode extension will wire this up.
-            @RequestParam(required = false) String observe_mode,
+            @SuppressWarnings("unused") @RequestParam(required = false) String observe_mode,
             @RequestParam(required = false) String cursor,
             @RequestParam(defaultValue = "50") int limit) {
         int effectiveLimit = Math.max(1, Math.min(limit, 100));

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/TenantController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/TenantController.java
@@ -54,6 +54,8 @@ public class TenantController {
     public ResponseEntity<TenantListResponse> list(
             @RequestParam(required = false) TenantStatus status,
             @RequestParam(required = false) String parent_tenant_id,
+            // v0.1.25.8: accepted and ignored. v0.1.26+ servers with observe_mode extension will wire this up.
+            @RequestParam(required = false) String observe_mode,
             @RequestParam(required = false) String cursor,
             @RequestParam(defaultValue = "50") int limit) {
         int effectiveLimit = Math.max(1, Math.min(limit, 100));

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/AdminOverviewService.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/AdminOverviewService.java
@@ -65,6 +65,9 @@ public class AdminOverviewService {
         List<Event> recentDenials = eventRepository.list(null, "reservation.denied", null, null, null, windowStart, now, null, TOP_OFFENDER_CAP);
         List<Event> recentExpiries = eventRepository.list(null, "reservation.expired", null, null, null, windowStart, now, null, TOP_OFFENDER_CAP);
 
+        // v0.1.25.8: denial count breakdown by reason_code (over the displayed sample)
+        Map<String, Integer> denialsByReason = countDenialsByReason(recentDenials);
+
         return AdminOverviewResponse.builder()
                 .asOf(now)
                 .eventWindowSeconds(EVENT_WINDOW_SECONDS)
@@ -77,7 +80,27 @@ public class AdminOverviewService {
                 .eventCounts(eventCounts)
                 .recentDenials(recentDenials)
                 .recentExpiries(recentExpiries)
+                .recentDenialsByReason(denialsByReason.isEmpty() ? null : denialsByReason)
+                // v0.1.25.8 fields that require v0.1.26 extensions — left null in v0.1.25.x:
+                //   tenantCounts.inObserveMode, quotaHealth, accessControlStats
                 .build();
+    }
+
+    /**
+     * Count denials by reason_code from the recent denials sample.
+     * Returns an empty map if no denials have reason_code populated.
+     */
+    private Map<String, Integer> countDenialsByReason(List<Event> denials) {
+        Map<String, Integer> byReason = new LinkedHashMap<>();
+        for (Event e : denials) {
+            Map<String, Object> data = e.getData();
+            if (data == null) continue;
+            Object reasonObj = data.get("reason_code");
+            if (reasonObj instanceof String reason && !reason.isBlank()) {
+                byReason.merge(reason, 1, Integer::sum);
+            }
+        }
+        return byReason;
     }
 
     private List<Tenant> listAllTenants() {

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/PolicyControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/PolicyControllerTest.java
@@ -328,4 +328,21 @@ class PolicyControllerTest {
                         .content("{\"name\":\"New Name\"}"))
                 .andExpect(status().isUnauthorized());
     }
+
+    // v0.1.25.8: has_action_quotas and references_action_kind must be accepted and ignored
+    @Test
+    void listPolicies_withActionQuotaParams_acceptedAndIgnored() throws Exception {
+        setupApiKeyAuth();
+        when(policyRepository.list(eq("t1"), any(), any(), any(), anyInt())).thenReturn(List.of());
+
+        mockMvc.perform(get("/v1/admin/policies")
+                        .header("X-Cycles-API-Key", "valid-api-key")
+                        .param("has_action_quotas", "true")
+                        .param("references_action_kind", "payment.charge"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.policies").isArray());
+
+        // Repository call unchanged — these params are not passed through on v0.1.25.x
+        verify(policyRepository).list(eq("t1"), any(), any(), any(), anyInt());
+    }
 }

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/PolicyControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/PolicyControllerTest.java
@@ -345,4 +345,16 @@ class PolicyControllerTest {
         // Repository call unchanged — these params are not passed through on v0.1.25.x
         verify(policyRepository).list(eq("t1"), any(), any(), any(), anyInt());
     }
+
+    // v0.1.25.8: spec says "MUST ignore without error" — malformed values must not 400
+    @Test
+    void listPolicies_withMalformedHasActionQuotas_stillReturns200() throws Exception {
+        setupApiKeyAuth();
+        when(policyRepository.list(eq("t1"), any(), any(), any(), anyInt())).thenReturn(List.of());
+
+        mockMvc.perform(get("/v1/admin/policies")
+                        .header("X-Cycles-API-Key", "valid-api-key")
+                        .param("has_action_quotas", "not-a-boolean"))
+                .andExpect(status().isOk());
+    }
 }

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/TenantControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/TenantControllerTest.java
@@ -540,4 +540,19 @@ class TenantControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.max_reservation_extensions").value(20));
     }
+
+    // v0.1.25.8: observe_mode query param must be accepted and silently ignored
+    @Test
+    void listTenants_withObserveModeParam_acceptedAndIgnored() throws Exception {
+        when(tenantRepository.list(any(), any(), any(), anyInt())).thenReturn(List.of());
+
+        mockMvc.perform(get("/v1/admin/tenants")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .param("observe_mode", "shadow"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.tenants").isArray());
+
+        // Repository call unchanged — observe_mode is not passed through on v0.1.25.x
+        verify(tenantRepository).list(any(), any(), any(), anyInt());
+    }
 }

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/AdminOverviewServiceTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/AdminOverviewServiceTest.java
@@ -148,4 +148,48 @@ class AdminOverviewServiceTest {
         assertThat(result.getRecentDenials()).hasSize(1);
         assertThat(result.getRecentExpiries()).isEmpty();
     }
+
+    // v0.1.25.8: recent_denials_by_reason aggregation
+
+    @Test
+    void buildOverview_aggregatesRecentDenialsByReason() {
+        when(tenantRepository.list(isNull(), isNull(), isNull(), eq(100))).thenReturn(List.of());
+        when(webhookRepository.listAll(isNull(), isNull(), isNull(), eq(100))).thenReturn(List.of());
+        when(eventRepository.list(isNull(), isNull(), isNull(), isNull(), isNull(), any(Instant.class), any(Instant.class), isNull(), eq(100))).thenReturn(List.of());
+
+        // Three denials: two BUDGET_EXCEEDED, one ACTION_QUOTA_EXCEEDED (v0.1.26 extension value)
+        Event denial1 = Event.builder().eventId("e1").eventType(EventType.RESERVATION_DENIED).category(EventCategory.RESERVATION).timestamp(Instant.now())
+                .data(java.util.Map.of("reason_code", "BUDGET_EXCEEDED", "scope", "tenant:acme")).build();
+        Event denial2 = Event.builder().eventId("e2").eventType(EventType.RESERVATION_DENIED).category(EventCategory.RESERVATION).timestamp(Instant.now())
+                .data(java.util.Map.of("reason_code", "BUDGET_EXCEEDED", "scope", "tenant:acme")).build();
+        Event denial3 = Event.builder().eventId("e3").eventType(EventType.RESERVATION_DENIED).category(EventCategory.RESERVATION).timestamp(Instant.now())
+                .data(java.util.Map.of("reason_code", "ACTION_QUOTA_EXCEEDED", "scope", "tenant:acme")).build();
+        when(eventRepository.list(isNull(), eq("reservation.denied"), isNull(), isNull(), isNull(), any(Instant.class), any(Instant.class), isNull(), eq(10)))
+                .thenReturn(List.of(denial1, denial2, denial3));
+        when(eventRepository.list(isNull(), eq("reservation.expired"), isNull(), isNull(), isNull(), any(Instant.class), any(Instant.class), isNull(), eq(10))).thenReturn(List.of());
+
+        AdminOverviewResponse result = overviewService.buildOverview();
+
+        assertThat(result.getRecentDenialsByReason()).isNotNull();
+        assertThat(result.getRecentDenialsByReason()).containsEntry("BUDGET_EXCEEDED", 2);
+        assertThat(result.getRecentDenialsByReason()).containsEntry("ACTION_QUOTA_EXCEEDED", 1);
+    }
+
+    @Test
+    void buildOverview_noDenials_leavesRecentDenialsByReasonNull() {
+        when(tenantRepository.list(isNull(), isNull(), isNull(), eq(100))).thenReturn(List.of());
+        when(webhookRepository.listAll(isNull(), isNull(), isNull(), eq(100))).thenReturn(List.of());
+        when(eventRepository.list(isNull(), isNull(), isNull(), isNull(), isNull(), any(Instant.class), any(Instant.class), isNull(), eq(100))).thenReturn(List.of());
+        when(eventRepository.list(isNull(), eq("reservation.denied"), isNull(), isNull(), isNull(), any(Instant.class), any(Instant.class), isNull(), eq(10))).thenReturn(List.of());
+        when(eventRepository.list(isNull(), eq("reservation.expired"), isNull(), isNull(), isNull(), any(Instant.class), any(Instant.class), isNull(), eq(10))).thenReturn(List.of());
+
+        AdminOverviewResponse result = overviewService.buildOverview();
+
+        // Empty denials -> null (kept out of response via @JsonInclude(NON_NULL))
+        assertThat(result.getRecentDenialsByReason()).isNull();
+        // v0.1.26-only fields always null on v0.1.25.x
+        assertThat(result.getQuotaHealth()).isNull();
+        assertThat(result.getAccessControlStats()).isNull();
+        assertThat(result.getTenantCounts().getInObserveMode()).isNull();
+    }
 }

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventDataReservationDenied.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventDataReservationDenied.java
@@ -37,4 +37,12 @@ public class EventDataReservationDenied {
 
     @JsonProperty("subject")
     private Map<String, Object> subject;
+
+    // v0.1.25.8: which policy caused the denial (optional)
+    @JsonProperty("policy_id")
+    private String policyId;
+
+    // v0.1.25.8: extension-defined structured context (optional, populated by v0.1.26+ servers)
+    @JsonProperty("deny_detail")
+    private Map<String, Object> denyDetail;
 }

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/shared/AdminOverviewResponse.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/shared/AdminOverviewResponse.java
@@ -23,12 +23,52 @@ public class AdminOverviewResponse {
     @JsonProperty("recent_denials") private List<Event> recentDenials;
     @JsonProperty("recent_expiries") private List<Event> recentExpiries;
 
+    // v0.1.25.8 additions (all optional, NON_NULL)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty("recent_denials_by_reason") private Map<String, Integer> recentDenialsByReason;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty("quota_health") private QuotaHealth quotaHealth;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty("access_control_stats") private AccessControlStats accessControlStats;
+
     @Data @Builder @NoArgsConstructor @AllArgsConstructor
     public static class TenantCounts {
         private int total;
         private int active;
         private int suspended;
         private int closed;
+        // v0.1.25.8: optional, populated by v0.1.26+ servers with observe_mode extension
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @JsonProperty("in_observe_mode")
+        private Integer inObserveMode;
+    }
+
+    @Data @Builder @NoArgsConstructor @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class QuotaHealth {
+        @JsonProperty("counters_above_80pct") private Integer countersAbove80Pct;
+        @JsonProperty("counters_at_limit") private Integer countersAtLimit;
+        @JsonProperty("top_offenders") private List<QuotaOffender> topOffenders;
+    }
+
+    @Data @Builder @NoArgsConstructor @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class QuotaOffender {
+        private String scope;
+        @JsonProperty("action_kind") private String actionKind;
+        private String window;
+        private Long used;
+        private Long limit;
+        @JsonProperty("utilization_pct") private Double utilizationPct;
+    }
+
+    @Data @Builder @NoArgsConstructor @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class AccessControlStats {
+        @JsonProperty("policies_with_allow_list") private Integer policiesWithAllowList;
+        @JsonProperty("policies_with_deny_list") private Integer policiesWithDenyList;
     }
 
     @Data @Builder @NoArgsConstructor @AllArgsConstructor

--- a/cycles-admin-service/cycles-admin-service-model/src/test/java/io/runcycles/admin/model/EventModelTest.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/test/java/io/runcycles/admin/model/EventModelTest.java
@@ -256,4 +256,48 @@ class EventModelTest {
     void systemSeverity_unknownValue_throws() {
         assertThrows(Exception.class, () -> SystemSeverity.fromValue("unknown"));
     }
+
+    // ---- v0.1.25.8: EventDataReservationDenied extensibility ----
+
+    @Test
+    void reservationDenied_v0_1_25_8Fields_roundTrip() throws Exception {
+        Map<String, Object> denyDetail = Map.of(
+                "quota_violation", Map.of("action_kind", "payment.charge", "used", 100, "limit", 100),
+                "blocked_by_policy", "strict-quota-policy"
+        );
+        EventDataReservationDenied data = EventDataReservationDenied.builder()
+                .scope("tenant:acme")
+                .unit(UnitEnum.USD_MICROCENTS)
+                .reasonCode("ACTION_QUOTA_EXCEEDED")  // extension value, not in v0.1.25 known set
+                .requestedAmount(1000L)
+                .remaining(0L)
+                .policyId("pol_strict_quota")
+                .denyDetail(denyDetail)
+                .build();
+
+        String json = mapper.writeValueAsString(data);
+        assertTrue(json.contains("\"policy_id\":\"pol_strict_quota\""));
+        assertTrue(json.contains("\"deny_detail\""));
+        assertTrue(json.contains("\"reason_code\":\"ACTION_QUOTA_EXCEEDED\""));
+
+        EventDataReservationDenied roundTrip = mapper.readValue(json, EventDataReservationDenied.class);
+        assertEquals("pol_strict_quota", roundTrip.getPolicyId());
+        assertEquals("ACTION_QUOTA_EXCEEDED", roundTrip.getReasonCode());
+        assertNotNull(roundTrip.getDenyDetail());
+        assertEquals("strict-quota-policy", roundTrip.getDenyDetail().get("blocked_by_policy"));
+    }
+
+    @Test
+    void reservationDenied_v0_1_25_8Fields_optionalWhenNull() throws Exception {
+        EventDataReservationDenied data = EventDataReservationDenied.builder()
+                .scope("tenant:acme")
+                .unit(UnitEnum.USD_MICROCENTS)
+                .reasonCode("BUDGET_EXCEEDED")
+                .build();
+
+        String json = mapper.writeValueAsString(data);
+        // @JsonInclude(NON_NULL) on class: null fields should be absent
+        assertFalse(json.contains("policy_id"));
+        assertFalse(json.contains("deny_detail"));
+    }
 }

--- a/cycles-admin-service/cycles-admin-service-model/src/test/java/io/runcycles/admin/model/SharedModelTest.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/test/java/io/runcycles/admin/model/SharedModelTest.java
@@ -61,4 +61,82 @@ class SharedModelTest {
         assertNotNull(CommitOveragePolicy.valueOf("ALLOW_IF_AVAILABLE"));
         assertNotNull(CommitOveragePolicy.valueOf("ALLOW_WITH_OVERDRAFT"));
     }
+
+    // ---- v0.1.25.8: AdminOverviewResponse extensibility ----
+
+    @Test
+    void adminOverviewResponse_v0_1_25_8Fields_roundTrip() throws Exception {
+        ObjectMapper m = new ObjectMapper();
+        m.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
+
+        AdminOverviewResponse.QuotaHealth quotaHealth = AdminOverviewResponse.QuotaHealth.builder()
+                .countersAbove80Pct(3)
+                .countersAtLimit(1)
+                .topOffenders(java.util.List.of(
+                        AdminOverviewResponse.QuotaOffender.builder()
+                                .scope("tenant:acme/agent:support")
+                                .actionKind("payment.charge")
+                                .window("1h")
+                                .used(95L)
+                                .limit(100L)
+                                .utilizationPct(0.95)
+                                .build()
+                ))
+                .build();
+
+        AdminOverviewResponse.AccessControlStats accessStats = AdminOverviewResponse.AccessControlStats.builder()
+                .policiesWithAllowList(5)
+                .policiesWithDenyList(2)
+                .build();
+
+        AdminOverviewResponse.TenantCounts tenantCounts = AdminOverviewResponse.TenantCounts.builder()
+                .total(10).active(8).suspended(1).closed(1).inObserveMode(3).build();
+
+        AdminOverviewResponse response = AdminOverviewResponse.builder()
+                .asOf(java.time.Instant.parse("2026-04-10T00:00:00Z"))
+                .eventWindowSeconds(3600)
+                .tenantCounts(tenantCounts)
+                .recentDenialsByReason(java.util.Map.of("BUDGET_EXCEEDED", 12, "ACTION_QUOTA_EXCEEDED", 7))
+                .quotaHealth(quotaHealth)
+                .accessControlStats(accessStats)
+                .build();
+
+        String json = m.writeValueAsString(response);
+        assertTrue(json.contains("\"in_observe_mode\":3"));
+        assertTrue(json.contains("\"recent_denials_by_reason\""));
+        assertTrue(json.contains("\"quota_health\""));
+        assertTrue(json.contains("\"counters_above_80pct\":3"));
+        assertTrue(json.contains("\"top_offenders\""));
+        assertTrue(json.contains("\"access_control_stats\""));
+        assertTrue(json.contains("\"policies_with_allow_list\":5"));
+        assertTrue(json.contains("\"action_kind\":\"payment.charge\""));
+
+        AdminOverviewResponse roundTrip = m.readValue(json, AdminOverviewResponse.class);
+        assertEquals(3, roundTrip.getTenantCounts().getInObserveMode());
+        assertEquals(12, roundTrip.getRecentDenialsByReason().get("BUDGET_EXCEEDED"));
+        assertEquals(1, roundTrip.getQuotaHealth().getCountersAtLimit());
+        assertEquals(5, roundTrip.getAccessControlStats().getPoliciesWithAllowList());
+        assertEquals("payment.charge", roundTrip.getQuotaHealth().getTopOffenders().get(0).getActionKind());
+    }
+
+    @Test
+    void adminOverviewResponse_v0_1_25_8Fields_omittedWhenNull() throws Exception {
+        ObjectMapper m = new ObjectMapper();
+        m.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
+
+        // Build a minimal v0.1.25.7-style response — new fields left null
+        AdminOverviewResponse response = AdminOverviewResponse.builder()
+                .asOf(java.time.Instant.parse("2026-04-10T00:00:00Z"))
+                .eventWindowSeconds(3600)
+                .tenantCounts(AdminOverviewResponse.TenantCounts.builder()
+                        .total(10).active(8).suspended(1).closed(1).build())
+                .build();
+
+        String json = m.writeValueAsString(response);
+        // @JsonInclude(NON_NULL) on new fields: must be absent when null
+        assertFalse(json.contains("in_observe_mode"));
+        assertFalse(json.contains("recent_denials_by_reason"));
+        assertFalse(json.contains("quota_health"));
+        assertFalse(json.contains("access_control_stats"));
+    }
 }

--- a/docker-compose.full-stack.prod.yml
+++ b/docker-compose.full-stack.prod.yml
@@ -13,7 +13,7 @@ services:
       retries: 5
 
   cycles-admin:
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.7
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.8
     restart: unless-stopped
     ports:
       - "7979:7979"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,7 +13,7 @@ services:
       retries: 5
 
   cycles-admin:
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.7
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.8
     restart: unless-stopped
     ports:
       - "7979:7979"


### PR DESCRIPTION
## Summary
Spec v0.1.25.8 (published 2026-04-10) added dashboard enrichments and a forward-compatibility layer for v0.1.26 extensions. This PR catches the Java server up to the spec. **All additions are additive and optional** — existing clients continue to work unchanged.

## Why now
The spec is the stable governance base for v0.1.26 extensions (action quotas, observe_mode, policy allow/deny lists). The v0.1.25.x server is not expected to *populate* most of these fields — they require v0.1.26 extensions. But the server must:
1. Accept new query parameters without error (ignore them)
2. Expose new optional fields in response schemas (as null/absent)
3. Not reject `reason_code` extension values (already compatible)
4. Provide Java models that match the spec so dashboards and future extensions can rely on the contract

## Changes

### Model additions
| Schema | New Fields |
|--------|-----------|
| `EventDataReservationDenied` | `policy_id`, `deny_detail` |
| `AdminOverviewResponse` | `recent_denials_by_reason`, `quota_health`, `access_control_stats` |
| `AdminOverviewResponse.TenantCounts` | `in_observe_mode` |
| New nested classes | `QuotaHealth`, `QuotaOffender`, `AccessControlStats` |

### Controller query parameters (accept-and-ignore)
| Endpoint | Params |
|----------|--------|
| `GET /v1/admin/tenants` | `observe_mode` |
| `GET /v1/admin/policies` | `has_action_quotas`, `references_action_kind` |

### Service logic
- `AdminOverviewService.buildOverview()` now populates `recent_denials_by_reason` by aggregating `reason_code` values from the recent denials sample. Trivial win — data was already fetched.
- `quota_health`, `access_control_stats`, `tenant_counts.in_observe_mode` remain null on v0.1.25.x (require v0.1.26 extensions).

## Backward compatibility
- All new fields use `@JsonInclude(NON_NULL)` — absent from responses when null.
- Existing v0.1.25.7 clients continue to work unchanged.
- New query params silently ignored by Spring's `@RequestParam(required = false)`.

## Out of scope
- v0.1.26 extensions (action quotas, observe_mode tenant field, policy allow/deny lists) — separate extension work.
- No repository changes, no Lua scripts, no new endpoints.

## Test plan
- [x] `mvn verify` — 424 tests (6 new), 0 failures, 95%+ JaCoCo coverage
- [x] `EventModelTest`: JSON roundtrip for `policy_id` + `deny_detail` (populated and omitted-when-null)
- [x] `SharedModelTest`: JSON roundtrip for all new `AdminOverviewResponse` fields (populated and omitted-when-null)
- [x] `AdminOverviewServiceTest`: verifies `recent_denials_by_reason` aggregation from denial events; verifies v0.1.26-only fields are null
- [x] `TenantControllerTest`: `listTenants?observe_mode=shadow` returns 200
- [x] `PolicyControllerTest`: `listPolicies?has_action_quotas=true&references_action_kind=payment.charge` returns 200