### PR TITLE
feat: observability — prometheus metrics + k8s liveness/readiness probes

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,8 +1,36 @@
 # Complete Budget Governance v0.1.25.8 — Admin Server Audit
 
-**Date:** 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
+**Date:** 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
 **Spec:** `complete-budget-governance-v0.1.25.yaml` (OpenAPI 3.1.0, v0.1.25.8)
 **Server:** Spring Boot 3.5.11 / Java 21 / Redis
+
+### 2026-04-10 — Observability: Prometheus metrics + Kubernetes probes
+
+Operational-hardening follow-up (not a spec change). Closes two HIGH items from the post-v0.1.25.8 gap analysis.
+
+**Metrics:**
+
+- Added `micrometer-registry-prometheus` dependency in `cycles-admin-service-api/pom.xml`.
+- Exposed `/actuator/prometheus` by adding `prometheus` to `management.endpoints.web.exposure.include` and enabling `management.prometheus.metrics.export.enabled=true`.
+- Tagged all metrics with `application=cycles-admin-service` for multi-service dashboards.
+- Spring Boot auto-provides: `http_server_requests_seconds_{count,sum,max}` per URI/method/status, JVM, Logback, process, Jedis pool gauges.
+- **Custom counters (domain events):**
+  - `cycles_admin_events_emitted_total{type, result}` — incremented on every `EventService.emit()` call; `result` is `success` or `failure`.
+  - `cycles_admin_webhook_dispatched_total{result}` — incremented per webhook enqueue attempt in `WebhookDispatchService.dispatch()`; `result` is `queued` or `failure`.
+
+**Kubernetes probes:**
+
+- Enabled Spring Boot's built-in liveness/readiness split with `management.endpoint.health.probes.enabled=true`.
+- New endpoints: `/actuator/health/liveness` and `/actuator/health/readiness`.
+- Updated `docker-compose.prod.yml` and `docker-compose.full-stack.prod.yml` healthchecks to hit `/actuator/health/liveness` (healthchecks should be liveness, not aggregate health).
+
+**Test updates:**
+
+- `EventServiceTest`: new `emit_success_incrementsEmittedCounter` and `emit_failure_incrementsEmittedCounter` tests using `SimpleMeterRegistry` via `@Spy`. Verifies counter labels (`type`, `result`) are correct.
+- `WebhookDispatchServiceTest`: new `dispatch_success_incrementsQueuedCounter` and `dispatch_failure_incrementsFailureCounter` tests.
+- Constructor signature of `EventService` and `WebhookDispatchService` now takes a `MeterRegistry` — test setup updated to pass `SimpleMeterRegistry`.
+
+**Backward compatibility:** None of the changes affect the HTTP API surface. Existing `/actuator/health` still works (returns aggregate). Prometheus endpoint is additive.
 
 ### 2026-04-10 — v0.1.25.8 spec alignment
 

--- a/README.md
+++ b/README.md
@@ -522,6 +522,31 @@ All errors return a standard `ErrorResponse`:
 | **Split-plane** | Admin + events separate from runtime enforcement |
 | **Full stack** | Admin (7979) + Runtime (7878) + Events (7980) + Redis |
 
+## Observability
+
+**Health endpoints** (Spring Boot Actuator):
+
+| Endpoint | Use |
+|----------|-----|
+| `GET /actuator/health` | Aggregate health (use for debugging) |
+| `GET /actuator/health/liveness` | K8s liveness probe — is the JVM alive? |
+| `GET /actuator/health/readiness` | K8s readiness probe — is the app ready to serve traffic? |
+| `GET /actuator/info` | Build info (version, git commit) |
+| `GET /actuator/prometheus` | Prometheus scrape endpoint |
+
+Docker healthchecks hit `/actuator/health/liveness` (not the aggregate endpoint) so a degraded readiness state doesn't restart the container.
+
+**Metrics:**
+
+Spring Boot auto-publishes `http_server_requests_seconds_*` (latency/count/errors per URI + method + status), JVM, Jedis pool, and logback counters. The admin service adds two custom counters for domain operations:
+
+| Metric | Tags | Description |
+|--------|------|-------------|
+| `cycles_admin_events_emitted_total` | `type`, `result` | Events emitted (`result` = `success` \| `failure`) |
+| `cycles_admin_webhook_dispatched_total` | `result` | Webhook delivery enqueue attempts (`result` = `queued` \| `failure`) |
+
+All metrics are tagged with `application=cycles-admin-service` for multi-service Prometheus/Grafana dashboards.
+
 ## Protocol Specification
 
 The full OpenAPI 3.1.0 specification is in [`complete-budget-governance-v0.1.25.yaml`](complete-budget-governance-v0.1.25.yaml).

--- a/cycles-admin-service/cycles-admin-service-api/pom.xml
+++ b/cycles-admin-service/cycles-admin-service-api/pom.xml
@@ -33,6 +33,10 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
         </dependency>

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/EventService.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/EventService.java
@@ -1,5 +1,7 @@
 package io.runcycles.admin.api.service;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.runcycles.admin.data.repository.EventRepository;
 import io.runcycles.admin.model.event.*;
 import org.slf4j.Logger;
@@ -16,10 +18,14 @@ public class EventService {
     private static final Logger LOG = LoggerFactory.getLogger(EventService.class);
     private final EventRepository eventRepository;
     private final WebhookDispatchService webhookDispatchService;
+    private final MeterRegistry meterRegistry;
 
-    public EventService(EventRepository eventRepository, WebhookDispatchService webhookDispatchService) {
+    public EventService(EventRepository eventRepository,
+                        WebhookDispatchService webhookDispatchService,
+                        MeterRegistry meterRegistry) {
         this.eventRepository = eventRepository;
         this.webhookDispatchService = webhookDispatchService;
+        this.meterRegistry = meterRegistry;
     }
 
     /**
@@ -39,9 +45,20 @@ public class EventService {
             }
             eventRepository.save(event);
             webhookDispatchService.dispatch(event);
+            recordEmitted(event.getEventType(), "success");
         } catch (Exception e) {
             LOG.error("Failed to emit event {}: {}", event.getEventType(), e.getMessage(), e);
+            recordEmitted(event.getEventType(), "failure");
         }
+    }
+
+    private void recordEmitted(EventType type, String result) {
+        Counter.builder("cycles_admin_events_emitted_total")
+            .description("Count of domain events emitted, labelled by event type and result")
+            .tag("type", type != null ? type.getValue() : "unknown")
+            .tag("result", result)
+            .register(meterRegistry)
+            .increment();
     }
 
     /**

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookDispatchService.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookDispatchService.java
@@ -1,5 +1,7 @@
 package io.runcycles.admin.api.service;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.runcycles.admin.data.repository.WebhookDeliveryRepository;
 import io.runcycles.admin.data.repository.WebhookRepository;
 import io.runcycles.admin.model.event.Event;
@@ -25,15 +27,18 @@ public class WebhookDispatchService {
     private final WebhookDeliveryRepository deliveryRepository;
     private final ObjectMapper objectMapper;
     private final JedisPool jedisPool;
+    private final MeterRegistry meterRegistry;
 
     public WebhookDispatchService(WebhookRepository webhookRepository,
                                    WebhookDeliveryRepository deliveryRepository,
                                    ObjectMapper objectMapper,
-                                   JedisPool jedisPool) {
+                                   JedisPool jedisPool,
+                                   MeterRegistry meterRegistry) {
         this.webhookRepository = webhookRepository;
         this.deliveryRepository = deliveryRepository;
         this.objectMapper = objectMapper;
         this.jedisPool = jedisPool;
+        this.meterRegistry = meterRegistry;
     }
 
     /**
@@ -47,14 +52,25 @@ public class WebhookDispatchService {
             for (WebhookSubscription sub : subs) {
                 try {
                     createDelivery(event, sub);
+                    recordDispatch("queued");
                 } catch (Exception e) {
                     LOG.error("Failed to create delivery for subscription {}: {}",
                         sub.getSubscriptionId(), e.getMessage());
+                    recordDispatch("failure");
                 }
             }
         } catch (Exception e) {
             LOG.error("Failed to dispatch event {}: {}", event.getEventId(), e.getMessage());
+            recordDispatch("failure");
         }
+    }
+
+    private void recordDispatch(String result) {
+        Counter.builder("cycles_admin_webhook_dispatched_total")
+            .description("Count of webhook delivery enqueue attempts, labelled by result")
+            .tag("result", result)
+            .register(meterRegistry)
+            .increment();
     }
 
     /**

--- a/cycles-admin-service/cycles-admin-service-api/src/main/resources/application.properties
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/resources/application.properties
@@ -23,8 +23,15 @@ springdoc.swagger-ui.path=/swagger-ui.html
 springdoc.swagger-ui.enabled=${SWAGGER_ENABLED:false}
 
 # Management/Actuator Endpoints
-management.endpoints.web.exposure.include=health,info
+management.endpoints.web.exposure.include=health,info,prometheus
 management.endpoint.health.show-details=when-authorized
+# Kubernetes-style liveness/readiness probes: /actuator/health/liveness, /actuator/health/readiness
+management.endpoint.health.probes.enabled=true
+management.health.livenessState.enabled=true
+management.health.readinessState.enabled=true
+# Prometheus scrape endpoint: /actuator/prometheus
+management.prometheus.metrics.export.enabled=true
+management.metrics.tags.application=${spring.application.name}
 
 # Admin API Key (for X-Admin-API-Key header)
 admin.api-key=${ADMIN_API_KEY:}

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/AdminOverviewControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/AdminOverviewControllerTest.java
@@ -7,6 +7,8 @@ import io.runcycles.admin.model.shared.AdminOverviewResponse.*;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import io.runcycles.admin.api.support.MetricsTestConfiguration;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import redis.clients.jedis.JedisPool;
@@ -20,6 +22,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(AdminOverviewController.class)
+@Import(MetricsTestConfiguration.class)
 class AdminOverviewControllerTest {
 
     @Autowired private MockMvc mockMvc;

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/ApiKeyControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/ApiKeyControllerTest.java
@@ -9,6 +9,8 @@ import io.runcycles.admin.model.shared.ErrorCode;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import io.runcycles.admin.api.support.MetricsTestConfiguration;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -23,6 +25,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(ApiKeyController.class)
+@Import(MetricsTestConfiguration.class)
 class ApiKeyControllerTest {
 
     @Autowired private MockMvc mockMvc;

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/AuditControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/AuditControllerTest.java
@@ -6,6 +6,8 @@ import io.runcycles.admin.model.audit.AuditLogEntry;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import io.runcycles.admin.api.support.MetricsTestConfiguration;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import redis.clients.jedis.JedisPool;
@@ -19,6 +21,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(AuditController.class)
+@Import(MetricsTestConfiguration.class)
 class AuditControllerTest {
 
     @Autowired private MockMvc mockMvc;

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/AuthControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/AuthControllerTest.java
@@ -5,6 +5,8 @@ import io.runcycles.admin.model.auth.ApiKeyValidationResponse;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import io.runcycles.admin.api.support.MetricsTestConfiguration;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -19,6 +21,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(AuthController.class)
+@Import(MetricsTestConfiguration.class)
 class AuthControllerTest {
 
     @Autowired private MockMvc mockMvc;

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BalanceControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BalanceControllerTest.java
@@ -9,6 +9,8 @@ import io.runcycles.admin.model.shared.UnitEnum;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import io.runcycles.admin.api.support.MetricsTestConfiguration;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import redis.clients.jedis.JedisPool;
@@ -22,6 +24,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(BalanceController.class)
+@Import(MetricsTestConfiguration.class)
 class BalanceControllerTest {
 
     @Autowired private MockMvc mockMvc;

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BudgetControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BudgetControllerTest.java
@@ -14,6 +14,8 @@ import io.runcycles.admin.model.shared.UnitEnum;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import io.runcycles.admin.api.support.MetricsTestConfiguration;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -28,6 +30,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(BudgetController.class)
+@Import(MetricsTestConfiguration.class)
 class BudgetControllerTest {
 
     @Autowired private MockMvc mockMvc;

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/EventAdminControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/EventAdminControllerTest.java
@@ -8,6 +8,8 @@ import io.runcycles.admin.model.event.*;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import io.runcycles.admin.api.support.MetricsTestConfiguration;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import redis.clients.jedis.JedisPool;
@@ -21,6 +23,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(EventAdminController.class)
+@Import(MetricsTestConfiguration.class)
 class EventAdminControllerTest {
 
     @Autowired private MockMvc mockMvc;

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/EventTenantControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/EventTenantControllerTest.java
@@ -8,6 +8,8 @@ import io.runcycles.admin.model.event.*;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import io.runcycles.admin.api.support.MetricsTestConfiguration;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import redis.clients.jedis.JedisPool;
@@ -21,6 +23,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(EventTenantController.class)
+@Import(MetricsTestConfiguration.class)
 class EventTenantControllerTest {
 
     @Autowired private MockMvc mockMvc;

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/PolicyControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/PolicyControllerTest.java
@@ -10,6 +10,8 @@ import io.runcycles.admin.model.policy.*;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import io.runcycles.admin.api.support.MetricsTestConfiguration;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -24,6 +26,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(PolicyController.class)
+@Import(MetricsTestConfiguration.class)
 class PolicyControllerTest {
 
     @Autowired private MockMvc mockMvc;

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/TenantControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/TenantControllerTest.java
@@ -13,6 +13,8 @@ import io.runcycles.admin.model.tenant.*;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import io.runcycles.admin.api.support.MetricsTestConfiguration;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -27,6 +29,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(TenantController.class)
+@Import(MetricsTestConfiguration.class)
 class TenantControllerTest {
 
     @Autowired private MockMvc mockMvc;

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookAdminControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookAdminControllerTest.java
@@ -10,6 +10,8 @@ import io.runcycles.admin.model.webhook.*;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import io.runcycles.admin.api.support.MetricsTestConfiguration;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -24,6 +26,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(WebhookAdminController.class)
+@Import(MetricsTestConfiguration.class)
 class WebhookAdminControllerTest {
 
     @Autowired private MockMvc mockMvc;

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookSecurityConfigControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookSecurityConfigControllerTest.java
@@ -8,6 +8,8 @@ import io.runcycles.admin.model.webhook.WebhookSecurityConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import io.runcycles.admin.api.support.MetricsTestConfiguration;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -21,6 +23,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(WebhookSecurityConfigController.class)
+@Import(MetricsTestConfiguration.class)
 class WebhookSecurityConfigControllerTest {
 
     @Autowired private MockMvc mockMvc;

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookTenantControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookTenantControllerTest.java
@@ -11,6 +11,8 @@ import io.runcycles.admin.model.webhook.*;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import io.runcycles.admin.api.support.MetricsTestConfiguration;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -25,6 +27,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(WebhookTenantController.class)
+@Import(MetricsTestConfiguration.class)
 class WebhookTenantControllerTest {
 
     @Autowired private MockMvc mockMvc;

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/EventServiceTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/EventServiceTest.java
@@ -1,11 +1,14 @@
 package io.runcycles.admin.api.service;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.runcycles.admin.data.repository.EventRepository;
 import io.runcycles.admin.model.event.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Instant;
@@ -21,6 +24,7 @@ class EventServiceTest {
 
     @Mock private EventRepository eventRepository;
     @Mock private WebhookDispatchService webhookDispatchService;
+    @Spy private MeterRegistry meterRegistry = new SimpleMeterRegistry();
     @InjectMocks private EventService eventService;
 
     @Test
@@ -193,5 +197,34 @@ class EventServiceTest {
             "t1".equals(event.getTenantId()) &&
             EventCategory.TENANT == event.getCategory()));
         verify(webhookDispatchService).dispatch(any());
+    }
+
+    @Test
+    void emit_success_incrementsEmittedCounterWithSuccessTag() {
+        Event event = Event.builder()
+            .eventType(EventType.BUDGET_CREATED)
+            .tenantId("t1")
+            .build();
+
+        eventService.emit(event);
+
+        double count = meterRegistry.counter("cycles_admin_events_emitted_total",
+            "type", EventType.BUDGET_CREATED.getValue(), "result", "success").count();
+        assertThat(count).isEqualTo(1.0);
+    }
+
+    @Test
+    void emit_failure_incrementsEmittedCounterWithFailureTag() {
+        Event event = Event.builder()
+            .eventType(EventType.BUDGET_CREATED)
+            .tenantId("t1")
+            .build();
+        doThrow(new RuntimeException("DB down")).when(eventRepository).save(any());
+
+        eventService.emit(event);
+
+        double count = meterRegistry.counter("cycles_admin_events_emitted_total",
+            "type", EventType.BUDGET_CREATED.getValue(), "result", "failure").count();
+        assertThat(count).isEqualTo(1.0);
     }
 }

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookDispatchServiceTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookDispatchServiceTest.java
@@ -1,6 +1,8 @@
 package io.runcycles.admin.api.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.runcycles.admin.data.repository.WebhookDeliveryRepository;
 import io.runcycles.admin.data.repository.WebhookRepository;
 import io.runcycles.admin.model.event.Event;
@@ -31,13 +33,15 @@ class WebhookDispatchServiceTest {
     @Mock private ObjectMapper objectMapper;
     @Mock private JedisPool jedisPool;
     @Mock private Jedis jedis;
+    private MeterRegistry meterRegistry;
 
     private WebhookDispatchService webhookDispatchService;
 
     @BeforeEach
     void setUp() {
         lenient().when(jedisPool.getResource()).thenReturn(jedis);
-        webhookDispatchService = new WebhookDispatchService(webhookRepository, deliveryRepository, objectMapper, jedisPool);
+        meterRegistry = new SimpleMeterRegistry();
+        webhookDispatchService = new WebhookDispatchService(webhookRepository, deliveryRepository, objectMapper, jedisPool, meterRegistry);
     }
 
     private Event buildEvent() {
@@ -162,5 +166,30 @@ class WebhookDispatchServiceTest {
             d.getEventId().equals("evt_1") &&
             d.getStatus() == DeliveryStatus.PENDING));
         verify(jedis).lpush(eq("dispatch:pending"), anyString());
+    }
+
+    @Test
+    void dispatch_success_incrementsQueuedCounter() {
+        Event event = buildEvent();
+        WebhookSubscription sub = buildSubscription("whsub_1");
+        when(webhookRepository.findMatchingSubscriptions("t1", EventType.BUDGET_CREATED, "org/team1"))
+            .thenReturn(List.of(sub));
+
+        webhookDispatchService.dispatch(event);
+
+        assertThat(meterRegistry.counter("cycles_admin_webhook_dispatched_total", "result", "queued").count())
+            .isEqualTo(1.0);
+    }
+
+    @Test
+    void dispatch_failure_incrementsFailureCounter() {
+        Event event = buildEvent();
+        when(webhookRepository.findMatchingSubscriptions(any(), any(), any()))
+            .thenThrow(new RuntimeException("DB error"));
+
+        webhookDispatchService.dispatch(event);
+
+        assertThat(meterRegistry.counter("cycles_admin_webhook_dispatched_total", "result", "failure").count())
+            .isEqualTo(1.0);
     }
 }

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/support/MetricsTestConfiguration.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/support/MetricsTestConfiguration.java
@@ -1,0 +1,23 @@
+package io.runcycles.admin.api.support;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Provides a {@link SimpleMeterRegistry} bean for @WebMvcTest slice tests.
+ *
+ * <p>Spring Boot disables observability auto-configuration in slice tests by default
+ * (via {@code DisableObservabilityContextCustomizer}), which means {@link MeterRegistry}
+ * is not in the context. Services that depend on it (e.g. EventService, WebhookDispatchService)
+ * fail to load. Import this configuration to supply an in-memory registry.
+ */
+@TestConfiguration
+public class MetricsTestConfiguration {
+
+    @Bean
+    public MeterRegistry meterRegistry() {
+        return new SimpleMeterRegistry();
+    }
+}

--- a/docker-compose.full-stack.prod.yml
+++ b/docker-compose.full-stack.prod.yml
@@ -26,7 +26,7 @@ services:
       EVENT_TTL_DAYS: ${EVENT_TTL_DAYS:-90}
       DELIVERY_TTL_DAYS: ${DELIVERY_TTL_DAYS:-14}
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:7979/actuator/health"]
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:7979/actuator/health/liveness"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -26,7 +26,7 @@ services:
       EVENT_TTL_DAYS: ${EVENT_TTL_DAYS:-90}
       DELIVERY_TTL_DAYS: ${DELIVERY_TTL_DAYS:-14}
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:7979/actuator/health"]
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:7979/actuator/health/liveness"]
       interval: 10s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary

Closes two HIGH operational gaps identified in the post-v0.1.25.8 review:
- No metrics endpoint (no way to chart request latency, error rates, or Jedis pool health)
- No readiness/liveness probe split (k8s restarts on any health degradation, even transient readiness drops)

This is operational hardening only — **no HTTP API surface changes**, no spec changes, fully backward compatible.

## Changes

### Metrics
- Add \`micrometer-registry-prometheus\` dependency
- Expose \`/actuator/prometheus\` via \`management.endpoints.web.exposure.include=health,info,prometheus\`
- Tag all metrics with \`application=cycles-admin-service\` for multi-service Grafana dashboards
- **Custom counters:**
  - \`cycles_admin_events_emitted_total{type, result}\` — incremented in \`EventService.emit()\`
  - \`cycles_admin_webhook_dispatched_total{result}\` — incremented in \`WebhookDispatchService.dispatch()\`
- Spring Boot auto-publishes: \`http_server_requests_seconds_*\`, JVM, Logback, Jedis pool gauges

### Kubernetes probes
- \`management.endpoint.health.probes.enabled=true\`
- New endpoints: \`/actuator/health/liveness\` and \`/actuator/health/readiness\`
- Docker healthchecks switched from \`/actuator/health\` to \`/actuator/health/liveness\` (liveness is the correct signal for container restart decisions — a not-ready container shouldn't be killed)

### Tests
- **425 → 429** (4 new counter assertion tests)
- \`EventServiceTest\` / \`WebhookDispatchServiceTest\` verify counter increments on success/failure paths
- New \`MetricsTestConfiguration\` provides \`MeterRegistry\` bean to \`@WebMvcTest\` slices (Spring Boot disables observability in slices by default, so services depending on \`MeterRegistry\` fail to load without this)
- \`@Import(MetricsTestConfiguration.class)\` added to all 13 \`@WebMvcTest\` classes

### Docs
- \`AUDIT.md\` changelog entry
- \`README.md\` new Observability section with endpoint table and custom metrics reference

## Test plan
- [x] \`mvn -B verify\` — 429/429 pass, JaCoCo coverage enforced
- [ ] After merge: deploy to staging, confirm \`curl :7979/actuator/prometheus\` returns text/plain with \`cycles_admin_*\` metrics
- [ ] After merge: confirm \`curl :7979/actuator/health/liveness\` and \`/readiness\` return 200
- [ ] After merge: confirm docker healthcheck still passes with new path