### PR TITLE
fix: CORS hardening — allowlist API key + request id headers, prod config

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,6 +1,7 @@
 # Complete Budget Governance v0.1.25.8 — Admin Server Audit
 
-**Date:** 2026-04-10 (CORS hardening + prod config), 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
+**Server version:** 0.1.25.9 (2026-04-10 patch release — CORS hardening + observability hardening)
+**Date:** 2026-04-10 (v0.1.25.9 release), 2026-04-10 (CORS hardening + prod config), 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
 **Spec:** `complete-budget-governance-v0.1.25.yaml` (OpenAPI 3.1.0, v0.1.25.8)
 **Server:** Spring Boot 3.5.11 / Java 21 / Redis
 

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,8 +1,25 @@
 # Complete Budget Governance v0.1.25.8 — Admin Server Audit
 
-**Date:** 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
+**Date:** 2026-04-10 (CORS hardening + prod config), 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
 **Spec:** `complete-budget-governance-v0.1.25.yaml` (OpenAPI 3.1.0, v0.1.25.8)
 **Server:** Spring Boot 3.5.11 / Java 21 / Redis
+
+### 2026-04-10 — CORS hardening + production config
+
+Two real bugs fixed while closing the MEDIUM CORS gap from the post-v0.1.25.8 gap analysis:
+
+1. **`X-Cycles-API-Key` missing from CORS allowedHeaders.** `AuthInterceptor` accepts the header for tenant authentication, but `WebConfig.addCorsMappings()` only allowlisted `X-Admin-API-Key` and `Content-Type`. Any browser-based dashboard using tenant API keys would have been blocked at CORS preflight. Added `X-Cycles-API-Key` to allowlist.
+2. **`X-Request-Id` not in allowedHeaders or exposedHeaders.** `RequestIdFilter` reads the header on input and writes it back on the response, but CORS hid both directions from browsers — breaking correlation-id propagation for dashboard debugging. Added to both `allowedHeaders` and `exposedHeaders`.
+
+**Production config changes:**
+
+- `WebConfig` now parses a comma-separated list from `dashboard.cors.origin`, enabling multi-origin deployments (e.g. `https://dash.example.com,https://staging.example.com`).
+- Startup log now prints the configured origins for operational visibility.
+- `application.properties` now explicitly binds `dashboard.cors.origin=${DASHBOARD_CORS_ORIGIN:http://localhost:5173}` with an inline comment flagging the localhost default as dev-only.
+- `docker-compose.prod.yml` and `docker-compose.full-stack.prod.yml` pass `DASHBOARD_CORS_ORIGIN` through to the admin container with a warning comment.
+- README `Environment Variables` table gained a `DASHBOARD_CORS_ORIGIN` row; new `CORS` subsection in Observability lists all allowlisted methods, headers, exposed headers, and origin format.
+
+**Tests:** 429 → 432 (three new `WebConfigTest` cases verifying header allowlist, exposed headers, and comma-separated origin parsing with whitespace/empty handling).
 
 ### 2026-04-10 — Observability: Prometheus metrics + Kubernetes probes
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ API keys use the format `cyc_live_{random}` (production) or `cyc_test_{random}` 
 | `SWAGGER_ENABLED` | No | `false` | Enable Swagger UI at `/swagger-ui.html` |
 | `EVENT_TTL_DAYS` | No | `90` | Event retention in Redis (days) |
 | `DELIVERY_TTL_DAYS` | No | `14` | Webhook delivery retention in Redis (days) |
+| `DASHBOARD_CORS_ORIGIN` | No | `http://localhost:5173` | Comma-separated list of origins allowed to call `/v1/**` from a browser. **Must be set in production** to your dashboard URL (e.g. `https://dash.example.com`). The default is the Vite dev server and will NOT work for prod dashboard deployments. |
 
 ### Webhook Secret Encryption
 
@@ -546,6 +547,19 @@ Spring Boot auto-publishes `http_server_requests_seconds_*` (latency/count/error
 | `cycles_admin_webhook_dispatched_total` | `result` | Webhook delivery enqueue attempts (`result` = `queued` \| `failure`) |
 
 All metrics are tagged with `application=cycles-admin-service` for multi-service Prometheus/Grafana dashboards.
+
+**CORS:**
+
+Browser clients (the dashboard) call `/v1/**` via CORS. The server allowlists:
+
+| | Values |
+|---|---|
+| Methods | `GET`, `POST`, `PATCH`, `DELETE`, `OPTIONS` |
+| Request headers | `X-Admin-API-Key`, `X-Cycles-API-Key`, `X-Request-Id`, `Content-Type` |
+| Exposed response headers | `X-Request-Id` (for correlation) |
+| Origins | `DASHBOARD_CORS_ORIGIN` env var (comma-separated), default `http://localhost:5173` |
+
+Multiple origins are supported for staging + prod deployments behind the same server: `DASHBOARD_CORS_ORIGIN=https://dash.example.com,https://staging.example.com`.
 
 ## Protocol Specification
 

--- a/README.md
+++ b/README.md
@@ -577,6 +577,8 @@ v0.1.25.7 adds backward-compatible wildcard fallback (`admin:write` satisfies an
 
 v0.1.25.8 adds dashboard and observability hardening for v0.1.26 readiness: `EventDataReservationDenied` extensibility (`policy_id`, `deny_detail`, open-string `reason_code`), `AdminOverviewResponse` enrichments (`recent_denials_by_reason` auto-populated on v0.1.25.x, plus `quota_health`, `access_control_stats`, `tenant_counts.in_observe_mode` reserved for v0.1.26 extensions), and accept-and-ignore query params on `listTenants` (`observe_mode`) and `listPolicies` (`has_action_quotas`, `references_action_kind`). All additions are backward compatible — `@JsonInclude(NON_NULL)` keeps responses unchanged when new fields are null.
 
+v0.1.25.9 is a patch release with operational hardening only — **no API surface changes**, spec stays at v0.1.25.8. Adds: Micrometer/Prometheus metrics at `/actuator/prometheus` with custom counters (`cycles_admin_events_emitted_total`, `cycles_admin_webhook_dispatched_total`); Kubernetes liveness/readiness probes at `/actuator/health/liveness` and `/actuator/health/readiness` (docker-compose healthchecks switched to liveness); CORS fixes — `X-Cycles-API-Key` and `X-Request-Id` are now allowlisted (both were previously blocked at preflight, breaking browser dashboards using tenant auth) and `X-Request-Id` is exposed for correlation; multi-origin CORS support via comma-separated `DASHBOARD_CORS_ORIGIN` env var.
+
 ## Documentation
 
 - [Cycles Documentation](https://runcycles.io) — full docs site

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/config/WebConfig.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/config/WebConfig.java
@@ -1,15 +1,27 @@
 package io.runcycles.admin.api.config;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.Arrays;
+
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+    private static final Logger LOG = LoggerFactory.getLogger(WebConfig.class);
+
     private final AuthInterceptor authInterceptor;
 
+    /**
+     * Comma-separated list of origins allowed to call the admin API from a browser.
+     * Default is the local Vite dev server for the dashboard. In production, set
+     * via {@code DASHBOARD_CORS_ORIGIN} (e.g. {@code https://dash.example.com}) or
+     * a comma list (e.g. {@code https://dash.example.com,https://staging.example.com}).
+     */
     @Value("${dashboard.cors.origin:http://localhost:5173}")
     private String dashboardOrigin;
 
@@ -25,10 +37,20 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
+        String[] origins = Arrays.stream(dashboardOrigin.split(","))
+            .map(String::trim)
+            .filter(s -> !s.isEmpty())
+            .toArray(String[]::new);
+        LOG.info("CORS configured for origins: {}", String.join(", ", origins));
         registry.addMapping("/v1/**")
-            .allowedOrigins(dashboardOrigin)
+            .allowedOrigins(origins)
             .allowedMethods("GET", "POST", "PATCH", "DELETE", "OPTIONS")
-            .allowedHeaders("X-Admin-API-Key", "Content-Type")
+            // Both auth headers must be allowlisted or browser preflight rejects them.
+            // X-Request-Id lets clients propagate a correlation id through the filter chain.
+            .allowedHeaders("X-Admin-API-Key", "X-Cycles-API-Key", "X-Request-Id", "Content-Type")
+            // X-Request-Id is also exposed so browser clients can read the server-assigned id
+            // when they didn't send one.
+            .exposedHeaders("X-Request-Id")
             .maxAge(3600);
     }
 }

--- a/cycles-admin-service/cycles-admin-service-api/src/main/resources/application.properties
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/resources/application.properties
@@ -33,6 +33,12 @@ management.health.readinessState.enabled=true
 management.prometheus.metrics.export.enabled=true
 management.metrics.tags.application=${spring.application.name}
 
+# Dashboard CORS origin(s). Comma-separated list of origins allowed to call /v1/**
+# from a browser. Default is the local Vite dev server. In production, set via
+# DASHBOARD_CORS_ORIGIN env var (e.g. https://dash.example.com or
+# https://dash.example.com,https://staging.example.com).
+dashboard.cors.origin=${DASHBOARD_CORS_ORIGIN:http://localhost:5173}
+
 # Admin API Key (for X-Admin-API-Key header)
 admin.api-key=${ADMIN_API_KEY:}
 

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/config/WebConfigTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/config/WebConfigTest.java
@@ -5,10 +5,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.servlet.config.annotation.CorsRegistration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -30,5 +34,65 @@ class WebConfigTest {
         ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
         verify(registration).addPathPatterns(pathCaptor.capture());
         assertThat(pathCaptor.getValue()).isEqualTo("/v1/**");
+    }
+
+    @Test
+    void addCorsMappings_allowlistsApiKeyAndRequestIdHeaders() {
+        WebConfig config = new WebConfig(authInterceptor);
+        ReflectionTestUtils.setField(config, "dashboardOrigin", "https://dash.example.com");
+
+        CorsRegistry corsRegistry = mock(CorsRegistry.class);
+        CorsRegistration corsReg = mock(CorsRegistration.class, RETURNS_SELF);
+        when(corsRegistry.addMapping("/v1/**")).thenReturn(corsReg);
+
+        config.addCorsMappings(corsRegistry);
+
+        // Verify the single origin was parsed and passed through.
+        verify(corsReg).allowedOrigins("https://dash.example.com");
+
+        // Capture the headers passed to allowedHeaders — both auth headers and
+        // X-Request-Id must be allowlisted, otherwise browser preflight blocks them.
+        ArgumentCaptor<String[]> headers = ArgumentCaptor.forClass(String[].class);
+        verify(corsReg).allowedHeaders(headers.capture());
+        assertThat(headers.getValue())
+            .containsExactlyInAnyOrder("X-Admin-API-Key", "X-Cycles-API-Key", "X-Request-Id", "Content-Type");
+
+        // X-Request-Id must be exposed so browser clients can read server-assigned ids.
+        ArgumentCaptor<String[]> exposed = ArgumentCaptor.forClass(String[].class);
+        verify(corsReg).exposedHeaders(exposed.capture());
+        assertThat(exposed.getValue()).containsExactly("X-Request-Id");
+
+        verify(corsReg).allowedMethods("GET", "POST", "PATCH", "DELETE", "OPTIONS");
+        verify(corsReg).maxAge(3600L);
+    }
+
+    @Test
+    void addCorsMappings_parsesCommaSeparatedOriginList() {
+        WebConfig config = new WebConfig(authInterceptor);
+        ReflectionTestUtils.setField(config, "dashboardOrigin",
+            "https://dash.example.com, https://staging.example.com ,https://dev.example.com");
+
+        CorsRegistry corsRegistry = mock(CorsRegistry.class);
+        CorsRegistration corsReg = mock(CorsRegistration.class, RETURNS_SELF);
+        when(corsRegistry.addMapping(any())).thenReturn(corsReg);
+
+        config.addCorsMappings(corsRegistry);
+
+        // All three origins, whitespace trimmed.
+        verify(corsReg).allowedOrigins("https://dash.example.com", "https://staging.example.com", "https://dev.example.com");
+    }
+
+    @Test
+    void addCorsMappings_ignoresEmptyEntriesInOriginList() {
+        WebConfig config = new WebConfig(authInterceptor);
+        ReflectionTestUtils.setField(config, "dashboardOrigin", "https://dash.example.com,,  ,https://other.example.com");
+
+        CorsRegistry corsRegistry = mock(CorsRegistry.class);
+        CorsRegistration corsReg = mock(CorsRegistration.class, RETURNS_SELF);
+        when(corsRegistry.addMapping(any())).thenReturn(corsReg);
+
+        config.addCorsMappings(corsRegistry);
+
+        verify(corsReg).allowedOrigins("https://dash.example.com", "https://other.example.com");
     }
 }

--- a/cycles-admin-service/pom.xml
+++ b/cycles-admin-service/pom.xml
@@ -18,7 +18,7 @@
         <module>cycles-admin-service-api</module>
     </modules>
     <properties>
-        <revision>0.1.25.8</revision>
+        <revision>0.1.25.9</revision>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/docker-compose.full-stack.prod.yml
+++ b/docker-compose.full-stack.prod.yml
@@ -13,7 +13,7 @@ services:
       retries: 5
 
   cycles-admin:
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.8
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.9
     restart: unless-stopped
     ports:
       - "7979:7979"

--- a/docker-compose.full-stack.prod.yml
+++ b/docker-compose.full-stack.prod.yml
@@ -25,6 +25,10 @@ services:
       WEBHOOK_SECRET_ENCRYPTION_KEY: ${WEBHOOK_SECRET_ENCRYPTION_KEY:-}
       EVENT_TTL_DAYS: ${EVENT_TTL_DAYS:-90}
       DELIVERY_TTL_DAYS: ${DELIVERY_TTL_DAYS:-14}
+      # Dashboard CORS origin(s). Comma-separated list. Set to your production
+      # dashboard URL, e.g. https://dash.example.com. Default localhost:5173 is
+      # the Vite dev server and will NOT work in production.
+      DASHBOARD_CORS_ORIGIN: ${DASHBOARD_CORS_ORIGIN:-http://localhost:5173}
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:7979/actuator/health/liveness"]
       interval: 10s

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,7 +13,7 @@ services:
       retries: 5
 
   cycles-admin:
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.8
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.9
     restart: unless-stopped
     ports:
       - "7979:7979"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -25,6 +25,10 @@ services:
       WEBHOOK_SECRET_ENCRYPTION_KEY: ${WEBHOOK_SECRET_ENCRYPTION_KEY:-}
       EVENT_TTL_DAYS: ${EVENT_TTL_DAYS:-90}
       DELIVERY_TTL_DAYS: ${DELIVERY_TTL_DAYS:-14}
+      # Dashboard CORS origin(s). Comma-separated list. Set to your production
+      # dashboard URL, e.g. https://dash.example.com. Default localhost:5173 is
+      # the Vite dev server and will NOT work in production.
+      DASHBOARD_CORS_ORIGIN: ${DASHBOARD_CORS_ORIGIN:-http://localhost:5173}
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:7979/actuator/health/liveness"]
       interval: 10s


### PR DESCRIPTION
## Summary

Closes the MEDIUM CORS gap from the post-v0.1.25.8 review and fixes **two real bugs** found while investigating it.

### Bugs fixed

1. **\`X-Cycles-API-Key\` was not in CORS \`allowedHeaders\`.** \`AuthInterceptor\` accepts the header for tenant authentication, but browsers would fail CORS preflight on any tenant-key call — only \`X-Admin-API-Key\` was allowlisted. Any browser-based dashboard using tenant API keys would be broken.
2. **\`X-Request-Id\` was neither in \`allowedHeaders\` nor \`exposedHeaders\`.** \`RequestIdFilter\` handles the header on both directions, but browsers couldn't send correlation ids in or read the server-assigned id out — silently breaking debugging flows.

### Production config

- \`WebConfig\` parses a comma-separated list from \`dashboard.cors.origin\` so a single admin deployment can front multiple dashboard environments (e.g. \`https://dash.example.com,https://staging.example.com\`). Empty entries and whitespace are trimmed.
- Startup log prints the configured origins for operator visibility.
- \`application.properties\` now explicitly binds \`dashboard.cors.origin=\${DASHBOARD_CORS_ORIGIN:http://localhost:5173}\`.
- \`docker-compose.prod.yml\` and \`docker-compose.full-stack.prod.yml\` pass the env var through with a warning comment that the localhost default is dev-only.

### Docs

- README \`Environment Variables\` table gained a \`DASHBOARD_CORS_ORIGIN\` row flagging it as must-set-in-prod.
- New **CORS** subsection in the Observability section listing allowlisted methods, request headers, exposed headers, and origin list format.
- AUDIT.md changelog entry.

### Tests

**429 → 432** (three new \`WebConfigTest\` cases):
- \`addCorsMappings_allowlistsApiKeyAndRequestIdHeaders\` — verifies all 4 headers are allowlisted and \`X-Request-Id\` is exposed
- \`addCorsMappings_parsesCommaSeparatedOriginList\` — three-origin list with mixed whitespace
- \`addCorsMappings_ignoresEmptyEntriesInOriginList\` — empty tokens between commas

## Backward compatibility

Single-origin deployments continue to work — the default property still resolves to a single origin. No HTTP API surface changes. No spec changes.

## Test plan
- [x] \`mvn -B verify\` — 432/432 pass
- [ ] After merge: deploy to staging, confirm dashboard with \`X-Cycles-API-Key\` completes browser preflight
- [ ] After merge: confirm \`curl -H "Origin: https://dash.example.com" -H "Access-Control-Request-Method: POST" -X OPTIONS :7979/v1/admin/tenants\` returns \`Access-Control-Allow-Headers\` containing \`X-Cycles-API-Key\`