### PR TITLE
release: v0.1.25.10 — spec-compliance hardening (Permission enum + typed Capabilities)

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,9 +1,33 @@
 # Complete Budget Governance v0.1.25.8 — Admin Server Audit
 
-**Server version:** 0.1.25.9 (2026-04-10 patch release — CORS hardening + observability hardening)
-**Date:** 2026-04-10 (v0.1.25.9 release), 2026-04-10 (CORS hardening + prod config), 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
+**Server version:** 0.1.25.10 (2026-04-12 patch release — spec-compliance hardening: `Permission` enum + typed `Capabilities`)
+**Date:** 2026-04-12 (v0.1.25.10 spec-compliance hardening), 2026-04-10 (v0.1.25.9 release), 2026-04-10 (CORS hardening + prod config), 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
 **Spec:** [`cycles-governance-admin-v0.1.25.yaml`](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml) (OpenAPI 3.1.0, v0.1.25.9) in [cycles-protocol](https://github.com/runcycles/cycles-protocol)
 **Server:** Spring Boot 3.5.11 / Java 21 / Redis
+
+### 2026-04-12 — v0.1.25.10 spec-compliance hardening (`Permission` enum + typed `Capabilities`)
+
+Full line-by-line audit of all 56 schemas in `cycles-governance-admin-v0.1.25.yaml` against every Java DTO. Endpoint surface (43/43 operations) and all other schemas verified compliant. Two real gaps fixed here; one low-impact gap (EventData `String` fields where spec defines enums — outbound-only, producer-disciplined) deferred.
+
+**Gap 1 — `Permission` schema not modeled.** Spec defines `Permission` as a 27-value enum (`reservations:create`, `budgets:write`, `admin:audit:read`, …). Every place the spec says `array of $ref Permission`, the impl used `List<String>`, so `POST /v1/admin/api-keys` and `PATCH /v1/admin/api-keys/{key_id}` accepted arbitrary strings — a typo like `"budgets:wirte"` would silently persist an unusable key.
+
+- **New:** `cycles-admin-service-model/.../auth/Permission.java` — enum with `@JsonValue` (wire-string) and `@JsonCreator` (rejects unknown values with `IllegalArgumentException`, surfaced by Spring as a 400).
+- **Changed:** `ApiKeyCreateRequest.permissions` and `ApiKeyUpdateRequest.permissions` from `List<String>` to `List<Permission>`. Added `getPermissionsAsStrings()` helper so the controller/repository path that writes to Redis (`ApiKey` entity) and emits events (`EventDataApiKey`) keeps using wire-strings — no Redis migration, no `AuthInterceptor` rewrite.
+- **Boundary touch-ups:** `ApiKeyController` (create audit meta, create event payload, update audit meta) and `ApiKeyRepository` (default permissions, update setter) converted via `getPermissionsAsStrings()`.
+- **Storage, outbound DTOs, `AuthInterceptor`, `EventDataApiKey`, `ApiKeyValidationResponse`, `ApiKey`/`ApiKeyResponse`** intentionally remain `List<String>` — once validated at the inbound boundary, strings in internal propagation are safe. `AuthIntrospectResponse.permissions` stays `List<String>` per spec line 2597 (the `"*"` admin wildcard is not a defined `Permission` enum value).
+
+**Gap 2 — `AuthIntrospectResponse.capabilities` weakly typed.** Spec (lines 2599–2611) requires an object with exactly eight named boolean properties, all required and "always present (explicit false, never omitted)". Impl was `Map<String, Boolean>` — a future bug could silently drop any of the eight keys and the dashboard would break in a hard-to-diagnose way.
+
+- **New:** `cycles-admin-service-model/.../auth/Capabilities.java` — eight `@JsonProperty` primitive booleans (`view_overview`, `view_budgets`, `view_events`, `view_webhooks`, `view_audit`, `view_tenants`, `view_api_keys`, `view_policies`), `@JsonInclude(ALWAYS)`.
+- **Changed:** `AuthIntrospectResponse.capabilities: Map<String, Boolean>` → `Capabilities`. `AuthController.deriveCapabilities(...)` now returns a `Capabilities.builder()` instead of `Map.of(...)`. **JSON wire shape is identical.**
+
+**Wire compatibility:** both changes are non-breaking for conformant clients. Inbound API-key callers that were previously sending typo'd permission strings will now see 400 instead of 200 — that is the point.
+
+**Tests:** 432 passing (+2 new `AuthModelTest` cases, offset by 2 existing test rewrites — `AuthModelTest.apiKeyCreateRequestValidation` and `ApiKeyRepositoryTest` permission setters — that now use `Permission` enum constants instead of raw strings): `apiKeyCreateRequest_unknownPermission_rejected` verifies an invalid permission in a create payload raises `JsonMappingException`; `apiKeyCreateRequest_validPermissions_deserialize` verifies happy-path round-trip `string → Permission → string`. Updated two existing tests in `AuthModelTest` and `ApiKeyRepositoryTest` to use enum constants instead of raw strings (one previously used invalid values `"read"`/`"write"` — now uses `Permission.BALANCES_READ`/`BUDGETS_WRITE`).
+
+**Deferred — EventData enum typing.** `EventDataBudgetLifecycle.operation`, `EventDataBudgetThreshold.direction`, `EventDataRateSpike.metric`, `EventDataTenantLifecycle.previous_status`/`new_status`, `EventDataApiKey.previous_status`/`new_status` are typed `String` where the spec constrains them with enums. These are outbound-only, producer-disciplined fields (events are emitted by the service, never received). No current user impact; revisit during broader event-model cleanup.
+
+**Follow-up — contract test.** No automated OpenAPI contract test is wired in today. Recommend pinning `cycles-governance-admin-v0.1.25.yaml` and running `openapi-generator validate` or Atlassian Swagger Request Validator against the live SpringDoc `/api-docs` in CI so future drift is caught without manual audits.
 
 ### 2026-04-10 — CORS hardening + production config
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Runcycles Admin Server
 
-Administrative API for the Complete Budget Governance System, aligned with [Cycles Protocol v0.1.25.9](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml).
+Administrative API for the Complete Budget Governance System, aligned with [Cycles Protocol v0.1.25.10](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml).
 
 ## Overview
 
@@ -578,6 +578,8 @@ v0.1.25.7 adds backward-compatible wildcard fallback (`admin:write` satisfies an
 v0.1.25.8 adds dashboard and observability hardening for v0.1.26 readiness: `EventDataReservationDenied` extensibility (`policy_id`, `deny_detail`, open-string `reason_code`), `AdminOverviewResponse` enrichments (`recent_denials_by_reason` auto-populated on v0.1.25.x, plus `quota_health`, `access_control_stats`, `tenant_counts.in_observe_mode` reserved for v0.1.26 extensions), and accept-and-ignore query params on `listTenants` (`observe_mode`) and `listPolicies` (`has_action_quotas`, `references_action_kind`). All additions are backward compatible — `@JsonInclude(NON_NULL)` keeps responses unchanged when new fields are null.
 
 v0.1.25.9 is a patch release with operational hardening only — **no API surface changes**, spec stays at v0.1.25.8. Adds: Micrometer/Prometheus metrics at `/actuator/prometheus` with custom counters (`cycles_admin_events_emitted_total`, `cycles_admin_webhook_dispatched_total`); Kubernetes liveness/readiness probes at `/actuator/health/liveness` and `/actuator/health/readiness` (docker-compose healthchecks switched to liveness); CORS fixes — `X-Cycles-API-Key` and `X-Request-Id` are now allowlisted (both were previously blocked at preflight, breaking browser dashboards using tenant auth) and `X-Request-Id` is exposed for correlation; multi-origin CORS support via comma-separated `DASHBOARD_CORS_ORIGIN` env var.
+
+v0.1.25.10 is a patch release hardening spec compliance for `cycles-governance-admin-v0.1.25` (no API surface changes). (1) **`Permission` enum now modeled** — the 27 spec permission values are a typed Java enum with Jackson `@JsonValue`/`@JsonCreator`; inbound `POST /v1/admin/api-keys` and `PATCH /v1/admin/api-keys/{key_id}` now reject unknown permission strings (e.g. typos like `"budgets:wirte"`) at deserialization with a 400 instead of silently storing them. Wire format unchanged. (2) **`AuthIntrospectResponse.capabilities` structurally typed** — replaced the `Map<String, Boolean>` with a dedicated `Capabilities` class exposing the eight required booleans (`view_overview`, `view_budgets`, `view_events`, `view_webhooks`, `view_audit`, `view_tenants`, `view_api_keys`, `view_policies`) per spec's "all fields always present" contract. JSON shape identical.
 
 ## Documentation
 

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/ApiKeyController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/ApiKeyController.java
@@ -37,7 +37,7 @@ public class ApiKeyController {
             .operation("createApiKey")
             .status(201)
             .metadata(request.getPermissions() != null
-                ? Map.of("name", request.getName(), "permissions", request.getPermissions())
+                ? Map.of("name", request.getName(), "permissions", request.getPermissionsAsStrings())
                 : Map.of("name", request.getName()))
             .build());
         try {
@@ -45,7 +45,7 @@ public class ApiKeyController {
                 Actor.builder().type(ActorType.ADMIN).build(),
                 objectMapper.convertValue(EventDataApiKey.builder()
                     .keyId(response.getKeyId()).keyName(request.getName())
-                    .newStatus("ACTIVE").permissions(request.getPermissions()).build(), Map.class),
+                    .newStatus("ACTIVE").permissions(request.getPermissionsAsStrings()).build(), Map.class),
                 null, httpRequest.getAttribute("requestId") != null ? httpRequest.getAttribute("requestId").toString() : null);
         } catch (Exception e) {
             LOG.warn("Failed to emit event: {}", e.getMessage());
@@ -83,7 +83,7 @@ public class ApiKeyController {
         ApiKey updated = repository.update(keyId, request);
         ApiKeyResponse response = ApiKeyResponse.from(updated);
         java.util.HashMap<String, Object> auditMeta = new java.util.HashMap<>();
-        if (request.getPermissions() != null) auditMeta.put("permissions", request.getPermissions());
+        if (request.getPermissions() != null) auditMeta.put("permissions", request.getPermissionsAsStrings());
         if (request.getScopeFilter() != null) auditMeta.put("scope_filter", request.getScopeFilter());
         if (request.getName() != null) auditMeta.put("name", request.getName());
         auditRepository.log(buildAuditEntry(httpRequest)

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/AuthController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/AuthController.java
@@ -3,6 +3,7 @@ import io.runcycles.admin.data.repository.ApiKeyRepository;
 import io.runcycles.admin.model.auth.ApiKeyValidationRequest;
 import io.runcycles.admin.model.auth.ApiKeyValidationResponse;
 import io.runcycles.admin.model.auth.AuthIntrospectResponse;
+import io.runcycles.admin.model.auth.Capabilities;
 import io.runcycles.admin.api.service.EventService;
 import io.runcycles.admin.model.event.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -54,17 +55,17 @@ public class AuthController {
                 .build());
     }
 
-    private Map<String, Boolean> deriveCapabilities(List<String> permissions) {
+    private Capabilities deriveCapabilities(List<String> permissions) {
         boolean isAdmin = permissions.contains("*");
-        return Map.of(
-                "view_overview",  isAdmin,
-                "view_budgets",   isAdmin || permissions.contains("admin:read") || permissions.contains("admin:budgets:read"),
-                "view_events",    isAdmin || permissions.contains("events:read") || permissions.contains("admin:events:read"),
-                "view_webhooks",  isAdmin || permissions.contains("webhooks:read") || permissions.contains("admin:webhooks:read"),
-                "view_audit",     isAdmin || permissions.contains("admin:audit:read"),
-                "view_tenants",   isAdmin || permissions.contains("admin:tenants:read"),
-                "view_api_keys",  isAdmin || permissions.contains("admin:apikeys:read"),
-                "view_policies",  isAdmin || permissions.contains("admin:read") || permissions.contains("admin:policies:read")
-        );
+        return Capabilities.builder()
+                .viewOverview(isAdmin)
+                .viewBudgets(isAdmin || permissions.contains("admin:read") || permissions.contains("admin:budgets:read"))
+                .viewEvents(isAdmin || permissions.contains("events:read") || permissions.contains("admin:events:read"))
+                .viewWebhooks(isAdmin || permissions.contains("webhooks:read") || permissions.contains("admin:webhooks:read"))
+                .viewAudit(isAdmin || permissions.contains("admin:audit:read"))
+                .viewTenants(isAdmin || permissions.contains("admin:tenants:read"))
+                .viewApiKeys(isAdmin || permissions.contains("admin:apikeys:read"))
+                .viewPolicies(isAdmin || permissions.contains("admin:read") || permissions.contains("admin:policies:read"))
+                .build();
     }
 }

--- a/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/ApiKeyRepository.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/ApiKeyRepository.java
@@ -66,7 +66,7 @@ public class ApiKeyRepository {
                 .keyHash(keyHash)
                 .name(request.getName())
                 .description(request.getDescription())
-                .permissions(request.getPermissions() != null ? request.getPermissions() : DEFAULT_PERMISSIONS)
+                .permissions(request.getPermissions() != null ? request.getPermissionsAsStrings() : DEFAULT_PERMISSIONS)
                 .scopeFilter(request.getScopeFilter())
                 .status(ApiKeyStatus.ACTIVE)
                 .createdAt(Instant.now())
@@ -161,7 +161,7 @@ public class ApiKeyRepository {
             // Apply partial updates — only non-null fields
             if (request.getName() != null) key.setName(request.getName());
             if (request.getDescription() != null) key.setDescription(request.getDescription());
-            if (request.getPermissions() != null) key.setPermissions(request.getPermissions());
+            if (request.getPermissions() != null) key.setPermissions(request.getPermissionsAsStrings());
             if (request.getScopeFilter() != null) key.setScopeFilter(request.getScopeFilter());
             if (request.getMetadata() != null) key.setMetadata(request.getMetadata());
             // Write back with Jackson (clean serialization, no cjson issues)

--- a/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/ApiKeyRepositoryTest.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/ApiKeyRepositoryTest.java
@@ -435,7 +435,7 @@ class ApiKeyRepositoryTest {
         ApiKeyCreateRequest request = new ApiKeyCreateRequest();
         request.setTenantId("test-tenant");
         request.setName("Test Key");
-        request.setPermissions(List.of("reservations:create"));
+        request.setPermissions(List.of(io.runcycles.admin.model.auth.Permission.RESERVATIONS_CREATE));
 
         ApiKeyCreateResponse response = repository.create(request);
 
@@ -723,7 +723,7 @@ class ApiKeyRepositoryTest {
 
         ApiKeyUpdateRequest request = new ApiKeyUpdateRequest();
         request.setName("Updated");
-        request.setPermissions(List.of("budgets:read", "budgets:write"));
+        request.setPermissions(List.of(io.runcycles.admin.model.auth.Permission.BUDGETS_READ, io.runcycles.admin.model.auth.Permission.BUDGETS_WRITE));
 
         ApiKey result = repository.update("key_1", request);
 

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/auth/ApiKeyCreateRequest.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/auth/ApiKeyCreateRequest.java
@@ -10,8 +10,13 @@ public class ApiKeyCreateRequest {
     @NotBlank @JsonProperty("tenant_id") private String tenantId;
     @NotBlank @Size(max = 256) @JsonProperty("name") private String name;
     @Size(max = 1024) @JsonProperty("description") private String description;
-    @JsonProperty("permissions") private List<String> permissions;
+    @JsonProperty("permissions") private List<Permission> permissions;
     @JsonProperty("scope_filter") private List<String> scopeFilter;
     @JsonProperty("expires_at") private Instant expiresAt;
     @JsonProperty("metadata") private Map<String, Object> metadata;
+
+    /** Returns permissions as wire-format strings, or null if unset. */
+    public List<String> getPermissionsAsStrings() {
+        return permissions == null ? null : permissions.stream().map(Permission::getValue).toList();
+    }
 }

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/auth/ApiKeyUpdateRequest.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/auth/ApiKeyUpdateRequest.java
@@ -10,7 +10,12 @@ import java.util.Map;
 public class ApiKeyUpdateRequest {
     @Size(max = 256) @JsonProperty("name") private String name;
     @Size(max = 1024) @JsonProperty("description") private String description;
-    @JsonProperty("permissions") private List<String> permissions;
+    @JsonProperty("permissions") private List<Permission> permissions;
     @JsonProperty("scope_filter") private List<String> scopeFilter;
     @JsonProperty("metadata") private Map<String, Object> metadata;
+
+    /** Returns permissions as wire-format strings, or null if unset. */
+    public List<String> getPermissionsAsStrings() {
+        return permissions == null ? null : permissions.stream().map(Permission::getValue).toList();
+    }
 }

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/auth/AuthIntrospectResponse.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/auth/AuthIntrospectResponse.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
 import java.util.List;
-import java.util.Map;
 
 @Data @Builder @NoArgsConstructor @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.ALWAYS)
@@ -13,5 +12,5 @@ public class AuthIntrospectResponse {
     @JsonProperty("authenticated") private boolean authenticated;
     @JsonProperty("auth_type") private String authType;
     @JsonProperty("permissions") private List<String> permissions;
-    @JsonProperty("capabilities") private Map<String, Boolean> capabilities;
+    @JsonProperty("capabilities") private Capabilities capabilities;
 }

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/auth/Capabilities.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/auth/Capabilities.java
@@ -1,0 +1,28 @@
+package io.runcycles.admin.model.auth;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Derived boolean capabilities for dashboard UI. Per spec, all 8 fields are
+ * always present (explicit false, never omitted).
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.ALWAYS)
+public class Capabilities {
+    @JsonProperty("view_overview") private boolean viewOverview;
+    @JsonProperty("view_budgets") private boolean viewBudgets;
+    @JsonProperty("view_events") private boolean viewEvents;
+    @JsonProperty("view_webhooks") private boolean viewWebhooks;
+    @JsonProperty("view_audit") private boolean viewAudit;
+    @JsonProperty("view_tenants") private boolean viewTenants;
+    @JsonProperty("view_api_keys") private boolean viewApiKeys;
+    @JsonProperty("view_policies") private boolean viewPolicies;
+}

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/auth/Permission.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/auth/Permission.java
@@ -1,0 +1,61 @@
+package io.runcycles.admin.model.auth;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * API key permission values, per cycles-governance-admin-v0.1.25 spec (schemas.Permission).
+ * Serializes to/from the spec's colon-separated string form (e.g. {@code "budgets:write"}).
+ * Jackson rejects unknown strings on deserialization via {@link #fromValue(String)}.
+ */
+public enum Permission {
+    // Tenant runtime permissions
+    RESERVATIONS_CREATE("reservations:create"),
+    RESERVATIONS_COMMIT("reservations:commit"),
+    RESERVATIONS_RELEASE("reservations:release"),
+    RESERVATIONS_EXTEND("reservations:extend"),
+    RESERVATIONS_LIST("reservations:list"),
+    BALANCES_READ("balances:read"),
+    BUDGETS_READ("budgets:read"),
+    BUDGETS_WRITE("budgets:write"),
+    POLICIES_READ("policies:read"),
+    POLICIES_WRITE("policies:write"),
+    WEBHOOKS_READ("webhooks:read"),
+    WEBHOOKS_WRITE("webhooks:write"),
+    EVENTS_READ("events:read"),
+    // Admin wildcard permissions (backward compatible)
+    ADMIN_READ("admin:read"),
+    ADMIN_WRITE("admin:write"),
+    // Granular admin permissions
+    ADMIN_TENANTS_READ("admin:tenants:read"),
+    ADMIN_TENANTS_WRITE("admin:tenants:write"),
+    ADMIN_BUDGETS_READ("admin:budgets:read"),
+    ADMIN_BUDGETS_WRITE("admin:budgets:write"),
+    ADMIN_POLICIES_READ("admin:policies:read"),
+    ADMIN_POLICIES_WRITE("admin:policies:write"),
+    ADMIN_APIKEYS_READ("admin:apikeys:read"),
+    ADMIN_APIKEYS_WRITE("admin:apikeys:write"),
+    ADMIN_WEBHOOKS_READ("admin:webhooks:read"),
+    ADMIN_WEBHOOKS_WRITE("admin:webhooks:write"),
+    ADMIN_EVENTS_READ("admin:events:read"),
+    ADMIN_AUDIT_READ("admin:audit:read");
+
+    private final String value;
+
+    Permission(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static Permission fromValue(String value) {
+        for (Permission p : values()) {
+            if (p.value.equals(value)) return p;
+        }
+        throw new IllegalArgumentException("Unknown permission: " + value);
+    }
+}

--- a/cycles-admin-service/cycles-admin-service-model/src/test/java/io/runcycles/admin/model/AuthModelTest.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/test/java/io/runcycles/admin/model/AuthModelTest.java
@@ -7,6 +7,7 @@ import io.runcycles.admin.model.auth.ApiKey;
 import io.runcycles.admin.model.auth.ApiKeyCreateRequest;
 import io.runcycles.admin.model.auth.ApiKeyResponse;
 import io.runcycles.admin.model.auth.ApiKeyStatus;
+import io.runcycles.admin.model.auth.Permission;
 import jakarta.validation.*;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -35,7 +36,7 @@ class AuthModelTest {
         ApiKeyCreateRequest request = new ApiKeyCreateRequest();
         request.setTenantId("tenant-1");
         request.setName("my-key");
-        request.setPermissions(List.of("read", "write"));
+        request.setPermissions(List.of(Permission.BALANCES_READ, Permission.BUDGETS_WRITE));
         request.setExpiresAt(Instant.parse("2027-01-01T00:00:00Z"));
 
         Set<ConstraintViolation<ApiKeyCreateRequest>> violations = validator.validate(request);
@@ -96,6 +97,28 @@ class AuthModelTest {
         request.setName("x".repeat(257));
         Set<ConstraintViolation<ApiKeyCreateRequest>> violations = validator.validate(request);
         assertFalse(violations.isEmpty());
+    }
+
+    @Test
+    void apiKeyCreateRequest_unknownPermission_rejected() {
+        String json = """
+            {"tenant_id":"t1","name":"k","permissions":["budgets:wirte"]}
+            """;
+        com.fasterxml.jackson.databind.JsonMappingException ex = assertThrows(
+                com.fasterxml.jackson.databind.JsonMappingException.class,
+                () -> mapper.readValue(json, ApiKeyCreateRequest.class));
+        assertTrue(ex.getMessage().contains("budgets:wirte"),
+                "Expected rejection message to mention bad permission, got: " + ex.getMessage());
+    }
+
+    @Test
+    void apiKeyCreateRequest_validPermissions_deserialize() throws Exception {
+        String json = """
+            {"tenant_id":"t1","name":"k","permissions":["budgets:read","admin:audit:read"]}
+            """;
+        ApiKeyCreateRequest req = mapper.readValue(json, ApiKeyCreateRequest.class);
+        assertEquals(List.of(Permission.BUDGETS_READ, Permission.ADMIN_AUDIT_READ), req.getPermissions());
+        assertEquals(List.of("budgets:read", "admin:audit:read"), req.getPermissionsAsStrings());
     }
 
     @Test

--- a/cycles-admin-service/pom.xml
+++ b/cycles-admin-service/pom.xml
@@ -18,7 +18,7 @@
         <module>cycles-admin-service-api</module>
     </modules>
     <properties>
-        <revision>0.1.25.9</revision>
+        <revision>0.1.25.10</revision>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/docker-compose.full-stack.prod.yml
+++ b/docker-compose.full-stack.prod.yml
@@ -13,7 +13,7 @@ services:
       retries: 5
 
   cycles-admin:
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.9
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.10
     restart: unless-stopped
     ports:
       - "7979:7979"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,7 +13,7 @@ services:
       retries: 5
 
   cycles-admin:
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.9
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.10
     restart: unless-stopped
     ports:
       - "7979:7979"


### PR DESCRIPTION
## Summary

Patch release closing two real compliance gaps found in a full line-by-line audit of all 56 schemas in `cycles-governance-admin-v0.1.25.yaml`. No API surface changes — wire format stays identical for conformant clients.

- **`Permission` enum now modeled.** The 27 spec permission values are a typed Java enum (`@JsonValue` / `@JsonCreator`). `POST /v1/admin/api-keys` and `PATCH /v1/admin/api-keys/{key_id}` now reject unknown permission strings at deserialization (e.g. typo `"budgets:wirte"` → 400) instead of silently persisting an unusable key. Storage, `AuthInterceptor`, and outbound DTOs intentionally stay `List<String>` — once validated at the inbound boundary, internal strings are safe. No Redis migration. `AuthIntrospectResponse.permissions` stays `List<String>` per spec line 2597 (the `"*"` admin wildcard is not a defined `Permission` enum value).
- **`AuthIntrospectResponse.capabilities` structurally typed.** Spec requires an object with exactly eight named booleans, all required and *"always present (explicit false, never omitted)"*. Replaced `Map<String, Boolean>` with a dedicated `Capabilities` class. JSON wire shape identical.
- **Deferred:** `EventData*` `String` fields where spec defines enums (outbound-only, producer-disciplined — no current user impact).
- **Follow-up:** wire an automated OpenAPI contract test in CI so future drift is caught without manual audits.

Also includes `b27a56c` (removes local spec copies, references `cycles-protocol` remote) — load-bearing for this release since AUDIT.md links to the remote spec.

Version bumped to `0.1.25.10` across `pom.xml`, both prod `docker-compose` image tags, `README` header + changelog, and `AUDIT.md` (new 2026-04-12 section).

## Test plan

- [x] `mvn clean verify` — 432 / 432 tests passing, 0 failures, JaCoCo 95%+ coverage checks met
- [x] New tests: `AuthModelTest.apiKeyCreateRequest_unknownPermission_rejected`, `AuthModelTest.apiKeyCreateRequest_validPermissions_deserialize`
- [x] Updated two existing tests to use `Permission` enum constants (one previously asserted on invalid strings `"read"`/`"write"`)
- [x] `AuthControllerTest` introspect JSONPath assertions (`$.capabilities.view_*`) unchanged → wire shape confirmed identical
- [x] Spring Boot fat jar builds as `cycles-admin-service-api-0.1.25.10.jar`
- [ ] Integration tests (Testcontainers + Redis) — require Docker, run in CI
- [ ] Dashboard smoke test post-deploy: verify `/v1/auth/introspect` still returns all 8 capability booleans
- [ ] Verify an API key create with a typo'd permission returns 400 (negative test)