### PR TITLE
test: rename tenant_id fixtures to meet spec minLength:3

### DIFF
--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/config/AuthInterceptorTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/config/AuthInterceptorTest.java
@@ -195,13 +195,13 @@ class AuthInterceptorTest {
 
         when(apiKeyRepository.validate("valid-key")).thenReturn(
                 ApiKeyValidationResponse.builder()
-                        .valid(true).tenantId("t1").keyId("key_1")
+                        .valid(true).tenantId("tenant-1").keyId("key_1")
                         .permissions(List.of("budgets:write", "balances:read"))
                         .scopeFilter(List.of("org/*"))
                         .build());
 
         assertThat(interceptor.preHandle(request, response, new Object())).isTrue();
-        assertThat(request.getAttribute("authenticated_tenant_id")).isEqualTo("t1");
+        assertThat(request.getAttribute("authenticated_tenant_id")).isEqualTo("tenant-1");
         assertThat(request.getAttribute("authenticated_key_id")).isEqualTo("key_1");
         assertThat(request.getAttribute("authenticated_permissions")).isEqualTo(List.of("budgets:write", "balances:read"));
         assertThat(request.getAttribute("authenticated_scope_filter")).isEqualTo(List.of("org/*"));
@@ -215,7 +215,7 @@ class AuthInterceptorTest {
 
         when(apiKeyRepository.validate("valid-key")).thenReturn(
                 ApiKeyValidationResponse.builder()
-                        .valid(true).tenantId("t1").keyId("key_1")
+                        .valid(true).tenantId("tenant-1").keyId("key_1")
                         .permissions(List.of("balances:read"))
                         .build());
 
@@ -231,7 +231,7 @@ class AuthInterceptorTest {
 
         when(apiKeyRepository.validate("valid-key")).thenReturn(
                 ApiKeyValidationResponse.builder()
-                        .valid(true).tenantId("t1").keyId("key_1")
+                        .valid(true).tenantId("tenant-1").keyId("key_1")
                         .permissions(List.of("balances:read"))
                         .build());
 
@@ -246,7 +246,7 @@ class AuthInterceptorTest {
 
         when(apiKeyRepository.validate("valid-key")).thenReturn(
                 ApiKeyValidationResponse.builder()
-                        .valid(true).tenantId("t1").keyId("key_1")
+                        .valid(true).tenantId("tenant-1").keyId("key_1")
                         .permissions(List.of("budgets:read"))
                         .build());
 
@@ -261,7 +261,7 @@ class AuthInterceptorTest {
 
         when(apiKeyRepository.validate("valid-key")).thenReturn(
                 ApiKeyValidationResponse.builder()
-                        .valid(true).tenantId("t1").keyId("key_1")
+                        .valid(true).tenantId("tenant-1").keyId("key_1")
                         .permissions(List.of("policies:read"))
                         .build());
 
@@ -279,7 +279,7 @@ class AuthInterceptorTest {
 
         when(apiKeyRepository.validate("valid-key")).thenReturn(
                 ApiKeyValidationResponse.builder()
-                        .valid(true).tenantId("t1").keyId("key_1")
+                        .valid(true).tenantId("tenant-1").keyId("key_1")
                         .permissions(List.of("admin:write"))
                         .build());
 
@@ -294,7 +294,7 @@ class AuthInterceptorTest {
 
         when(apiKeyRepository.validate("valid-key")).thenReturn(
                 ApiKeyValidationResponse.builder()
-                        .valid(true).tenantId("t1").keyId("key_1")
+                        .valid(true).tenantId("tenant-1").keyId("key_1")
                         .permissions(List.of("admin:read"))
                         .build());
 
@@ -309,7 +309,7 @@ class AuthInterceptorTest {
 
         when(apiKeyRepository.validate("valid-key")).thenReturn(
                 ApiKeyValidationResponse.builder()
-                        .valid(true).tenantId("t1").keyId("key_1")
+                        .valid(true).tenantId("tenant-1").keyId("key_1")
                         .permissions(List.of("admin:write"))
                         .build());
 
@@ -324,7 +324,7 @@ class AuthInterceptorTest {
 
         when(apiKeyRepository.validate("valid-key")).thenReturn(
                 ApiKeyValidationResponse.builder()
-                        .valid(true).tenantId("t1").keyId("key_1")
+                        .valid(true).tenantId("tenant-1").keyId("key_1")
                         .permissions(List.of("admin:read"))
                         .build());
 
@@ -340,7 +340,7 @@ class AuthInterceptorTest {
 
         when(apiKeyRepository.validate("valid-key")).thenReturn(
                 ApiKeyValidationResponse.builder()
-                        .valid(true).tenantId("t1").keyId("key_1")
+                        .valid(true).tenantId("tenant-1").keyId("key_1")
                         .permissions(null)
                         .build());
 
@@ -401,12 +401,12 @@ class AuthInterceptorTest {
 
         when(apiKeyRepository.validate("valid-key")).thenReturn(
                 ApiKeyValidationResponse.builder()
-                        .valid(true).tenantId("t1").keyId("key_1")
+                        .valid(true).tenantId("tenant-1").keyId("key_1")
                         .permissions(List.of("reservations:write"))
                         .build());
 
         assertThat(interceptor.preHandle(request, response, new Object())).isTrue();
-        assertThat(request.getAttribute("authenticated_tenant_id")).isEqualTo("t1");
+        assertThat(request.getAttribute("authenticated_tenant_id")).isEqualTo("tenant-1");
     }
 
     // --- API key validation edge cases ---
@@ -629,12 +629,12 @@ class AuthInterceptorTest {
 
         when(apiKeyRepository.validate("valid-key")).thenReturn(
                 ApiKeyValidationResponse.builder()
-                        .valid(true).tenantId("t1").keyId("key_1")
+                        .valid(true).tenantId("tenant-1").keyId("key_1")
                         .permissions(List.of("budgets:read"))
                         .build());
 
         assertThat(interceptor.preHandle(request, response, new Object())).isTrue();
-        assertThat(request.getAttribute("authenticated_tenant_id")).isEqualTo("t1");
+        assertThat(request.getAttribute("authenticated_tenant_id")).isEqualTo("tenant-1");
     }
 
     @Test
@@ -645,12 +645,12 @@ class AuthInterceptorTest {
 
         when(apiKeyRepository.validate("valid-key")).thenReturn(
                 ApiKeyValidationResponse.builder()
-                        .valid(true).tenantId("t1").keyId("key_1")
+                        .valid(true).tenantId("tenant-1").keyId("key_1")
                         .permissions(List.of("policies:read"))
                         .build());
 
         assertThat(interceptor.preHandle(request, response, new Object())).isTrue();
-        assertThat(request.getAttribute("authenticated_tenant_id")).isEqualTo("t1");
+        assertThat(request.getAttribute("authenticated_tenant_id")).isEqualTo("tenant-1");
     }
 
     // --- Dual-auth: scope filter no-op for admin key ---

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/ApiKeyControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/ApiKeyControllerTest.java
@@ -41,7 +41,7 @@ class ApiKeyControllerTest {
     void createApiKey_returns201() throws Exception {
         ApiKeyCreateResponse response = ApiKeyCreateResponse.builder()
                 .keyId("key_123").keySecret("gov_secret").keyPrefix("gov_secret1234")
-                .tenantId("t1").permissions(List.of("balances:read"))
+                .tenantId("tenant-1").permissions(List.of("balances:read"))
                 .createdAt(Instant.now()).expiresAt(Instant.now().plusSeconds(86400))
                 .build();
         when(apiKeyRepository.create(any())).thenReturn(response);
@@ -49,7 +49,7 @@ class ApiKeyControllerTest {
         mockMvc.perform(post("/v1/admin/api-keys")
                         .header("X-Admin-API-Key", ADMIN_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"tenant_id\":\"t1\",\"name\":\"My Key\"}"))
+                        .content("{\"tenant_id\":\"tenant-1\",\"name\":\"My Key\"}"))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.key_id").value("key_123"))
                 .andExpect(jsonPath("$.key_secret").value("gov_secret"));
@@ -67,14 +67,14 @@ class ApiKeyControllerTest {
     @Test
     void listApiKeys_returns200() throws Exception {
         ApiKey key = ApiKey.builder()
-                .keyId("key_1").tenantId("t1").keyPrefix("gov_pre")
+                .keyId("key_1").tenantId("tenant-1").keyPrefix("gov_pre")
                 .status(ApiKeyStatus.ACTIVE).createdAt(Instant.now())
                 .expiresAt(Instant.now().plusSeconds(86400)).build();
-        when(apiKeyRepository.list(eq("t1"), any(), any(), anyInt())).thenReturn(List.of(key));
+        when(apiKeyRepository.list(eq("tenant-1"), any(), any(), anyInt())).thenReturn(List.of(key));
 
         mockMvc.perform(get("/v1/admin/api-keys")
                         .header("X-Admin-API-Key", ADMIN_KEY)
-                        .param("tenant_id", "t1"))
+                        .param("tenant_id", "tenant-1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.keys").isArray())
                 .andExpect(jsonPath("$.keys[0].key_id").value("key_1"));
@@ -83,7 +83,7 @@ class ApiKeyControllerTest {
     @Test
     void revokeApiKey_returns200() throws Exception {
         ApiKey revoked = ApiKey.builder()
-                .keyId("key_1").tenantId("t1").keyPrefix("gov_pre")
+                .keyId("key_1").tenantId("tenant-1").keyPrefix("gov_pre")
                 .status(ApiKeyStatus.REVOKED).revokedAt(Instant.now())
                 .revokedReason("test").createdAt(Instant.now())
                 .expiresAt(Instant.now().plusSeconds(86400)).build();
@@ -111,7 +111,7 @@ class ApiKeyControllerTest {
     void createApiKey_logsAuditEntry() throws Exception {
         ApiKeyCreateResponse response = ApiKeyCreateResponse.builder()
                 .keyId("key_123").keySecret("gov_secret").keyPrefix("gov_secret1234")
-                .tenantId("t1").permissions(List.of("balances:read"))
+                .tenantId("tenant-1").permissions(List.of("balances:read"))
                 .createdAt(Instant.now()).expiresAt(Instant.now().plusSeconds(86400))
                 .build();
         when(apiKeyRepository.create(any())).thenReturn(response);
@@ -119,12 +119,12 @@ class ApiKeyControllerTest {
         mockMvc.perform(post("/v1/admin/api-keys")
                         .header("X-Admin-API-Key", ADMIN_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"tenant_id\":\"t1\",\"name\":\"My Key\"}"))
+                        .content("{\"tenant_id\":\"tenant-1\",\"name\":\"My Key\"}"))
                 .andExpect(status().isCreated());
 
         verify(auditRepository).log(argThat(entry ->
                 "createApiKey".equals(entry.getOperation()) &&
-                "t1".equals(entry.getTenantId()) &&
+                "tenant-1".equals(entry.getTenantId()) &&
                 "key_123".equals(entry.getKeyId()) &&
                 entry.getStatus() == 201));
     }
@@ -132,7 +132,7 @@ class ApiKeyControllerTest {
     @Test
     void revokeApiKey_logsAuditEntry() throws Exception {
         ApiKey revoked = ApiKey.builder()
-                .keyId("key_1").tenantId("t1").keyPrefix("gov_pre")
+                .keyId("key_1").tenantId("tenant-1").keyPrefix("gov_pre")
                 .status(ApiKeyStatus.REVOKED).revokedAt(Instant.now())
                 .revokedReason("test").createdAt(Instant.now())
                 .expiresAt(Instant.now().plusSeconds(86400)).build();
@@ -145,18 +145,18 @@ class ApiKeyControllerTest {
 
         verify(auditRepository).log(argThat(entry ->
                 "revokeApiKey".equals(entry.getOperation()) &&
-                "t1".equals(entry.getTenantId()) &&
+                "tenant-1".equals(entry.getTenantId()) &&
                 "key_1".equals(entry.getKeyId()) &&
                 entry.getStatus() == 200));
     }
 
     @Test
     void listApiKeys_emptyResult_hasMoreFalseAndNoCursor() throws Exception {
-        when(apiKeyRepository.list(eq("t1"), any(), any(), anyInt())).thenReturn(List.of());
+        when(apiKeyRepository.list(eq("tenant-1"), any(), any(), anyInt())).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/api-keys")
                         .header("X-Admin-API-Key", ADMIN_KEY)
-                        .param("tenant_id", "t1"))
+                        .param("tenant_id", "tenant-1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.keys").isEmpty())
                 .andExpect(jsonPath("$.has_more").value(false))
@@ -165,35 +165,35 @@ class ApiKeyControllerTest {
 
     @Test
     void listApiKeys_limitClampedToMax100() throws Exception {
-        when(apiKeyRepository.list(eq("t1"), any(), any(), eq(100))).thenReturn(List.of());
+        when(apiKeyRepository.list(eq("tenant-1"), any(), any(), eq(100))).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/api-keys")
                         .header("X-Admin-API-Key", ADMIN_KEY)
-                        .param("tenant_id", "t1")
+                        .param("tenant_id", "tenant-1")
                         .param("limit", "500"))
                 .andExpect(status().isOk());
 
-        verify(apiKeyRepository).list(eq("t1"), any(), any(), eq(100));
+        verify(apiKeyRepository).list(eq("tenant-1"), any(), any(), eq(100));
     }
 
     @Test
     void listApiKeys_limitClampedToMin1() throws Exception {
-        when(apiKeyRepository.list(eq("t1"), any(), any(), eq(1))).thenReturn(List.of());
+        when(apiKeyRepository.list(eq("tenant-1"), any(), any(), eq(1))).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/api-keys")
                         .header("X-Admin-API-Key", ADMIN_KEY)
-                        .param("tenant_id", "t1")
+                        .param("tenant_id", "tenant-1")
                         .param("limit", "0"))
                 .andExpect(status().isOk());
 
-        verify(apiKeyRepository).list(eq("t1"), any(), any(), eq(1));
+        verify(apiKeyRepository).list(eq("tenant-1"), any(), any(), eq(1));
     }
 
     @Test
     void createApiKey_auditEntry_requestIdIsFallbackUuidWhenAttributeMissing() throws Exception {
         ApiKeyCreateResponse response = ApiKeyCreateResponse.builder()
                 .keyId("key_123").keySecret("gov_secret").keyPrefix("gov_secret1234")
-                .tenantId("t1").permissions(List.of("balances:read"))
+                .tenantId("tenant-1").permissions(List.of("balances:read"))
                 .createdAt(Instant.now()).expiresAt(Instant.now().plusSeconds(86400))
                 .build();
         when(apiKeyRepository.create(any())).thenReturn(response);
@@ -202,7 +202,7 @@ class ApiKeyControllerTest {
         mockMvc.perform(post("/v1/admin/api-keys")
                         .header("X-Admin-API-Key", ADMIN_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"tenant_id\":\"t1\",\"name\":\"My Key\"}"))
+                        .content("{\"tenant_id\":\"tenant-1\",\"name\":\"My Key\"}"))
                 .andExpect(status().isCreated());
 
         verify(auditRepository).log(argThat(entry ->
@@ -215,7 +215,7 @@ class ApiKeyControllerTest {
     void createApiKey_auditEntry_userAgentIsNullWhenHeaderMissing() throws Exception {
         ApiKeyCreateResponse response = ApiKeyCreateResponse.builder()
                 .keyId("key_123").keySecret("gov_secret").keyPrefix("gov_secret1234")
-                .tenantId("t1").permissions(List.of("balances:read"))
+                .tenantId("tenant-1").permissions(List.of("balances:read"))
                 .createdAt(Instant.now()).expiresAt(Instant.now().plusSeconds(86400))
                 .build();
         when(apiKeyRepository.create(any())).thenReturn(response);
@@ -224,7 +224,7 @@ class ApiKeyControllerTest {
         mockMvc.perform(post("/v1/admin/api-keys")
                         .header("X-Admin-API-Key", ADMIN_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"tenant_id\":\"t1\",\"name\":\"My Key\"}"))
+                        .content("{\"tenant_id\":\"tenant-1\",\"name\":\"My Key\"}"))
                 .andExpect(status().isCreated());
 
         verify(auditRepository).log(argThat(entry ->
@@ -235,7 +235,7 @@ class ApiKeyControllerTest {
     @Test
     void revokeApiKey_auditEntry_requestIdIsFallbackUuidWhenAttributeMissing() throws Exception {
         ApiKey revoked = ApiKey.builder()
-                .keyId("key_1").tenantId("t1").keyPrefix("gov_pre")
+                .keyId("key_1").tenantId("tenant-1").keyPrefix("gov_pre")
                 .status(ApiKeyStatus.REVOKED).revokedAt(Instant.now())
                 .revokedReason("test").createdAt(Instant.now())
                 .expiresAt(Instant.now().plusSeconds(86400)).build();
@@ -254,45 +254,45 @@ class ApiKeyControllerTest {
 
     @Test
     void listApiKeys_withStatusFilter_passesToRepository() throws Exception {
-        when(apiKeyRepository.list(eq("t1"), eq(ApiKeyStatus.REVOKED), any(), anyInt())).thenReturn(List.of());
+        when(apiKeyRepository.list(eq("tenant-1"), eq(ApiKeyStatus.REVOKED), any(), anyInt())).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/api-keys")
                         .header("X-Admin-API-Key", ADMIN_KEY)
-                        .param("tenant_id", "t1")
+                        .param("tenant_id", "tenant-1")
                         .param("status", "REVOKED"))
                 .andExpect(status().isOk());
 
-        verify(apiKeyRepository).list(eq("t1"), eq(ApiKeyStatus.REVOKED), any(), anyInt());
+        verify(apiKeyRepository).list(eq("tenant-1"), eq(ApiKeyStatus.REVOKED), any(), anyInt());
     }
 
     @Test
     void listApiKeys_withCursorParam_passesToRepository() throws Exception {
-        when(apiKeyRepository.list(eq("t1"), any(), eq("key_abc"), anyInt())).thenReturn(List.of());
+        when(apiKeyRepository.list(eq("tenant-1"), any(), eq("key_abc"), anyInt())).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/api-keys")
                         .header("X-Admin-API-Key", ADMIN_KEY)
-                        .param("tenant_id", "t1")
+                        .param("tenant_id", "tenant-1")
                         .param("cursor", "key_abc"))
                 .andExpect(status().isOk());
 
-        verify(apiKeyRepository).list(eq("t1"), any(), eq("key_abc"), anyInt());
+        verify(apiKeyRepository).list(eq("tenant-1"), any(), eq("key_abc"), anyInt());
     }
 
     @Test
     void listApiKeys_resultCountEqualsLimit_hasMoreTrueWithCursor() throws Exception {
         ApiKey k1 = ApiKey.builder()
-                .keyId("key_1").tenantId("t1").keyPrefix("gov_pre1")
+                .keyId("key_1").tenantId("tenant-1").keyPrefix("gov_pre1")
                 .status(ApiKeyStatus.ACTIVE).createdAt(Instant.now())
                 .expiresAt(Instant.now().plusSeconds(86400)).build();
         ApiKey k2 = ApiKey.builder()
-                .keyId("key_2").tenantId("t1").keyPrefix("gov_pre2")
+                .keyId("key_2").tenantId("tenant-1").keyPrefix("gov_pre2")
                 .status(ApiKeyStatus.ACTIVE).createdAt(Instant.now())
                 .expiresAt(Instant.now().plusSeconds(86400)).build();
-        when(apiKeyRepository.list(eq("t1"), any(), any(), eq(2))).thenReturn(List.of(k1, k2));
+        when(apiKeyRepository.list(eq("tenant-1"), any(), any(), eq(2))).thenReturn(List.of(k1, k2));
 
         mockMvc.perform(get("/v1/admin/api-keys")
                         .header("X-Admin-API-Key", ADMIN_KEY)
-                        .param("tenant_id", "t1")
+                        .param("tenant_id", "tenant-1")
                         .param("limit", "2"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.has_more").value(true))
@@ -302,7 +302,7 @@ class ApiKeyControllerTest {
     @Test
     void revokeApiKey_withoutReason_passesNullReason() throws Exception {
         ApiKey revoked = ApiKey.builder()
-                .keyId("key_1").tenantId("t1").keyPrefix("gov_pre")
+                .keyId("key_1").tenantId("tenant-1").keyPrefix("gov_pre")
                 .status(ApiKeyStatus.REVOKED).revokedAt(Instant.now())
                 .createdAt(Instant.now()).expiresAt(Instant.now().plusSeconds(86400)).build();
         when(apiKeyRepository.revoke("key_1", null)).thenReturn(revoked);
@@ -318,7 +318,7 @@ class ApiKeyControllerTest {
     @Test
     void updateApiKey_returns200() throws Exception {
         ApiKey updated = ApiKey.builder()
-                .keyId("key_1").tenantId("t1").keyPrefix("cyc_live_abc12")
+                .keyId("key_1").tenantId("tenant-1").keyPrefix("cyc_live_abc12")
                 .name("Updated Key").description("new desc")
                 .permissions(List.of("budgets:read", "budgets:write"))
                 .status(ApiKeyStatus.ACTIVE).createdAt(Instant.now())
@@ -371,7 +371,7 @@ class ApiKeyControllerTest {
     @Test
     void updateApiKey_logsAuditEntry() throws Exception {
         ApiKey updated = ApiKey.builder()
-                .keyId("key_1").tenantId("t1").keyPrefix("cyc_live_abc12")
+                .keyId("key_1").tenantId("tenant-1").keyPrefix("cyc_live_abc12")
                 .name("Updated").status(ApiKeyStatus.ACTIVE)
                 .createdAt(Instant.now()).expiresAt(Instant.now().plusSeconds(86400)).build();
         when(apiKeyRepository.update(eq("key_1"), any())).thenReturn(updated);
@@ -384,7 +384,7 @@ class ApiKeyControllerTest {
 
         verify(auditRepository).log(argThat(entry ->
                 "updateApiKey".equals(entry.getOperation()) &&
-                "t1".equals(entry.getTenantId()) &&
+                "tenant-1".equals(entry.getTenantId()) &&
                 "key_1".equals(entry.getKeyId()) &&
                 entry.getStatus() == 200));
     }
@@ -393,7 +393,7 @@ class ApiKeyControllerTest {
     void updateApiKey_permissionsChanged_emitsEvent() throws Exception {
         // Mock old key with different permissions
         ApiKey oldKey = ApiKey.builder()
-                .keyId("key_1").tenantId("t1").keyPrefix("cyc_live_abc12")
+                .keyId("key_1").tenantId("tenant-1").keyPrefix("cyc_live_abc12")
                 .permissions(List.of("balances:read"))
                 .status(ApiKeyStatus.ACTIVE).createdAt(Instant.now())
                 .expiresAt(Instant.now().plusSeconds(86400)).build();
@@ -402,7 +402,7 @@ class ApiKeyControllerTest {
         when(jedisMock.get("apikey:key_1")).thenReturn(objectMapper.writeValueAsString(oldKey));
 
         ApiKey updated = ApiKey.builder()
-                .keyId("key_1").tenantId("t1").keyPrefix("cyc_live_abc12")
+                .keyId("key_1").tenantId("tenant-1").keyPrefix("cyc_live_abc12")
                 .permissions(List.of("budgets:read", "budgets:write"))
                 .status(ApiKeyStatus.ACTIVE).createdAt(Instant.now())
                 .expiresAt(Instant.now().plusSeconds(86400)).build();
@@ -415,13 +415,13 @@ class ApiKeyControllerTest {
                 .andExpect(status().isOk());
 
         verify(eventService).emit(eq(io.runcycles.admin.model.event.EventType.API_KEY_PERMISSIONS_CHANGED),
-                eq("t1"), any(), any(), any(), any(), any(), any());
+                eq("tenant-1"), any(), any(), any(), any(), any(), any());
     }
 
     @Test
     void updateApiKey_nameOnlyChange_doesNotEmitPermissionsEvent() throws Exception {
         ApiKey updated = ApiKey.builder()
-                .keyId("key_1").tenantId("t1").keyPrefix("cyc_live_abc12")
+                .keyId("key_1").tenantId("tenant-1").keyPrefix("cyc_live_abc12")
                 .name("New Name").status(ApiKeyStatus.ACTIVE)
                 .createdAt(Instant.now()).expiresAt(Instant.now().plusSeconds(86400)).build();
         when(apiKeyRepository.update(eq("key_1"), any())).thenReturn(updated);

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/AuditControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/AuditControllerTest.java
@@ -34,7 +34,7 @@ class AuditControllerTest {
     @Test
     void listAuditLogs_returns200() throws Exception {
         AuditLogEntry entry = AuditLogEntry.builder()
-                .logId("log_1").tenantId("t1").operation("createTenant")
+                .logId("log_1").tenantId("tenant-1").operation("createTenant")
                 .status(201).timestamp(Instant.now()).build();
         when(auditRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), any(), anyInt()))
                 .thenReturn(List.of(entry));
@@ -48,12 +48,12 @@ class AuditControllerTest {
 
     @Test
     void listAuditLogs_withFilters() throws Exception {
-        when(auditRepository.list(eq("t1"), eq("key_1"), eq("createTenant"), eq(201), any(), any(), any(), any(), any(), anyInt()))
+        when(auditRepository.list(eq("tenant-1"), eq("key_1"), eq("createTenant"), eq(201), any(), any(), any(), any(), any(), anyInt()))
                 .thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/audit/logs")
                         .header("X-Admin-API-Key", ADMIN_KEY)
-                        .param("tenant_id", "t1")
+                        .param("tenant_id", "tenant-1")
                         .param("key_id", "key_1")
                         .param("operation", "createTenant")
                         .param("status", "201"))
@@ -119,10 +119,10 @@ class AuditControllerTest {
     @Test
     void listAuditLogs_resultCountEqualsLimit_hasMoreTrueWithCursor() throws Exception {
         AuditLogEntry e1 = AuditLogEntry.builder()
-                .logId("log_1").tenantId("t1").operation("createTenant")
+                .logId("log_1").tenantId("tenant-1").operation("createTenant")
                 .status(201).timestamp(Instant.now()).build();
         AuditLogEntry e2 = AuditLogEntry.builder()
-                .logId("log_2").tenantId("t1").operation("updateTenant")
+                .logId("log_2").tenantId("tenant-1").operation("updateTenant")
                 .status(200).timestamp(Instant.now()).build();
         when(auditRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), any(), eq(2)))
                 .thenReturn(List.of(e1, e2));

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/AuthControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/AuthControllerTest.java
@@ -34,7 +34,7 @@ class AuthControllerTest {
     void validate_validKey_returns200WithValid() throws Exception {
         when(apiKeyRepository.validate("gov_valid_key")).thenReturn(
                 ApiKeyValidationResponse.builder()
-                        .valid(true).tenantId("t1").keyId("key_1")
+                        .valid(true).tenantId("tenant-1").keyId("key_1")
                         .permissions(List.of("balances:read"))
                         .build());
 
@@ -44,7 +44,7 @@ class AuthControllerTest {
                         .content("{\"key_secret\":\"gov_valid_key\"}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.valid").value(true))
-                .andExpect(jsonPath("$.tenant_id").value("t1"))
+                .andExpect(jsonPath("$.tenant_id").value("tenant-1"))
                 .andExpect(jsonPath("$.key_id").value("key_1"));
     }
 
@@ -122,7 +122,7 @@ class AuthControllerTest {
     void validate_expiredKey_returns200WithReasonKeyExpired() throws Exception {
         when(apiKeyRepository.validate("expired_key")).thenReturn(
                 ApiKeyValidationResponse.builder()
-                        .valid(false).tenantId("t1").keyId("key_exp")
+                        .valid(false).tenantId("tenant-1").keyId("key_exp")
                         .reason("KEY_EXPIRED")
                         .build());
 
@@ -140,7 +140,7 @@ class AuthControllerTest {
     void validate_revokedKey_returns200WithReasonKeyRevoked() throws Exception {
         when(apiKeyRepository.validate("revoked_key")).thenReturn(
                 ApiKeyValidationResponse.builder()
-                        .valid(false).tenantId("t1").keyId("key_rev")
+                        .valid(false).tenantId("tenant-1").keyId("key_rev")
                         .reason("KEY_REVOKED")
                         .build());
 

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BalanceControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BalanceControllerTest.java
@@ -35,7 +35,7 @@ class BalanceControllerTest {
     private void setupApiKeyAuth() {
         when(apiKeyRepository.validate("valid-api-key")).thenReturn(
                 ApiKeyValidationResponse.builder()
-                        .valid(true).tenantId("t1").keyId("key_1")
+                        .valid(true).tenantId("tenant-1").keyId("key_1")
                         .permissions(List.of("balances:read")).build());
     }
 
@@ -47,7 +47,7 @@ class BalanceControllerTest {
                 .allocated(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .remaining(new Amount(UnitEnum.USD_MICROCENTS, 800L))
                 .status(BudgetStatus.ACTIVE).createdAt(Instant.now()).build();
-        when(budgetRepository.list(eq("t1"), any(), any(), eq(BudgetStatus.ACTIVE), isNull(), eq(50)))
+        when(budgetRepository.list(eq("tenant-1"), any(), any(), eq(BudgetStatus.ACTIVE), isNull(), eq(50)))
                 .thenReturn(List.of(ledger));
 
         mockMvc.perform(get("/v1/balances")
@@ -60,7 +60,7 @@ class BalanceControllerTest {
     @Test
     void queryBalances_emptyResult_returnsEmptyList() throws Exception {
         setupApiKeyAuth();
-        when(budgetRepository.list(eq("t1"), any(), any(), eq(BudgetStatus.ACTIVE), isNull(), eq(50)))
+        when(budgetRepository.list(eq("tenant-1"), any(), any(), eq(BudgetStatus.ACTIVE), isNull(), eq(50)))
                 .thenReturn(List.of());
 
         mockMvc.perform(get("/v1/balances")
@@ -79,7 +79,7 @@ class BalanceControllerTest {
     @Test
     void queryBalances_usesScopePrefixFilter() throws Exception {
         setupApiKeyAuth();
-        when(budgetRepository.list(eq("t1"), eq("org/"), any(), eq(BudgetStatus.ACTIVE), isNull(), eq(50)))
+        when(budgetRepository.list(eq("tenant-1"), eq("org/"), any(), eq(BudgetStatus.ACTIVE), isNull(), eq(50)))
                 .thenReturn(List.of());
 
         mockMvc.perform(get("/v1/balances")
@@ -87,13 +87,13 @@ class BalanceControllerTest {
                         .param("scope_prefix", "org/"))
                 .andExpect(status().isOk());
 
-        verify(budgetRepository).list(eq("t1"), eq("org/"), any(), eq(BudgetStatus.ACTIVE), isNull(), eq(50));
+        verify(budgetRepository).list(eq("tenant-1"), eq("org/"), any(), eq(BudgetStatus.ACTIVE), isNull(), eq(50));
     }
 
     @Test
     void queryBalances_usesAuthenticatedTenantId_ignoresUserSupplied() throws Exception {
         setupApiKeyAuth();
-        when(budgetRepository.list(eq("t1"), any(), any(), eq(BudgetStatus.ACTIVE), isNull(), eq(50)))
+        when(budgetRepository.list(eq("tenant-1"), any(), any(), eq(BudgetStatus.ACTIVE), isNull(), eq(50)))
                 .thenReturn(List.of());
 
         mockMvc.perform(get("/v1/balances")
@@ -101,13 +101,13 @@ class BalanceControllerTest {
                         .param("tenant_id", "attacker-tenant"))
                 .andExpect(status().isOk());
 
-        verify(budgetRepository).list(eq("t1"), any(), any(), eq(BudgetStatus.ACTIVE), isNull(), eq(50));
+        verify(budgetRepository).list(eq("tenant-1"), any(), any(), eq(BudgetStatus.ACTIVE), isNull(), eq(50));
     }
 
     @Test
     void queryBalances_emptyResult_nextCursorIsNull() throws Exception {
         setupApiKeyAuth();
-        when(budgetRepository.list(eq("t1"), any(), any(), eq(BudgetStatus.ACTIVE), isNull(), eq(50)))
+        when(budgetRepository.list(eq("tenant-1"), any(), any(), eq(BudgetStatus.ACTIVE), isNull(), eq(50)))
                 .thenReturn(List.of());
 
         mockMvc.perform(get("/v1/balances")
@@ -120,7 +120,7 @@ class BalanceControllerTest {
     @Test
     void queryBalances_withUnitFilter_passesUnitToRepository() throws Exception {
         setupApiKeyAuth();
-        when(budgetRepository.list(eq("t1"), any(), eq(UnitEnum.TOKENS), eq(BudgetStatus.ACTIVE), isNull(), eq(50)))
+        when(budgetRepository.list(eq("tenant-1"), any(), eq(UnitEnum.TOKENS), eq(BudgetStatus.ACTIVE), isNull(), eq(50)))
                 .thenReturn(List.of());
 
         mockMvc.perform(get("/v1/balances")
@@ -128,13 +128,13 @@ class BalanceControllerTest {
                         .param("unit", "TOKENS"))
                 .andExpect(status().isOk());
 
-        verify(budgetRepository).list(eq("t1"), any(), eq(UnitEnum.TOKENS), eq(BudgetStatus.ACTIVE), isNull(), eq(50));
+        verify(budgetRepository).list(eq("tenant-1"), any(), eq(UnitEnum.TOKENS), eq(BudgetStatus.ACTIVE), isNull(), eq(50));
     }
 
     @Test
     void queryBalances_withCursorParam_passesToRepository() throws Exception {
         setupApiKeyAuth();
-        when(budgetRepository.list(eq("t1"), any(), any(), eq(BudgetStatus.ACTIVE), eq("led-abc"), eq(50)))
+        when(budgetRepository.list(eq("tenant-1"), any(), any(), eq(BudgetStatus.ACTIVE), eq("led-abc"), eq(50)))
                 .thenReturn(List.of());
 
         mockMvc.perform(get("/v1/balances")
@@ -142,13 +142,13 @@ class BalanceControllerTest {
                         .param("cursor", "led-abc"))
                 .andExpect(status().isOk());
 
-        verify(budgetRepository).list(eq("t1"), any(), any(), eq(BudgetStatus.ACTIVE), eq("led-abc"), eq(50));
+        verify(budgetRepository).list(eq("tenant-1"), any(), any(), eq(BudgetStatus.ACTIVE), eq("led-abc"), eq(50));
     }
 
     @Test
     void queryBalances_withCustomLimit_passesToRepository() throws Exception {
         setupApiKeyAuth();
-        when(budgetRepository.list(eq("t1"), any(), any(), eq(BudgetStatus.ACTIVE), isNull(), eq(10)))
+        when(budgetRepository.list(eq("tenant-1"), any(), any(), eq(BudgetStatus.ACTIVE), isNull(), eq(10)))
                 .thenReturn(List.of());
 
         mockMvc.perform(get("/v1/balances")
@@ -156,7 +156,7 @@ class BalanceControllerTest {
                         .param("limit", "10"))
                 .andExpect(status().isOk());
 
-        verify(budgetRepository).list(eq("t1"), any(), any(), eq(BudgetStatus.ACTIVE), isNull(), eq(10));
+        verify(budgetRepository).list(eq("tenant-1"), any(), any(), eq(BudgetStatus.ACTIVE), isNull(), eq(10));
     }
 
     @Test
@@ -168,7 +168,7 @@ class BalanceControllerTest {
                 .allocated(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .remaining(new Amount(UnitEnum.USD_MICROCENTS, 800L))
                 .status(BudgetStatus.ACTIVE).createdAt(Instant.now()).build();
-        when(budgetRepository.list(eq("t1"), any(), any(), eq(BudgetStatus.ACTIVE), isNull(), eq(1)))
+        when(budgetRepository.list(eq("tenant-1"), any(), any(), eq(BudgetStatus.ACTIVE), isNull(), eq(1)))
                 .thenReturn(List.of(ledger));
 
         mockMvc.perform(get("/v1/balances")

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BudgetControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BudgetControllerTest.java
@@ -44,7 +44,7 @@ class BudgetControllerTest {
     private void setupApiKeyAuth() {
         when(apiKeyRepository.validate("valid-api-key")).thenReturn(
                 ApiKeyValidationResponse.builder()
-                        .valid(true).tenantId("t1").keyId("key_1")
+                        .valid(true).tenantId("tenant-1").keyId("key_1")
                         .permissions(List.of("budgets:read", "budgets:write", "balances:read")).build());
     }
 
@@ -56,7 +56,7 @@ class BudgetControllerTest {
                 .allocated(new Amount(UnitEnum.USD_MICROCENTS, 1000000L))
                 .remaining(new Amount(UnitEnum.USD_MICROCENTS, 1000000L))
                 .status(BudgetStatus.ACTIVE).createdAt(Instant.now()).build();
-        when(budgetRepository.create(eq("t1"), any())).thenReturn(ledger);
+        when(budgetRepository.create(eq("tenant-1"), any())).thenReturn(ledger);
 
         mockMvc.perform(post("/v1/admin/budgets")
                         .header("X-Cycles-API-Key", "valid-api-key")
@@ -70,7 +70,7 @@ class BudgetControllerTest {
     @Test
     void createBudget_duplicate_returns409() throws Exception {
         setupApiKeyAuth();
-        when(budgetRepository.create(eq("t1"), any()))
+        when(budgetRepository.create(eq("tenant-1"), any()))
                 .thenThrow(GovernanceException.duplicateResource("Budget", "org/team1"));
 
         mockMvc.perform(post("/v1/admin/budgets")
@@ -97,7 +97,7 @@ class BudgetControllerTest {
                 .allocated(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .remaining(new Amount(UnitEnum.USD_MICROCENTS, 800L))
                 .status(BudgetStatus.ACTIVE).createdAt(Instant.now()).build();
-        when(budgetRepository.list(eq("t1"), any(), any(), any(), any(), anyInt())).thenReturn(List.of(ledger));
+        when(budgetRepository.list(eq("tenant-1"), any(), any(), any(), any(), anyInt())).thenReturn(List.of(ledger));
 
         mockMvc.perform(get("/v1/admin/budgets")
                         .header("X-Cycles-API-Key", "valid-api-key"))
@@ -110,7 +110,7 @@ class BudgetControllerTest {
     void createBudget_scopeFilterDenied_returns403() throws Exception {
         when(apiKeyRepository.validate("restricted-key")).thenReturn(
                 ApiKeyValidationResponse.builder()
-                        .valid(true).tenantId("t1").keyId("key_1")
+                        .valid(true).tenantId("tenant-1").keyId("key_1")
                         .permissions(List.of("budgets:read", "budgets:write", "balances:read"))
                         .scopeFilter(List.of("workspace:eng"))
                         .build());
@@ -127,7 +127,7 @@ class BudgetControllerTest {
     void createBudget_scopeFilterAllowed_returns201() throws Exception {
         when(apiKeyRepository.validate("restricted-key")).thenReturn(
                 ApiKeyValidationResponse.builder()
-                        .valid(true).tenantId("t1").keyId("key_1")
+                        .valid(true).tenantId("tenant-1").keyId("key_1")
                         .permissions(List.of("budgets:read", "budgets:write", "balances:read"))
                         .scopeFilter(List.of("workspace:eng"))
                         .build());
@@ -136,7 +136,7 @@ class BudgetControllerTest {
                 .allocated(new Amount(UnitEnum.USD_MICROCENTS, 1000000L))
                 .remaining(new Amount(UnitEnum.USD_MICROCENTS, 1000000L))
                 .status(BudgetStatus.ACTIVE).createdAt(Instant.now()).build();
-        when(budgetRepository.create(eq("t1"), any())).thenReturn(ledger);
+        when(budgetRepository.create(eq("tenant-1"), any())).thenReturn(ledger);
 
         mockMvc.perform(post("/v1/admin/budgets")
                         .header("X-Cycles-API-Key", "restricted-key")
@@ -157,7 +157,7 @@ class BudgetControllerTest {
                 .previousRemaining(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .newRemaining(new Amount(UnitEnum.USD_MICROCENTS, 2000L))
                 .timestamp(Instant.now()).build();
-        when(budgetRepository.fund(eq("t1"), eq("org_team1"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
+        when(budgetRepository.fund(eq("tenant-1"), eq("org_team1"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
 
         mockMvc.perform(post("/v1/admin/budgets/fund")
                         .param("scope", "org_team1")
@@ -173,7 +173,7 @@ class BudgetControllerTest {
     @Test
     void fundBudget_frozen_returns409() throws Exception {
         setupApiKeyAuth();
-        when(budgetRepository.fund(eq("t1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any()))
+        when(budgetRepository.fund(eq("tenant-1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any()))
                 .thenThrow(GovernanceException.budgetFrozen("scope"));
 
         mockMvc.perform(post("/v1/admin/budgets/fund")
@@ -189,7 +189,7 @@ class BudgetControllerTest {
     @Test
     void fundBudget_insufficientFunds_returns409() throws Exception {
         setupApiKeyAuth();
-        when(budgetRepository.fund(eq("t1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any()))
+        when(budgetRepository.fund(eq("tenant-1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any()))
                 .thenThrow(GovernanceException.insufficientFunds("scope"));
 
         mockMvc.perform(post("/v1/admin/budgets/fund")
@@ -210,7 +210,7 @@ class BudgetControllerTest {
                 .allocated(new Amount(UnitEnum.USD_MICROCENTS, 1000000L))
                 .remaining(new Amount(UnitEnum.USD_MICROCENTS, 1000000L))
                 .status(BudgetStatus.ACTIVE).createdAt(Instant.now()).build();
-        when(budgetRepository.create(eq("t1"), any())).thenReturn(ledger);
+        when(budgetRepository.create(eq("tenant-1"), any())).thenReturn(ledger);
 
         mockMvc.perform(post("/v1/admin/budgets")
                         .header("X-Cycles-API-Key", "valid-api-key")
@@ -220,7 +220,7 @@ class BudgetControllerTest {
 
         verify(auditRepository).log(argThat(entry ->
                 "createBudget".equals(entry.getOperation()) &&
-                "t1".equals(entry.getTenantId()) &&
+                "tenant-1".equals(entry.getTenantId()) &&
                 entry.getStatus() == 201));
     }
 
@@ -234,7 +234,7 @@ class BudgetControllerTest {
                 .previousRemaining(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .newRemaining(new Amount(UnitEnum.USD_MICROCENTS, 2000L))
                 .timestamp(Instant.now()).build();
-        when(budgetRepository.fund(eq("t1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
+        when(budgetRepository.fund(eq("tenant-1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
 
         mockMvc.perform(post("/v1/admin/budgets/fund")
                         .param("scope", "scope")
@@ -252,20 +252,20 @@ class BudgetControllerTest {
     @Test
     void listBudgets_usesAuthenticatedTenantId_ignoresUserSupplied() throws Exception {
         setupApiKeyAuth();
-        when(budgetRepository.list(eq("t1"), any(), any(), any(), any(), anyInt())).thenReturn(List.of());
+        when(budgetRepository.list(eq("tenant-1"), any(), any(), any(), any(), anyInt())).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/budgets")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .param("tenant_id", "attacker-tenant"))
                 .andExpect(status().isOk());
 
-        verify(budgetRepository).list(eq("t1"), any(), any(), any(), any(), anyInt());
+        verify(budgetRepository).list(eq("tenant-1"), any(), any(), any(), any(), anyInt());
     }
 
     @Test
     void listBudgets_emptyResult_hasMoreFalseAndNoCursor() throws Exception {
         setupApiKeyAuth();
-        when(budgetRepository.list(eq("t1"), any(), any(), any(), any(), anyInt())).thenReturn(List.of());
+        when(budgetRepository.list(eq("tenant-1"), any(), any(), any(), any(), anyInt())).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/budgets")
                         .header("X-Cycles-API-Key", "valid-api-key"))
@@ -278,33 +278,33 @@ class BudgetControllerTest {
     @Test
     void listBudgets_limitClampedToMax100() throws Exception {
         setupApiKeyAuth();
-        when(budgetRepository.list(eq("t1"), any(), any(), any(), any(), eq(100))).thenReturn(List.of());
+        when(budgetRepository.list(eq("tenant-1"), any(), any(), any(), any(), eq(100))).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/budgets")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .param("limit", "999"))
                 .andExpect(status().isOk());
 
-        verify(budgetRepository).list(eq("t1"), any(), any(), any(), any(), eq(100));
+        verify(budgetRepository).list(eq("tenant-1"), any(), any(), any(), any(), eq(100));
     }
 
     @Test
     void listBudgets_limitClampedToMin1() throws Exception {
         setupApiKeyAuth();
-        when(budgetRepository.list(eq("t1"), any(), any(), any(), any(), eq(1))).thenReturn(List.of());
+        when(budgetRepository.list(eq("tenant-1"), any(), any(), any(), any(), eq(1))).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/budgets")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .param("limit", "0"))
                 .andExpect(status().isOk());
 
-        verify(budgetRepository).list(eq("t1"), any(), any(), any(), any(), eq(1));
+        verify(budgetRepository).list(eq("tenant-1"), any(), any(), any(), any(), eq(1));
     }
 
     @Test
     void fundBudget_notFound_returns404() throws Exception {
         setupApiKeyAuth();
-        when(budgetRepository.fund(eq("t1"), eq("missing"), eq(UnitEnum.USD_MICROCENTS), any()))
+        when(budgetRepository.fund(eq("tenant-1"), eq("missing"), eq(UnitEnum.USD_MICROCENTS), any()))
                 .thenThrow(GovernanceException.budgetNotFound("missing"));
 
         mockMvc.perform(post("/v1/admin/budgets/fund")
@@ -320,27 +320,27 @@ class BudgetControllerTest {
     @Test
     void listBudgets_withCursorParam_passesToRepository() throws Exception {
         setupApiKeyAuth();
-        when(budgetRepository.list(eq("t1"), any(), any(), any(), eq("led-abc"), anyInt())).thenReturn(List.of());
+        when(budgetRepository.list(eq("tenant-1"), any(), any(), any(), eq("led-abc"), anyInt())).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/budgets")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .param("cursor", "led-abc"))
                 .andExpect(status().isOk());
 
-        verify(budgetRepository).list(eq("t1"), any(), any(), any(), eq("led-abc"), anyInt());
+        verify(budgetRepository).list(eq("tenant-1"), any(), any(), any(), eq("led-abc"), anyInt());
     }
 
     @Test
     void listBudgets_withStatusFilter_passesToRepository() throws Exception {
         setupApiKeyAuth();
-        when(budgetRepository.list(eq("t1"), any(), any(), eq(BudgetStatus.FROZEN), any(), anyInt())).thenReturn(List.of());
+        when(budgetRepository.list(eq("tenant-1"), any(), any(), eq(BudgetStatus.FROZEN), any(), anyInt())).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/budgets")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .param("status", "FROZEN"))
                 .andExpect(status().isOk());
 
-        verify(budgetRepository).list(eq("t1"), any(), any(), eq(BudgetStatus.FROZEN), any(), anyInt());
+        verify(budgetRepository).list(eq("tenant-1"), any(), any(), eq(BudgetStatus.FROZEN), any(), anyInt());
     }
 
     @Test
@@ -351,7 +351,7 @@ class BudgetControllerTest {
                 .allocated(new Amount(UnitEnum.USD_MICROCENTS, 1000000L))
                 .remaining(new Amount(UnitEnum.USD_MICROCENTS, 1000000L))
                 .status(BudgetStatus.ACTIVE).createdAt(Instant.now()).build();
-        when(budgetRepository.create(eq("t1"), any())).thenReturn(ledger);
+        when(budgetRepository.create(eq("tenant-1"), any())).thenReturn(ledger);
 
         mockMvc.perform(post("/v1/admin/budgets")
                         .header("X-Cycles-API-Key", "valid-api-key")
@@ -375,7 +375,7 @@ class BudgetControllerTest {
                 .previousRemaining(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .newRemaining(new Amount(UnitEnum.USD_MICROCENTS, 2000L))
                 .timestamp(Instant.now()).build();
-        when(budgetRepository.fund(eq("t1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
+        when(budgetRepository.fund(eq("tenant-1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
 
         mockMvc.perform(post("/v1/admin/budgets/fund")
                         .param("scope", "scope")
@@ -387,7 +387,7 @@ class BudgetControllerTest {
 
         verify(auditRepository).log(argThat(entry ->
                 "fundBudget".equals(entry.getOperation()) &&
-                "t1".equals(entry.getTenantId()) &&
+                "tenant-1".equals(entry.getTenantId()) &&
                 "key_1".equals(entry.getKeyId())));
     }
 
@@ -401,7 +401,7 @@ class BudgetControllerTest {
                 .previousRemaining(new Amount(UnitEnum.USD_MICROCENTS, 2000L))
                 .newRemaining(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .timestamp(Instant.now()).build();
-        when(budgetRepository.fund(eq("t1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
+        when(budgetRepository.fund(eq("tenant-1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
 
         mockMvc.perform(post("/v1/admin/budgets/fund")
                         .param("scope", "scope")
@@ -423,7 +423,7 @@ class BudgetControllerTest {
                 .previousRemaining(new Amount(UnitEnum.USD_MICROCENTS, 1500L))
                 .newRemaining(new Amount(UnitEnum.USD_MICROCENTS, 5000L))
                 .timestamp(Instant.now()).build();
-        when(budgetRepository.fund(eq("t1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
+        when(budgetRepository.fund(eq("tenant-1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
 
         mockMvc.perform(post("/v1/admin/budgets/fund")
                         .param("scope", "scope")
@@ -445,7 +445,7 @@ class BudgetControllerTest {
                 .previousRemaining(new Amount(UnitEnum.USD_MICROCENTS, -200L))
                 .newRemaining(new Amount(UnitEnum.USD_MICROCENTS, 300L))
                 .timestamp(Instant.now()).build();
-        when(budgetRepository.fund(eq("t1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
+        when(budgetRepository.fund(eq("tenant-1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
 
         mockMvc.perform(post("/v1/admin/budgets/fund")
                         .param("scope", "scope")
@@ -460,27 +460,27 @@ class BudgetControllerTest {
     @Test
     void listBudgets_withScopePrefixFilter_passesToRepository() throws Exception {
         setupApiKeyAuth();
-        when(budgetRepository.list(eq("t1"), eq("org/"), any(), any(), any(), anyInt())).thenReturn(List.of());
+        when(budgetRepository.list(eq("tenant-1"), eq("org/"), any(), any(), any(), anyInt())).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/budgets")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .param("scope_prefix", "org/"))
                 .andExpect(status().isOk());
 
-        verify(budgetRepository).list(eq("t1"), eq("org/"), any(), any(), any(), anyInt());
+        verify(budgetRepository).list(eq("tenant-1"), eq("org/"), any(), any(), any(), anyInt());
     }
 
     @Test
     void listBudgets_withUnitFilter_passesToRepository() throws Exception {
         setupApiKeyAuth();
-        when(budgetRepository.list(eq("t1"), any(), eq(UnitEnum.TOKENS), any(), any(), anyInt())).thenReturn(List.of());
+        when(budgetRepository.list(eq("tenant-1"), any(), eq(UnitEnum.TOKENS), any(), any(), anyInt())).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/budgets")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .param("unit", "TOKENS"))
                 .andExpect(status().isOk());
 
-        verify(budgetRepository).list(eq("t1"), any(), eq(UnitEnum.TOKENS), any(), any(), anyInt());
+        verify(budgetRepository).list(eq("tenant-1"), any(), eq(UnitEnum.TOKENS), any(), any(), anyInt());
     }
 
     @Test
@@ -496,7 +496,7 @@ class BudgetControllerTest {
                 .allocated(new Amount(UnitEnum.USD_MICROCENTS, 2000L))
                 .remaining(new Amount(UnitEnum.USD_MICROCENTS, 1500L))
                 .status(BudgetStatus.ACTIVE).createdAt(Instant.now()).build();
-        when(budgetRepository.list(eq("t1"), any(), any(), any(), any(), eq(2))).thenReturn(List.of(l1, l2));
+        when(budgetRepository.list(eq("tenant-1"), any(), any(), any(), any(), eq(2))).thenReturn(List.of(l1, l2));
 
         mockMvc.perform(get("/v1/admin/budgets")
                         .header("X-Cycles-API-Key", "valid-api-key")
@@ -509,7 +509,7 @@ class BudgetControllerTest {
     @Test
     void fundBudget_budgetClosed_returns409() throws Exception {
         setupApiKeyAuth();
-        when(budgetRepository.fund(eq("t1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any()))
+        when(budgetRepository.fund(eq("tenant-1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any()))
                 .thenThrow(GovernanceException.budgetClosed("scope"));
 
         mockMvc.perform(post("/v1/admin/budgets/fund")
@@ -532,7 +532,7 @@ class BudgetControllerTest {
                 .previousRemaining(new Amount(UnitEnum.USD_MICROCENTS, 0L))
                 .newRemaining(new Amount(UnitEnum.USD_MICROCENTS, 500000L))
                 .timestamp(Instant.now()).build();
-        when(budgetRepository.fund(eq("t1"), eq("tenant:acme/workspace:prod"), eq(UnitEnum.USD_MICROCENTS), any()))
+        when(budgetRepository.fund(eq("tenant-1"), eq("tenant:acme/workspace:prod"), eq(UnitEnum.USD_MICROCENTS), any()))
                 .thenReturn(funding);
 
         mockMvc.perform(post("/v1/admin/budgets/fund")
@@ -545,7 +545,7 @@ class BudgetControllerTest {
                 .andExpect(jsonPath("$.operation").value("CREDIT"))
                 .andExpect(jsonPath("$.new_allocated.amount").value(500000));
 
-        verify(budgetRepository).fund(eq("t1"), eq("tenant:acme/workspace:prod"), eq(UnitEnum.USD_MICROCENTS), any());
+        verify(budgetRepository).fund(eq("tenant-1"), eq("tenant:acme/workspace:prod"), eq(UnitEnum.USD_MICROCENTS), any());
     }
 
     // ========== PATCH /v1/admin/budgets ==========
@@ -607,7 +607,7 @@ class BudgetControllerTest {
                 .ledgerId("led-1").scope("scope").unit(UnitEnum.USD_MICROCENTS)
                 .allocated(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .remaining(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
-                .tenantId("t1")
+                .tenantId("tenant-1")
                 .status(BudgetStatus.ACTIVE).createdAt(Instant.now()).build();
         when(budgetRepository.update(isNull(), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(ledger);
 
@@ -621,7 +621,7 @@ class BudgetControllerTest {
 
         verify(auditRepository).log(argThat(entry ->
                 "updateBudget".equals(entry.getOperation()) &&
-                "t1".equals(entry.getTenantId()) &&
+                "tenant-1".equals(entry.getTenantId()) &&
                 entry.getStatus() == 200));
     }
 
@@ -708,7 +708,7 @@ class BudgetControllerTest {
                 .allocated(new Amount(UnitEnum.USD_MICROCENTS, 1000000L))
                 .remaining(new Amount(UnitEnum.USD_MICROCENTS, 1000000L))
                 .status(BudgetStatus.ACTIVE).createdAt(Instant.now()).build();
-        when(budgetRepository.create(eq("t1"), any())).thenReturn(ledger);
+        when(budgetRepository.create(eq("tenant-1"), any())).thenReturn(ledger);
 
         mockMvc.perform(post("/v1/admin/budgets")
                         .header("X-Cycles-API-Key", "valid-api-key")
@@ -716,7 +716,7 @@ class BudgetControllerTest {
                         .content("{\"scope\":\"org/team1\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"USD_MICROCENTS\",\"amount\":1000000}}"))
                 .andExpect(status().isCreated());
 
-        verify(eventService).emit(eq(EventType.BUDGET_CREATED), eq("t1"), eq("org/team1"), any(), any(), any(), any(), any());
+        verify(eventService).emit(eq(EventType.BUDGET_CREATED), eq("tenant-1"), eq("org/team1"), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -749,7 +749,7 @@ class BudgetControllerTest {
                 .previousRemaining(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .newRemaining(new Amount(UnitEnum.USD_MICROCENTS, 2000L))
                 .timestamp(Instant.now()).build();
-        when(budgetRepository.fund(eq("t1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
+        when(budgetRepository.fund(eq("tenant-1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
 
         mockMvc.perform(post("/v1/admin/budgets/fund")
                         .param("scope", "scope")
@@ -759,7 +759,7 @@ class BudgetControllerTest {
                         .content("{\"operation\":\"CREDIT\",\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":1000}}"))
                 .andExpect(status().isOk());
 
-        verify(eventService).emit(eq(EventType.BUDGET_FUNDED), eq("t1"), eq("scope"), any(), any(), any(), any(), any());
+        verify(eventService).emit(eq(EventType.BUDGET_FUNDED), eq("tenant-1"), eq("scope"), any(), any(), any(), any(), any());
     }
 
     // ========== INSUFFICIENT_PERMISSIONS ==========
@@ -769,7 +769,7 @@ class BudgetControllerTest {
         // API key with only balances:read — lacks admin:write required for POST /v1/admin/budgets
         when(apiKeyRepository.validate("readonly-key")).thenReturn(
                 ApiKeyValidationResponse.builder()
-                        .valid(true).tenantId("t1").keyId("key_ro")
+                        .valid(true).tenantId("tenant-1").keyId("key_ro")
                         .permissions(List.of("balances:read")).build());
 
         mockMvc.perform(post("/v1/admin/budgets")
@@ -785,7 +785,7 @@ class BudgetControllerTest {
         // API key with only budgets:read — lacks budgets:write required for POST /v1/admin/budgets/fund
         when(apiKeyRepository.validate("read-only-key")).thenReturn(
                 ApiKeyValidationResponse.builder()
-                        .valid(true).tenantId("t1").keyId("key_ro")
+                        .valid(true).tenantId("tenant-1").keyId("key_ro")
                         .permissions(List.of("budgets:read")).build());
 
         mockMvc.perform(post("/v1/admin/budgets/fund")
@@ -803,7 +803,7 @@ class BudgetControllerTest {
         // API key with only balances:read — lacks admin:read required for GET /v1/admin/budgets
         when(apiKeyRepository.validate("balance-only-key")).thenReturn(
                 ApiKeyValidationResponse.builder()
-                        .valid(true).tenantId("t1").keyId("key_bo")
+                        .valid(true).tenantId("tenant-1").keyId("key_bo")
                         .permissions(List.of("balances:read")).build());
 
         mockMvc.perform(get("/v1/admin/budgets")
@@ -817,7 +817,7 @@ class BudgetControllerTest {
     @Test
     void fundBudget_idempotencyMismatch_returns409() throws Exception {
         setupApiKeyAuth();
-        when(budgetRepository.fund(eq("t1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any()))
+        when(budgetRepository.fund(eq("tenant-1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any()))
                 .thenThrow(new GovernanceException(
                         io.runcycles.admin.model.shared.ErrorCode.IDEMPOTENCY_MISMATCH,
                         "Idempotency key already used with different payload", 409));
@@ -838,7 +838,7 @@ class BudgetControllerTest {
     void listBudgets_apiKeyHashNeverInResponse() throws Exception {
         // Verify the ApiKey internal model is never directly serialized — controllers use ApiKeyResponse DTO
         setupApiKeyAuth();
-        when(budgetRepository.list(eq("t1"), any(), any(), any(), any(), anyInt())).thenReturn(List.of());
+        when(budgetRepository.list(eq("tenant-1"), any(), any(), any(), any(), anyInt())).thenReturn(List.of());
 
         String responseBody = mockMvc.perform(get("/v1/admin/budgets")
                         .header("X-Cycles-API-Key", "valid-api-key"))
@@ -856,7 +856,7 @@ class BudgetControllerTest {
                 .ledgerId("led-1").scope("org/team1").unit(UnitEnum.USD_MICROCENTS)
                 .allocated(new Amount(UnitEnum.USD_MICROCENTS, 1000000L))
                 .remaining(new Amount(UnitEnum.USD_MICROCENTS, 500000L))
-                .tenantId("t1")
+                .tenantId("tenant-1")
                 .status(BudgetStatus.FROZEN).createdAt(Instant.now()).build();
         when(budgetRepository.freeze("org/team1", UnitEnum.USD_MICROCENTS)).thenReturn(ledger);
 
@@ -875,7 +875,7 @@ class BudgetControllerTest {
                 .ledgerId("led-1").scope("scope").unit(UnitEnum.USD_MICROCENTS)
                 .allocated(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .remaining(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
-                .tenantId("t1")
+                .tenantId("tenant-1")
                 .status(BudgetStatus.FROZEN).createdAt(Instant.now()).build();
         when(budgetRepository.freeze("scope", UnitEnum.USD_MICROCENTS)).thenReturn(ledger);
 
@@ -944,7 +944,7 @@ class BudgetControllerTest {
                 .ledgerId("led-1").scope("scope").unit(UnitEnum.USD_MICROCENTS)
                 .allocated(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .remaining(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
-                .tenantId("t1")
+                .tenantId("tenant-1")
                 .status(BudgetStatus.FROZEN).createdAt(Instant.now()).build();
         when(budgetRepository.freeze("scope", UnitEnum.USD_MICROCENTS)).thenReturn(ledger);
 
@@ -956,7 +956,7 @@ class BudgetControllerTest {
 
         verify(auditRepository).log(argThat(entry ->
                 "freezeBudget".equals(entry.getOperation()) &&
-                "t1".equals(entry.getTenantId()) &&
+                "tenant-1".equals(entry.getTenantId()) &&
                 entry.getStatus() == 200));
     }
 
@@ -966,7 +966,7 @@ class BudgetControllerTest {
                 .ledgerId("led-1").scope("scope").unit(UnitEnum.USD_MICROCENTS)
                 .allocated(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .remaining(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
-                .tenantId("t1")
+                .tenantId("tenant-1")
                 .status(BudgetStatus.FROZEN).createdAt(Instant.now()).build();
         when(budgetRepository.freeze("scope", UnitEnum.USD_MICROCENTS)).thenReturn(ledger);
 
@@ -976,7 +976,7 @@ class BudgetControllerTest {
                         .header("X-Admin-API-Key", "test-admin-key"))
                 .andExpect(status().isOk());
 
-        verify(eventService).emit(eq(EventType.BUDGET_FROZEN), eq("t1"), eq("scope"), any(), any(), any(), any(), any());
+        verify(eventService).emit(eq(EventType.BUDGET_FROZEN), eq("tenant-1"), eq("scope"), any(), any(), any(), any(), any());
     }
 
     // ========== POST /v1/admin/budgets/unfreeze ==========
@@ -987,7 +987,7 @@ class BudgetControllerTest {
                 .ledgerId("led-1").scope("org/team1").unit(UnitEnum.USD_MICROCENTS)
                 .allocated(new Amount(UnitEnum.USD_MICROCENTS, 1000000L))
                 .remaining(new Amount(UnitEnum.USD_MICROCENTS, 500000L))
-                .tenantId("t1")
+                .tenantId("tenant-1")
                 .status(BudgetStatus.ACTIVE).createdAt(Instant.now()).build();
         when(budgetRepository.unfreeze("org/team1", UnitEnum.USD_MICROCENTS)).thenReturn(ledger);
 
@@ -1032,7 +1032,7 @@ class BudgetControllerTest {
                 .ledgerId("led-1").scope("scope").unit(UnitEnum.USD_MICROCENTS)
                 .allocated(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .remaining(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
-                .tenantId("t1")
+                .tenantId("tenant-1")
                 .status(BudgetStatus.ACTIVE).createdAt(Instant.now()).build();
         when(budgetRepository.unfreeze("scope", UnitEnum.USD_MICROCENTS)).thenReturn(ledger);
 
@@ -1042,7 +1042,7 @@ class BudgetControllerTest {
                         .header("X-Admin-API-Key", "test-admin-key"))
                 .andExpect(status().isOk());
 
-        verify(eventService).emit(eq(EventType.BUDGET_UNFROZEN), eq("t1"), eq("scope"), any(), any(), any(), any(), any());
+        verify(eventService).emit(eq(EventType.BUDGET_UNFROZEN), eq("tenant-1"), eq("scope"), any(), any(), any(), any(), any());
     }
 
     // ========== POST /v1/admin/budgets/fund with AdminKeyAuth ==========
@@ -1056,10 +1056,10 @@ class BudgetControllerTest {
                 .previousRemaining(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .newRemaining(new Amount(UnitEnum.USD_MICROCENTS, 2000L))
                 .timestamp(Instant.now()).build();
-        when(budgetRepository.fund(eq("t1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
+        when(budgetRepository.fund(eq("tenant-1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
 
         mockMvc.perform(post("/v1/admin/budgets/fund")
-                        .param("tenant_id", "t1")
+                        .param("tenant_id", "tenant-1")
                         .param("scope", "scope")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Admin-API-Key", "test-admin-key")
@@ -1090,10 +1090,10 @@ class BudgetControllerTest {
                 .previousRemaining(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .newRemaining(new Amount(UnitEnum.USD_MICROCENTS, 2000L))
                 .timestamp(Instant.now()).build();
-        when(budgetRepository.fund(eq("t1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
+        when(budgetRepository.fund(eq("tenant-1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
 
         mockMvc.perform(post("/v1/admin/budgets/fund")
-                        .param("tenant_id", "t1")
+                        .param("tenant_id", "tenant-1")
                         .param("scope", "scope")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Admin-API-Key", "test-admin-key")
@@ -1103,7 +1103,7 @@ class BudgetControllerTest {
 
         verify(auditRepository).log(argThat(entry ->
                 "fundBudget".equals(entry.getOperation()) &&
-                "t1".equals(entry.getTenantId()) &&
+                "tenant-1".equals(entry.getTenantId()) &&
                 entry.getStatus() == 200));
     }
 }

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/EventAdminControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/EventAdminControllerTest.java
@@ -52,13 +52,13 @@ class EventAdminControllerTest {
     void listEvents_withFilters_passes() throws Exception {
         EventListResponse response = EventListResponse.builder()
             .events(List.of()).hasMore(false).build();
-        when(eventService.list(eq("t1"), eq("budget.created"), eq("budget"), eq("org/team1"),
+        when(eventService.list(eq("tenant-1"), eq("budget.created"), eq("budget"), eq("org/team1"),
                 eq("corr_1"), any(), any(), any(), anyInt()))
             .thenReturn(response);
 
         mockMvc.perform(get("/v1/admin/events")
                         .header("X-Admin-API-Key", ADMIN_KEY)
-                        .param("tenant_id", "t1")
+                        .param("tenant_id", "tenant-1")
                         .param("event_type", "budget.created")
                         .param("category", "budget")
                         .param("scope", "org/team1")
@@ -76,7 +76,7 @@ class EventAdminControllerTest {
     void getEvent_returns200() throws Exception {
         Event event = Event.builder()
             .eventId("evt_1").eventType(EventType.BUDGET_CREATED)
-            .category(EventCategory.BUDGET).tenantId("t1")
+            .category(EventCategory.BUDGET).tenantId("tenant-1")
             .timestamp(Instant.now()).source("admin").build();
         when(eventService.findById("evt_1")).thenReturn(event);
 

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/EventTenantControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/EventTenantControllerTest.java
@@ -35,7 +35,7 @@ class EventTenantControllerTest {
     private void setupApiKeyAuth() {
         when(apiKeyRepository.validate("valid-api-key")).thenReturn(
                 ApiKeyValidationResponse.builder()
-                        .valid(true).tenantId("t1").keyId("key_1")
+                        .valid(true).tenantId("tenant-1").keyId("key_1")
                         .permissions(List.of("events:read")).build());
     }
 
@@ -44,7 +44,7 @@ class EventTenantControllerTest {
         setupApiKeyAuth();
         EventListResponse response = EventListResponse.builder()
             .events(List.of()).hasMore(false).build();
-        when(eventService.list(eq("t1"), any(), any(), any(), any(), any(), any(), any(), anyInt()))
+        when(eventService.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt()))
             .thenReturn(response);
 
         mockMvc.perform(get("/v1/events")
@@ -52,7 +52,7 @@ class EventTenantControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.events").isArray());
 
-        verify(eventService).list(eq("t1"), any(), any(), any(), any(), any(), any(), any(), anyInt());
+        verify(eventService).list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt());
     }
 
     @Test
@@ -66,7 +66,7 @@ class EventTenantControllerTest {
         setupApiKeyAuth();
         EventListResponse response = EventListResponse.builder()
             .events(List.of()).hasMore(false).build();
-        when(eventService.list(eq("t1"), eq("budget.created"), eq("budget"), any(), any(), any(), any(), any(), anyInt()))
+        when(eventService.list(eq("tenant-1"), eq("budget.created"), eq("budget"), any(), any(), any(), any(), any(), anyInt()))
             .thenReturn(response);
 
         mockMvc.perform(get("/v1/events")
@@ -75,7 +75,7 @@ class EventTenantControllerTest {
                         .param("category", "budget"))
                 .andExpect(status().isOk());
 
-        verify(eventService).list(eq("t1"), eq("budget.created"), eq("budget"), any(), any(), any(), any(), any(), anyInt());
+        verify(eventService).list(eq("tenant-1"), eq("budget.created"), eq("budget"), any(), any(), any(), any(), any(), anyInt());
     }
 
     @Test
@@ -83,7 +83,7 @@ class EventTenantControllerTest {
         setupApiKeyAuth();
         EventListResponse response = EventListResponse.builder()
             .events(List.of()).hasMore(false).build();
-        when(eventService.list(eq("t1"), any(), any(), any(), any(), any(), any(), any(), eq(100)))
+        when(eventService.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), eq(100)))
             .thenReturn(response);
 
         mockMvc.perform(get("/v1/events")
@@ -91,7 +91,7 @@ class EventTenantControllerTest {
                         .param("limit", "999"))
                 .andExpect(status().isOk());
 
-        verify(eventService).list(eq("t1"), any(), any(), any(), any(), any(), any(), any(), eq(100));
+        verify(eventService).list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), eq(100));
     }
 
     @Test

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/PolicyControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/PolicyControllerTest.java
@@ -39,7 +39,7 @@ class PolicyControllerTest {
     private void setupApiKeyAuth() {
         when(apiKeyRepository.validate("valid-api-key")).thenReturn(
                 ApiKeyValidationResponse.builder()
-                        .valid(true).tenantId("t1").keyId("key_1")
+                        .valid(true).tenantId("tenant-1").keyId("key_1")
                         .permissions(List.of("policies:read", "policies:write", "balances:read")).build());
     }
 
@@ -49,7 +49,7 @@ class PolicyControllerTest {
         Policy policy = Policy.builder()
                 .policyId("pol_123").scopePattern("org/*").name("Rate Limit")
                 .status(PolicyStatus.ACTIVE).createdAt(Instant.now()).build();
-        when(policyRepository.create(eq("t1"), any())).thenReturn(policy);
+        when(policyRepository.create(eq("tenant-1"), any())).thenReturn(policy);
 
         mockMvc.perform(post("/v1/admin/policies")
                         .header("X-Cycles-API-Key", "valid-api-key")
@@ -85,7 +85,7 @@ class PolicyControllerTest {
         Policy policy = Policy.builder()
                 .policyId("pol_1").scopePattern("org/*").name("P1")
                 .status(PolicyStatus.ACTIVE).createdAt(Instant.now()).build();
-        when(policyRepository.list(eq("t1"), any(), any(), any(), anyInt())).thenReturn(List.of(policy));
+        when(policyRepository.list(eq("tenant-1"), any(), any(), any(), anyInt())).thenReturn(List.of(policy));
 
         mockMvc.perform(get("/v1/admin/policies")
                         .header("X-Cycles-API-Key", "valid-api-key"))
@@ -97,7 +97,7 @@ class PolicyControllerTest {
     @Test
     void listPolicies_withFilters() throws Exception {
         setupApiKeyAuth();
-        when(policyRepository.list(eq("t1"), eq("org/*"), eq(PolicyStatus.ACTIVE), any(), anyInt()))
+        when(policyRepository.list(eq("tenant-1"), eq("org/*"), eq(PolicyStatus.ACTIVE), any(), anyInt()))
                 .thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/policies")
@@ -114,7 +114,7 @@ class PolicyControllerTest {
         Policy policy = Policy.builder()
                 .policyId("pol_123").scopePattern("org/*").name("Rate Limit")
                 .status(PolicyStatus.ACTIVE).createdAt(Instant.now()).build();
-        when(policyRepository.create(eq("t1"), any())).thenReturn(policy);
+        when(policyRepository.create(eq("tenant-1"), any())).thenReturn(policy);
 
         mockMvc.perform(post("/v1/admin/policies")
                         .header("X-Cycles-API-Key", "valid-api-key")
@@ -124,7 +124,7 @@ class PolicyControllerTest {
 
         verify(auditRepository).log(argThat(entry ->
                 "createPolicy".equals(entry.getOperation()) &&
-                "t1".equals(entry.getTenantId()) &&
+                "tenant-1".equals(entry.getTenantId()) &&
                 "key_1".equals(entry.getKeyId()) &&
                 entry.getStatus() == 201));
     }
@@ -132,19 +132,19 @@ class PolicyControllerTest {
     @Test
     void listPolicies_usesAuthenticatedTenantId() throws Exception {
         setupApiKeyAuth();
-        when(policyRepository.list(eq("t1"), any(), any(), any(), anyInt())).thenReturn(List.of());
+        when(policyRepository.list(eq("tenant-1"), any(), any(), any(), anyInt())).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/policies")
                         .header("X-Cycles-API-Key", "valid-api-key"))
                 .andExpect(status().isOk());
 
-        verify(policyRepository).list(eq("t1"), any(), any(), any(), anyInt());
+        verify(policyRepository).list(eq("tenant-1"), any(), any(), any(), anyInt());
     }
 
     @Test
     void listPolicies_emptyResult_hasMoreFalseAndNoCursor() throws Exception {
         setupApiKeyAuth();
-        when(policyRepository.list(eq("t1"), any(), any(), any(), anyInt())).thenReturn(List.of());
+        when(policyRepository.list(eq("tenant-1"), any(), any(), any(), anyInt())).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/policies")
                         .header("X-Cycles-API-Key", "valid-api-key"))
@@ -157,27 +157,27 @@ class PolicyControllerTest {
     @Test
     void listPolicies_limitClampedToMax100() throws Exception {
         setupApiKeyAuth();
-        when(policyRepository.list(eq("t1"), any(), any(), any(), eq(100))).thenReturn(List.of());
+        when(policyRepository.list(eq("tenant-1"), any(), any(), any(), eq(100))).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/policies")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .param("limit", "500"))
                 .andExpect(status().isOk());
 
-        verify(policyRepository).list(eq("t1"), any(), any(), any(), eq(100));
+        verify(policyRepository).list(eq("tenant-1"), any(), any(), any(), eq(100));
     }
 
     @Test
     void listPolicies_limitClampedToMin1() throws Exception {
         setupApiKeyAuth();
-        when(policyRepository.list(eq("t1"), any(), any(), any(), eq(1))).thenReturn(List.of());
+        when(policyRepository.list(eq("tenant-1"), any(), any(), any(), eq(1))).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/policies")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .param("limit", "0"))
                 .andExpect(status().isOk());
 
-        verify(policyRepository).list(eq("t1"), any(), any(), any(), eq(1));
+        verify(policyRepository).list(eq("tenant-1"), any(), any(), any(), eq(1));
     }
 
     @Test
@@ -186,7 +186,7 @@ class PolicyControllerTest {
         Policy policy = Policy.builder()
                 .policyId("pol_123").scopePattern("org/*").name("Rate Limit")
                 .status(PolicyStatus.ACTIVE).createdAt(Instant.now()).build();
-        when(policyRepository.create(eq("t1"), any())).thenReturn(policy);
+        when(policyRepository.create(eq("tenant-1"), any())).thenReturn(policy);
 
         mockMvc.perform(post("/v1/admin/policies")
                         .header("X-Cycles-API-Key", "valid-api-key")
@@ -206,7 +206,7 @@ class PolicyControllerTest {
         Policy policy = Policy.builder()
                 .policyId("pol_123").scopePattern("org/*").name("Rate Limit")
                 .status(PolicyStatus.ACTIVE).createdAt(Instant.now()).build();
-        when(policyRepository.create(eq("t1"), any())).thenReturn(policy);
+        when(policyRepository.create(eq("tenant-1"), any())).thenReturn(policy);
 
         mockMvc.perform(post("/v1/admin/policies")
                         .header("X-Cycles-API-Key", "valid-api-key")
@@ -225,7 +225,7 @@ class PolicyControllerTest {
         Policy policy = Policy.builder()
                 .policyId("pol_123").scopePattern("org/*").name("Rate Limit")
                 .status(PolicyStatus.ACTIVE).createdAt(Instant.now()).build();
-        when(policyRepository.create(eq("t1"), any())).thenReturn(policy);
+        when(policyRepository.create(eq("tenant-1"), any())).thenReturn(policy);
 
         mockMvc.perform(post("/v1/admin/policies")
                         .header("X-Cycles-API-Key", "valid-api-key")
@@ -247,7 +247,7 @@ class PolicyControllerTest {
         Policy p2 = Policy.builder()
                 .policyId("pol_2").scopePattern("team/*").name("P2")
                 .status(PolicyStatus.ACTIVE).createdAt(Instant.now()).build();
-        when(policyRepository.list(eq("t1"), any(), any(), any(), eq(2))).thenReturn(List.of(p1, p2));
+        when(policyRepository.list(eq("tenant-1"), any(), any(), any(), eq(2))).thenReturn(List.of(p1, p2));
 
         mockMvc.perform(get("/v1/admin/policies")
                         .header("X-Cycles-API-Key", "valid-api-key")
@@ -260,14 +260,14 @@ class PolicyControllerTest {
     @Test
     void listPolicies_withCursorParam_passesToRepository() throws Exception {
         setupApiKeyAuth();
-        when(policyRepository.list(eq("t1"), any(), any(), eq("pol_abc"), anyInt())).thenReturn(List.of());
+        when(policyRepository.list(eq("tenant-1"), any(), any(), eq("pol_abc"), anyInt())).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/policies")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .param("cursor", "pol_abc"))
                 .andExpect(status().isOk());
 
-        verify(policyRepository).list(eq("t1"), any(), any(), eq("pol_abc"), anyInt());
+        verify(policyRepository).list(eq("tenant-1"), any(), any(), eq("pol_abc"), anyInt());
     }
 
     // ========== PATCH /v1/admin/policies/{policy_id} ==========
@@ -278,7 +278,7 @@ class PolicyControllerTest {
         Policy policy = Policy.builder()
                 .policyId("pol_123").scopePattern("org/*").name("Updated Name")
                 .priority(10).status(PolicyStatus.ACTIVE).createdAt(Instant.now()).build();
-        when(policyRepository.update(eq("t1"), eq("pol_123"), any())).thenReturn(policy);
+        when(policyRepository.update(eq("tenant-1"), eq("pol_123"), any())).thenReturn(policy);
 
         mockMvc.perform(patch("/v1/admin/policies/pol_123")
                         .header("X-Cycles-API-Key", "valid-api-key")
@@ -293,7 +293,7 @@ class PolicyControllerTest {
     @Test
     void updatePolicy_notFound_returns404() throws Exception {
         setupApiKeyAuth();
-        when(policyRepository.update(eq("t1"), eq("pol_missing"), any()))
+        when(policyRepository.update(eq("tenant-1"), eq("pol_missing"), any()))
                 .thenThrow(GovernanceException.policyNotFound("pol_missing"));
 
         mockMvc.perform(patch("/v1/admin/policies/pol_missing")
@@ -310,7 +310,7 @@ class PolicyControllerTest {
         Policy policy = Policy.builder()
                 .policyId("pol_123").scopePattern("org/*").name("P")
                 .status(PolicyStatus.ACTIVE).createdAt(Instant.now()).build();
-        when(policyRepository.update(eq("t1"), eq("pol_123"), any())).thenReturn(policy);
+        when(policyRepository.update(eq("tenant-1"), eq("pol_123"), any())).thenReturn(policy);
 
         mockMvc.perform(patch("/v1/admin/policies/pol_123")
                         .header("X-Cycles-API-Key", "valid-api-key")
@@ -320,7 +320,7 @@ class PolicyControllerTest {
 
         verify(auditRepository).log(argThat(entry ->
                 "updatePolicy".equals(entry.getOperation()) &&
-                "t1".equals(entry.getTenantId()) &&
+                "tenant-1".equals(entry.getTenantId()) &&
                 entry.getStatus() == 200));
     }
 
@@ -336,7 +336,7 @@ class PolicyControllerTest {
     @Test
     void listPolicies_withActionQuotaParams_acceptedAndIgnored() throws Exception {
         setupApiKeyAuth();
-        when(policyRepository.list(eq("t1"), any(), any(), any(), anyInt())).thenReturn(List.of());
+        when(policyRepository.list(eq("tenant-1"), any(), any(), any(), anyInt())).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/policies")
                         .header("X-Cycles-API-Key", "valid-api-key")
@@ -346,14 +346,14 @@ class PolicyControllerTest {
                 .andExpect(jsonPath("$.policies").isArray());
 
         // Repository call unchanged — these params are not passed through on v0.1.25.x
-        verify(policyRepository).list(eq("t1"), any(), any(), any(), anyInt());
+        verify(policyRepository).list(eq("tenant-1"), any(), any(), any(), anyInt());
     }
 
     // v0.1.25.8: spec says "MUST ignore without error" — malformed values must not 400
     @Test
     void listPolicies_withMalformedHasActionQuotas_stillReturns200() throws Exception {
         setupApiKeyAuth();
-        when(policyRepository.list(eq("t1"), any(), any(), any(), anyInt())).thenReturn(List.of());
+        when(policyRepository.list(eq("tenant-1"), any(), any(), any(), anyInt())).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/policies")
                         .header("X-Cycles-API-Key", "valid-api-key")

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/TenantControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/TenantControllerTest.java
@@ -115,14 +115,14 @@ class TenantControllerTest {
     @Test
     void listTenants_returns200() throws Exception {
         List<Tenant> tenants = List.of(
-                Tenant.builder().tenantId("t1").name("A").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build());
+                Tenant.builder().tenantId("tenant-1").name("A").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build());
         when(tenantRepository.list(any(), any(), any(), anyInt())).thenReturn(tenants);
 
         mockMvc.perform(get("/v1/admin/tenants")
                         .header("X-Admin-API-Key", ADMIN_KEY))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.tenants").isArray())
-                .andExpect(jsonPath("$.tenants[0].tenant_id").value("t1"));
+                .andExpect(jsonPath("$.tenants[0].tenant_id").value("tenant-1"));
     }
 
     @Test
@@ -139,13 +139,13 @@ class TenantControllerTest {
     @Test
     void getTenant_returns200() throws Exception {
         Tenant tenant = Tenant.builder()
-                .tenantId("t1").name("A").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build();
-        when(tenantRepository.get("t1")).thenReturn(tenant);
+                .tenantId("tenant-1").name("A").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build();
+        when(tenantRepository.get("tenant-1")).thenReturn(tenant);
 
-        mockMvc.perform(get("/v1/admin/tenants/t1")
+        mockMvc.perform(get("/v1/admin/tenants/tenant-1")
                         .header("X-Admin-API-Key", ADMIN_KEY))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.tenant_id").value("t1"));
+                .andExpect(jsonPath("$.tenant_id").value("tenant-1"));
     }
 
     @Test
@@ -161,10 +161,10 @@ class TenantControllerTest {
     @Test
     void updateTenant_returns200() throws Exception {
         Tenant updated = Tenant.builder()
-                .tenantId("t1").name("Updated").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build();
-        when(tenantRepository.update(eq("t1"), any())).thenReturn(updated);
+                .tenantId("tenant-1").name("Updated").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build();
+        when(tenantRepository.update(eq("tenant-1"), any())).thenReturn(updated);
 
-        mockMvc.perform(patch("/v1/admin/tenants/t1")
+        mockMvc.perform(patch("/v1/admin/tenants/tenant-1")
                         .header("X-Admin-API-Key", ADMIN_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"name\":\"Updated\"}"))
@@ -174,10 +174,10 @@ class TenantControllerTest {
 
     @Test
     void updateTenant_invalidTransition_returns400() throws Exception {
-        when(tenantRepository.update(eq("t1"), any()))
+        when(tenantRepository.update(eq("tenant-1"), any()))
                 .thenThrow(new GovernanceException(ErrorCode.INVALID_REQUEST, "Cannot transition from CLOSED", 400));
 
-        mockMvc.perform(patch("/v1/admin/tenants/t1")
+        mockMvc.perform(patch("/v1/admin/tenants/tenant-1")
                         .header("X-Admin-API-Key", ADMIN_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"status\":\"ACTIVE\"}"))
@@ -223,10 +223,10 @@ class TenantControllerTest {
     @Test
     void updateTenant_logsAuditEntry() throws Exception {
         Tenant updated = Tenant.builder()
-                .tenantId("t1").name("Updated").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build();
-        when(tenantRepository.update(eq("t1"), any())).thenReturn(updated);
+                .tenantId("tenant-1").name("Updated").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build();
+        when(tenantRepository.update(eq("tenant-1"), any())).thenReturn(updated);
 
-        mockMvc.perform(patch("/v1/admin/tenants/t1")
+        mockMvc.perform(patch("/v1/admin/tenants/tenant-1")
                         .header("X-Admin-API-Key", ADMIN_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"name\":\"Updated\"}"))
@@ -234,7 +234,7 @@ class TenantControllerTest {
 
         verify(auditRepository).log(argThat(entry ->
                 "updateTenant".equals(entry.getOperation()) &&
-                "t1".equals(entry.getTenantId()) &&
+                "tenant-1".equals(entry.getTenantId()) &&
                 entry.getStatus() == 200));
     }
 
@@ -325,10 +325,10 @@ class TenantControllerTest {
     @Test
     void updateTenant_auditEntry_requestIdIsFallbackUuidWhenAttributeMissing() throws Exception {
         Tenant updated = Tenant.builder()
-                .tenantId("t1").name("Updated").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build();
-        when(tenantRepository.update(eq("t1"), any())).thenReturn(updated);
+                .tenantId("tenant-1").name("Updated").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build();
+        when(tenantRepository.update(eq("tenant-1"), any())).thenReturn(updated);
 
-        mockMvc.perform(patch("/v1/admin/tenants/t1")
+        mockMvc.perform(patch("/v1/admin/tenants/tenant-1")
                         .header("X-Admin-API-Key", ADMIN_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"name\":\"Updated\"}"))
@@ -343,10 +343,10 @@ class TenantControllerTest {
     @Test
     void updateTenant_auditEntry_capturesSourceIp() throws Exception {
         Tenant updated = Tenant.builder()
-                .tenantId("t1").name("Updated").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build();
-        when(tenantRepository.update(eq("t1"), any())).thenReturn(updated);
+                .tenantId("tenant-1").name("Updated").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build();
+        when(tenantRepository.update(eq("tenant-1"), any())).thenReturn(updated);
 
-        mockMvc.perform(patch("/v1/admin/tenants/t1")
+        mockMvc.perform(patch("/v1/admin/tenants/tenant-1")
                         .header("X-Admin-API-Key", ADMIN_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"name\":\"Updated\"}"))
@@ -360,12 +360,12 @@ class TenantControllerTest {
     @Test
     void updateTenant_defaultCommitOveragePolicy_returns200() throws Exception {
         Tenant updated = Tenant.builder()
-                .tenantId("t1").name("Test").status(TenantStatus.ACTIVE)
+                .tenantId("tenant-1").name("Test").status(TenantStatus.ACTIVE)
                 .defaultCommitOveragePolicy(CommitOveragePolicy.ALLOW_WITH_OVERDRAFT)
                 .createdAt(Instant.now()).build();
-        when(tenantRepository.update(eq("t1"), any())).thenReturn(updated);
+        when(tenantRepository.update(eq("tenant-1"), any())).thenReturn(updated);
 
-        mockMvc.perform(patch("/v1/admin/tenants/t1")
+        mockMvc.perform(patch("/v1/admin/tenants/tenant-1")
                         .header("X-Admin-API-Key", ADMIN_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"default_commit_overage_policy\":\"ALLOW_WITH_OVERDRAFT\"}"))
@@ -375,7 +375,7 @@ class TenantControllerTest {
 
     @Test
     void updateTenant_invalidCommitOveragePolicy_returns400() throws Exception {
-        mockMvc.perform(patch("/v1/admin/tenants/t1")
+        mockMvc.perform(patch("/v1/admin/tenants/tenant-1")
                         .header("X-Admin-API-Key", ADMIN_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"default_commit_overage_policy\":\"INVALID_VALUE\"}"))
@@ -398,8 +398,8 @@ class TenantControllerTest {
     void listTenants_resultCountEqualsLimit_hasMoreTrueWithCursor() throws Exception {
         // Return exactly 2 tenants with limit=2 to trigger has_more=true branch
         List<Tenant> tenants = List.of(
-                Tenant.builder().tenantId("t1").name("A").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build(),
-                Tenant.builder().tenantId("t2").name("B").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build());
+                Tenant.builder().tenantId("tenant-1").name("A").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build(),
+                Tenant.builder().tenantId("tenant-2").name("B").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build());
         when(tenantRepository.list(any(), any(), any(), eq(2))).thenReturn(tenants);
 
         mockMvc.perform(get("/v1/admin/tenants")
@@ -407,7 +407,7 @@ class TenantControllerTest {
                         .param("limit", "2"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.has_more").value(true))
-                .andExpect(jsonPath("$.next_cursor").value("t2"));
+                .andExpect(jsonPath("$.next_cursor").value("tenant-2"));
     }
 
     @Test
@@ -440,61 +440,61 @@ class TenantControllerTest {
     @Test
     void updateTenant_emitsEvent() throws Exception {
         Tenant updated = Tenant.builder()
-                .tenantId("t1").name("Updated").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build();
-        when(tenantRepository.update(eq("t1"), any())).thenReturn(updated);
+                .tenantId("tenant-1").name("Updated").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build();
+        when(tenantRepository.update(eq("tenant-1"), any())).thenReturn(updated);
 
-        mockMvc.perform(patch("/v1/admin/tenants/t1")
+        mockMvc.perform(patch("/v1/admin/tenants/tenant-1")
                         .header("X-Admin-API-Key", ADMIN_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"name\":\"Updated\"}"))
                 .andExpect(status().isOk());
 
-        verify(eventService).emit(eq(EventType.TENANT_UPDATED), eq("t1"), any(), any(), any(), any(), any(), any());
+        verify(eventService).emit(eq(EventType.TENANT_UPDATED), eq("tenant-1"), any(), any(), any(), any(), any(), any());
     }
 
     @Test
     void updateTenant_withSuspendedStatus_emitsSuspendedEvent() throws Exception {
         Tenant updated = Tenant.builder()
-                .tenantId("t1").name("Test").status(TenantStatus.SUSPENDED).createdAt(Instant.now()).build();
-        when(tenantRepository.update(eq("t1"), any())).thenReturn(updated);
+                .tenantId("tenant-1").name("Test").status(TenantStatus.SUSPENDED).createdAt(Instant.now()).build();
+        when(tenantRepository.update(eq("tenant-1"), any())).thenReturn(updated);
 
-        mockMvc.perform(patch("/v1/admin/tenants/t1")
+        mockMvc.perform(patch("/v1/admin/tenants/tenant-1")
                         .header("X-Admin-API-Key", ADMIN_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"status\":\"SUSPENDED\"}"))
                 .andExpect(status().isOk());
 
-        verify(eventService).emit(eq(EventType.TENANT_SUSPENDED), eq("t1"), any(), any(), any(), any(), any(), any());
+        verify(eventService).emit(eq(EventType.TENANT_SUSPENDED), eq("tenant-1"), any(), any(), any(), any(), any(), any());
     }
 
     @Test
     void updateTenant_withClosedStatus_emitsClosedEvent() throws Exception {
         Tenant updated = Tenant.builder()
-                .tenantId("t1").name("Test").status(TenantStatus.CLOSED).createdAt(Instant.now()).build();
-        when(tenantRepository.update(eq("t1"), any())).thenReturn(updated);
+                .tenantId("tenant-1").name("Test").status(TenantStatus.CLOSED).createdAt(Instant.now()).build();
+        when(tenantRepository.update(eq("tenant-1"), any())).thenReturn(updated);
 
-        mockMvc.perform(patch("/v1/admin/tenants/t1")
+        mockMvc.perform(patch("/v1/admin/tenants/tenant-1")
                         .header("X-Admin-API-Key", ADMIN_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"status\":\"CLOSED\"}"))
                 .andExpect(status().isOk());
 
-        verify(eventService).emit(eq(EventType.TENANT_CLOSED), eq("t1"), any(), any(), any(), any(), any(), any());
+        verify(eventService).emit(eq(EventType.TENANT_CLOSED), eq("tenant-1"), any(), any(), any(), any(), any(), any());
     }
 
     @Test
     void updateTenant_withActiveStatus_emitsReactivatedEvent() throws Exception {
         Tenant updated = Tenant.builder()
-                .tenantId("t1").name("Test").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build();
-        when(tenantRepository.update(eq("t1"), any())).thenReturn(updated);
+                .tenantId("tenant-1").name("Test").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build();
+        when(tenantRepository.update(eq("tenant-1"), any())).thenReturn(updated);
 
-        mockMvc.perform(patch("/v1/admin/tenants/t1")
+        mockMvc.perform(patch("/v1/admin/tenants/tenant-1")
                         .header("X-Admin-API-Key", ADMIN_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"status\":\"ACTIVE\"}"))
                 .andExpect(status().isOk());
 
-        verify(eventService).emit(eq(EventType.TENANT_REACTIVATED), eq("t1"), any(), any(), any(), any(), any(), any());
+        verify(eventService).emit(eq(EventType.TENANT_REACTIVATED), eq("tenant-1"), any(), any(), any(), any(), any(), any());
     }
 
     // ========== Tenant TTL update fields ==========
@@ -502,11 +502,11 @@ class TenantControllerTest {
     @Test
     void updateTenant_defaultReservationTtlMs_returns200() throws Exception {
         Tenant tenant = Tenant.builder()
-                .tenantId("t1").name("T1").status(TenantStatus.ACTIVE)
+                .tenantId("tenant-1").name("T1").status(TenantStatus.ACTIVE)
                 .defaultReservationTtlMs(30000L).createdAt(Instant.now()).build();
-        when(tenantRepository.update(eq("t1"), any())).thenReturn(tenant);
+        when(tenantRepository.update(eq("tenant-1"), any())).thenReturn(tenant);
 
-        mockMvc.perform(patch("/v1/admin/tenants/t1")
+        mockMvc.perform(patch("/v1/admin/tenants/tenant-1")
                         .header("X-Admin-API-Key", ADMIN_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"default_reservation_ttl_ms\":30000}"))
@@ -517,11 +517,11 @@ class TenantControllerTest {
     @Test
     void updateTenant_maxReservationTtlMs_returns200() throws Exception {
         Tenant tenant = Tenant.builder()
-                .tenantId("t1").name("T1").status(TenantStatus.ACTIVE)
+                .tenantId("tenant-1").name("T1").status(TenantStatus.ACTIVE)
                 .maxReservationTtlMs(1800000L).createdAt(Instant.now()).build();
-        when(tenantRepository.update(eq("t1"), any())).thenReturn(tenant);
+        when(tenantRepository.update(eq("tenant-1"), any())).thenReturn(tenant);
 
-        mockMvc.perform(patch("/v1/admin/tenants/t1")
+        mockMvc.perform(patch("/v1/admin/tenants/tenant-1")
                         .header("X-Admin-API-Key", ADMIN_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"max_reservation_ttl_ms\":1800000}"))
@@ -532,11 +532,11 @@ class TenantControllerTest {
     @Test
     void updateTenant_maxReservationExtensions_returns200() throws Exception {
         Tenant tenant = Tenant.builder()
-                .tenantId("t1").name("T1").status(TenantStatus.ACTIVE)
+                .tenantId("tenant-1").name("T1").status(TenantStatus.ACTIVE)
                 .maxReservationExtensions(20).createdAt(Instant.now()).build();
-        when(tenantRepository.update(eq("t1"), any())).thenReturn(tenant);
+        when(tenantRepository.update(eq("tenant-1"), any())).thenReturn(tenant);
 
-        mockMvc.perform(patch("/v1/admin/tenants/t1")
+        mockMvc.perform(patch("/v1/admin/tenants/tenant-1")
                         .header("X-Admin-API-Key", ADMIN_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"max_reservation_extensions\":20}"))

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookAdminControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookAdminControllerTest.java
@@ -41,16 +41,16 @@ class WebhookAdminControllerTest {
     @Test
     void createWebhook_returns201() throws Exception {
         WebhookSubscription sub = WebhookSubscription.builder()
-            .subscriptionId("whsub_1").tenantId("t1").url("https://example.com/wh")
+            .subscriptionId("whsub_1").tenantId("tenant-1").url("https://example.com/wh")
             .eventTypes(List.of(EventType.BUDGET_CREATED)).status(WebhookStatus.ACTIVE)
             .createdAt(Instant.now()).build();
         WebhookCreateResponse response = WebhookCreateResponse.builder()
             .subscription(sub).signingSecret("whsec_abc").build();
-        when(webhookService.create(eq("t1"), any())).thenReturn(response);
+        when(webhookService.create(eq("tenant-1"), any())).thenReturn(response);
 
         mockMvc.perform(post("/v1/admin/webhooks")
                         .header("X-Admin-API-Key", ADMIN_KEY)
-                        .param("tenant_id", "t1")
+                        .param("tenant_id", "tenant-1")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"url\":\"https://example.com/wh\",\"event_types\":[\"budget.created\"]}"))
                 .andExpect(status().isCreated())
@@ -85,7 +85,7 @@ class WebhookAdminControllerTest {
     @Test
     void getWebhook_returns200() throws Exception {
         WebhookSubscription sub = WebhookSubscription.builder()
-            .subscriptionId("whsub_1").tenantId("t1").url("https://example.com/wh")
+            .subscriptionId("whsub_1").tenantId("tenant-1").url("https://example.com/wh")
             .status(WebhookStatus.ACTIVE).createdAt(Instant.now()).build();
         when(webhookService.get("whsub_1")).thenReturn(sub);
 
@@ -109,7 +109,7 @@ class WebhookAdminControllerTest {
     @Test
     void updateWebhook_returns200() throws Exception {
         WebhookSubscription updated = WebhookSubscription.builder()
-            .subscriptionId("whsub_1").tenantId("t1").name("Updated")
+            .subscriptionId("whsub_1").tenantId("tenant-1").name("Updated")
             .url("https://example.com/wh").status(WebhookStatus.ACTIVE)
             .createdAt(Instant.now()).build();
         when(webhookService.update(eq("whsub_1"), any())).thenReturn(updated);
@@ -123,14 +123,14 @@ class WebhookAdminControllerTest {
 
         verify(auditRepository).log(argThat(entry ->
                 "updateWebhookSubscription".equals(entry.getOperation()) &&
-                "t1".equals(entry.getTenantId()) &&
+                "tenant-1".equals(entry.getTenantId()) &&
                 entry.getStatus() == 200));
     }
 
     @Test
     void deleteWebhook_returns204() throws Exception {
         WebhookSubscription sub = WebhookSubscription.builder()
-            .subscriptionId("whsub_1").tenantId("t1").url("https://example.com/wh")
+            .subscriptionId("whsub_1").tenantId("tenant-1").url("https://example.com/wh")
             .status(WebhookStatus.ACTIVE).createdAt(Instant.now()).build();
         when(webhookService.get("whsub_1")).thenReturn(sub);
 
@@ -141,7 +141,7 @@ class WebhookAdminControllerTest {
         verify(webhookService).delete("whsub_1");
         verify(auditRepository).log(argThat(entry ->
                 "deleteWebhookSubscription".equals(entry.getOperation()) &&
-                "t1".equals(entry.getTenantId()) &&
+                "tenant-1".equals(entry.getTenantId()) &&
                 entry.getStatus() == 204));
     }
 

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookTenantControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookTenantControllerTest.java
@@ -40,7 +40,7 @@ class WebhookTenantControllerTest {
     private void setupApiKeyAuth() {
         when(apiKeyRepository.validate("valid-api-key")).thenReturn(
                 ApiKeyValidationResponse.builder()
-                        .valid(true).tenantId("t1").keyId("key_1")
+                        .valid(true).tenantId("tenant-1").keyId("key_1")
                         .permissions(List.of("webhooks:read", "webhooks:write", "events:read")).build());
     }
 
@@ -48,12 +48,12 @@ class WebhookTenantControllerTest {
     void createWebhook_withValidTenantEventTypes_returns201() throws Exception {
         setupApiKeyAuth();
         WebhookSubscription sub = WebhookSubscription.builder()
-            .subscriptionId("whsub_1").tenantId("t1").url("https://example.com/wh")
+            .subscriptionId("whsub_1").tenantId("tenant-1").url("https://example.com/wh")
             .eventTypes(List.of(EventType.BUDGET_CREATED)).status(WebhookStatus.ACTIVE)
             .createdAt(Instant.now()).build();
         WebhookCreateResponse response = WebhookCreateResponse.builder()
             .subscription(sub).signingSecret("whsec_abc").build();
-        when(webhookService.create(eq("t1"), any())).thenReturn(response);
+        when(webhookService.create(eq("tenant-1"), any())).thenReturn(response);
 
         mockMvc.perform(post("/v1/webhooks")
                         .header("X-Cycles-API-Key", "valid-api-key")
@@ -64,7 +64,7 @@ class WebhookTenantControllerTest {
 
         verify(auditRepository).log(argThat(entry ->
                 "createTenantWebhook".equals(entry.getOperation()) &&
-                "t1".equals(entry.getTenantId()) &&
+                "tenant-1".equals(entry.getTenantId()) &&
                 "key_1".equals(entry.getKeyId()) &&
                 entry.getStatus() == 201));
     }
@@ -85,7 +85,7 @@ class WebhookTenantControllerTest {
     void getWebhook_ownWebhook_returns200() throws Exception {
         setupApiKeyAuth();
         WebhookSubscription sub = WebhookSubscription.builder()
-            .subscriptionId("whsub_1").tenantId("t1").url("https://example.com/wh")
+            .subscriptionId("whsub_1").tenantId("tenant-1").url("https://example.com/wh")
             .status(WebhookStatus.ACTIVE).createdAt(Instant.now()).build();
         when(webhookService.get("whsub_1")).thenReturn(sub);
 
@@ -99,7 +99,7 @@ class WebhookTenantControllerTest {
     void getWebhook_otherTenantWebhook_returns404() throws Exception {
         setupApiKeyAuth();
         WebhookSubscription sub = WebhookSubscription.builder()
-            .subscriptionId("whsub_other").tenantId("t2").url("https://example.com/wh")
+            .subscriptionId("whsub_other").tenantId("tenant-2").url("https://example.com/wh")
             .status(WebhookStatus.ACTIVE).createdAt(Instant.now()).build();
         when(webhookService.get("whsub_other")).thenReturn(sub);
 
@@ -113,7 +113,7 @@ class WebhookTenantControllerTest {
     void deleteWebhook_ownWebhook_returns204() throws Exception {
         setupApiKeyAuth();
         WebhookSubscription sub = WebhookSubscription.builder()
-            .subscriptionId("whsub_1").tenantId("t1").url("https://example.com/wh")
+            .subscriptionId("whsub_1").tenantId("tenant-1").url("https://example.com/wh")
             .status(WebhookStatus.ACTIVE).createdAt(Instant.now()).build();
         when(webhookService.get("whsub_1")).thenReturn(sub);
 
@@ -124,7 +124,7 @@ class WebhookTenantControllerTest {
         verify(webhookService).delete("whsub_1");
         verify(auditRepository).log(argThat(entry ->
                 "deleteTenantWebhook".equals(entry.getOperation()) &&
-                "t1".equals(entry.getTenantId()) &&
+                "tenant-1".equals(entry.getTenantId()) &&
                 "key_1".equals(entry.getKeyId()) &&
                 entry.getStatus() == 204));
     }
@@ -141,11 +141,11 @@ class WebhookTenantControllerTest {
     void updateWebhook_ownWebhook_returns200() throws Exception {
         setupApiKeyAuth();
         WebhookSubscription sub = WebhookSubscription.builder()
-            .subscriptionId("whsub_1").tenantId("t1").url("https://example.com/wh")
+            .subscriptionId("whsub_1").tenantId("tenant-1").url("https://example.com/wh")
             .status(WebhookStatus.ACTIVE).createdAt(Instant.now()).build();
         when(webhookService.get("whsub_1")).thenReturn(sub);
         WebhookSubscription updated = WebhookSubscription.builder()
-            .subscriptionId("whsub_1").tenantId("t1").url("https://example.com/wh2")
+            .subscriptionId("whsub_1").tenantId("tenant-1").url("https://example.com/wh2")
             .status(WebhookStatus.ACTIVE).createdAt(Instant.now()).build();
         when(webhookService.update(eq("whsub_1"), any())).thenReturn(updated);
 
@@ -158,7 +158,7 @@ class WebhookTenantControllerTest {
 
         verify(auditRepository).log(argThat(entry ->
                 "updateTenantWebhook".equals(entry.getOperation()) &&
-                "t1".equals(entry.getTenantId()) &&
+                "tenant-1".equals(entry.getTenantId()) &&
                 "key_1".equals(entry.getKeyId()) &&
                 entry.getStatus() == 200));
     }
@@ -167,7 +167,7 @@ class WebhookTenantControllerTest {
     void updateWebhook_withAdminOnlyEventType_returns400() throws Exception {
         setupApiKeyAuth();
         WebhookSubscription sub = WebhookSubscription.builder()
-            .subscriptionId("whsub_1").tenantId("t1").url("https://example.com/wh")
+            .subscriptionId("whsub_1").tenantId("tenant-1").url("https://example.com/wh")
             .status(WebhookStatus.ACTIVE).createdAt(Instant.now()).build();
         when(webhookService.get("whsub_1")).thenReturn(sub);
 
@@ -183,7 +183,7 @@ class WebhookTenantControllerTest {
     void updateWebhook_otherTenantWebhook_returns404() throws Exception {
         setupApiKeyAuth();
         WebhookSubscription sub = WebhookSubscription.builder()
-            .subscriptionId("whsub_other").tenantId("t2").url("https://example.com/wh")
+            .subscriptionId("whsub_other").tenantId("tenant-2").url("https://example.com/wh")
             .status(WebhookStatus.ACTIVE).createdAt(Instant.now()).build();
         when(webhookService.get("whsub_other")).thenReturn(sub);
 
@@ -198,7 +198,7 @@ class WebhookTenantControllerTest {
     void testWebhook_ownWebhook_returns200() throws Exception {
         setupApiKeyAuth();
         WebhookSubscription sub = WebhookSubscription.builder()
-            .subscriptionId("whsub_1").tenantId("t1").url("https://example.com/wh")
+            .subscriptionId("whsub_1").tenantId("tenant-1").url("https://example.com/wh")
             .status(WebhookStatus.ACTIVE).createdAt(Instant.now()).build();
         when(webhookService.get("whsub_1")).thenReturn(sub);
         WebhookTestResponse testResponse = WebhookTestResponse.builder()
@@ -212,7 +212,7 @@ class WebhookTenantControllerTest {
 
         verify(auditRepository).log(argThat(entry ->
                 "testTenantWebhook".equals(entry.getOperation()) &&
-                "t1".equals(entry.getTenantId()) &&
+                "tenant-1".equals(entry.getTenantId()) &&
                 "key_1".equals(entry.getKeyId()) &&
                 entry.getStatus() == 200));
     }
@@ -221,7 +221,7 @@ class WebhookTenantControllerTest {
     void testWebhook_otherTenantWebhook_returns404() throws Exception {
         setupApiKeyAuth();
         WebhookSubscription sub = WebhookSubscription.builder()
-            .subscriptionId("whsub_other").tenantId("t2").url("https://example.com/wh")
+            .subscriptionId("whsub_other").tenantId("tenant-2").url("https://example.com/wh")
             .status(WebhookStatus.ACTIVE).createdAt(Instant.now()).build();
         when(webhookService.get("whsub_other")).thenReturn(sub);
 
@@ -234,7 +234,7 @@ class WebhookTenantControllerTest {
     void listDeliveries_ownWebhook_returns200() throws Exception {
         setupApiKeyAuth();
         WebhookSubscription sub = WebhookSubscription.builder()
-            .subscriptionId("whsub_1").tenantId("t1").url("https://example.com/wh")
+            .subscriptionId("whsub_1").tenantId("tenant-1").url("https://example.com/wh")
             .status(WebhookStatus.ACTIVE).createdAt(Instant.now()).build();
         when(webhookService.get("whsub_1")).thenReturn(sub);
         WebhookDeliveryListResponse deliveries = WebhookDeliveryListResponse.builder()
@@ -252,7 +252,7 @@ class WebhookTenantControllerTest {
     void listDeliveries_otherTenantWebhook_returns404() throws Exception {
         setupApiKeyAuth();
         WebhookSubscription sub = WebhookSubscription.builder()
-            .subscriptionId("whsub_other").tenantId("t2").url("https://example.com/wh")
+            .subscriptionId("whsub_other").tenantId("tenant-2").url("https://example.com/wh")
             .status(WebhookStatus.ACTIVE).createdAt(Instant.now()).build();
         when(webhookService.get("whsub_other")).thenReturn(sub);
 
@@ -266,21 +266,21 @@ class WebhookTenantControllerTest {
         setupApiKeyAuth();
         WebhookListResponse response = WebhookListResponse.builder()
             .subscriptions(List.of()).hasMore(false).build();
-        when(webhookService.listByTenant(eq("t1"), any(), any(), any(), eq(100))).thenReturn(response);
+        when(webhookService.listByTenant(eq("tenant-1"), any(), any(), any(), eq(100))).thenReturn(response);
 
         mockMvc.perform(get("/v1/webhooks")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .param("limit", "999"))
                 .andExpect(status().isOk());
 
-        verify(webhookService).listByTenant(eq("t1"), any(), any(), any(), eq(100));
+        verify(webhookService).listByTenant(eq("tenant-1"), any(), any(), any(), eq(100));
     }
 
     @Test
     void listDeliveries_clampsLimitTo100() throws Exception {
         setupApiKeyAuth();
         WebhookSubscription sub = WebhookSubscription.builder()
-            .subscriptionId("whsub_1").tenantId("t1").url("https://example.com/wh")
+            .subscriptionId("whsub_1").tenantId("tenant-1").url("https://example.com/wh")
             .status(WebhookStatus.ACTIVE).createdAt(Instant.now()).build();
         when(webhookService.get("whsub_1")).thenReturn(sub);
         WebhookDeliveryListResponse response = WebhookDeliveryListResponse.builder()
@@ -301,7 +301,7 @@ class WebhookTenantControllerTest {
         setupApiKeyAuth();
         WebhookListResponse response = WebhookListResponse.builder()
             .subscriptions(List.of()).hasMore(false).build();
-        when(webhookService.listByTenant(eq("t1"), any(), any(), any(), anyInt())).thenReturn(response);
+        when(webhookService.listByTenant(eq("tenant-1"), any(), any(), any(), anyInt())).thenReturn(response);
 
         mockMvc.perform(get("/v1/webhooks")
                         .header("X-Cycles-API-Key", "valid-api-key"))

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/exception/GlobalExceptionHandlerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/exception/GlobalExceptionHandlerTest.java
@@ -40,13 +40,13 @@ class GlobalExceptionHandlerTest {
 
     @Test
     void handleGovernanceException_returnsCorrectStatusAndBody() {
-        GovernanceException ex = GovernanceException.tenantNotFound("t1");
+        GovernanceException ex = GovernanceException.tenantNotFound("tenant-1");
 
         ResponseEntity<ErrorResponse> response = handler.handleGovernanceException(ex, mockRequest);
 
         assertThat(response.getStatusCode().value()).isEqualTo(404);
         assertThat(response.getBody().getError()).isEqualTo(ErrorCode.TENANT_NOT_FOUND);
-        assertThat(response.getBody().getMessage()).contains("t1");
+        assertThat(response.getBody().getMessage()).contains("tenant-1");
         assertThat(response.getBody().getRequestId()).isNotNull();
     }
 
@@ -74,7 +74,7 @@ class GlobalExceptionHandlerTest {
 
     @Test
     void handleGovernanceException_duplicateResource_returns409() {
-        GovernanceException ex = GovernanceException.duplicateResource("Tenant", "t1");
+        GovernanceException ex = GovernanceException.duplicateResource("Tenant", "tenant-1");
 
         ResponseEntity<ErrorResponse> response = handler.handleGovernanceException(ex, mockRequest);
 
@@ -206,7 +206,7 @@ class GlobalExceptionHandlerTest {
 
     @Test
     void resolveRequestId_whenRequestIsNull_returnsUuid() {
-        GovernanceException ex = GovernanceException.tenantNotFound("t1");
+        GovernanceException ex = GovernanceException.tenantNotFound("tenant-1");
 
         ResponseEntity<ErrorResponse> response = handler.handleGovernanceException(ex, null);
 
@@ -219,7 +219,7 @@ class GlobalExceptionHandlerTest {
     @Test
     void resolveRequestId_whenRequestHasNoRequestIdAttribute_returnsUuid() {
         // mockRequest returns null for getAttribute by default (no REQUEST_ID_ATTRIBUTE set)
-        GovernanceException ex = GovernanceException.tenantNotFound("t1");
+        GovernanceException ex = GovernanceException.tenantNotFound("tenant-1");
 
         ResponseEntity<ErrorResponse> response = handler.handleGovernanceException(ex, mockRequest);
 
@@ -232,7 +232,7 @@ class GlobalExceptionHandlerTest {
     void resolveRequestId_whenRequestHasRequestIdAttribute_returnsAttribute() {
         when(mockRequest.getAttribute("requestId")).thenReturn("custom-req-id-123");
 
-        GovernanceException ex = GovernanceException.tenantNotFound("t1");
+        GovernanceException ex = GovernanceException.tenantNotFound("tenant-1");
 
         ResponseEntity<ErrorResponse> response = handler.handleGovernanceException(ex, mockRequest);
 

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/AdminOverviewServiceTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/AdminOverviewServiceTest.java
@@ -42,9 +42,9 @@ class AdminOverviewServiceTest {
     void buildOverview_aggregatesTenantCounts() {
         when(tenantRepository.list(isNull(), isNull(), isNull(), eq(100)))
                 .thenReturn(List.of(
-                        Tenant.builder().tenantId("t1").status(TenantStatus.ACTIVE).build(),
-                        Tenant.builder().tenantId("t2").status(TenantStatus.SUSPENDED).build(),
-                        Tenant.builder().tenantId("t3").status(TenantStatus.CLOSED).build()
+                        Tenant.builder().tenantId("tenant-1").status(TenantStatus.ACTIVE).build(),
+                        Tenant.builder().tenantId("tenant-2").status(TenantStatus.SUSPENDED).build(),
+                        Tenant.builder().tenantId("tenant-3").status(TenantStatus.CLOSED).build()
                 ));
         when(budgetRepository.list(anyString())).thenReturn(List.of());
         when(webhookRepository.listAll(isNull(), isNull(), isNull(), eq(100))).thenReturn(List.of());
@@ -63,7 +63,7 @@ class AdminOverviewServiceTest {
 
     @Test
     void buildOverview_aggregatesBudgetCountsAndTopOffenders() {
-        Tenant tenant = Tenant.builder().tenantId("t1").status(TenantStatus.ACTIVE).build();
+        Tenant tenant = Tenant.builder().tenantId("tenant-1").status(TenantStatus.ACTIVE).build();
         when(tenantRepository.list(isNull(), isNull(), isNull(), eq(100))).thenReturn(List.of(tenant));
 
         BudgetLedger overLimit = BudgetLedger.builder()
@@ -81,7 +81,7 @@ class AdminOverviewServiceTest {
                 .remaining(new Amount(UnitEnum.TOKENS, 3000L))
                 .debt(new Amount(UnitEnum.TOKENS, 0L))
                 .build();
-        when(budgetRepository.list("t1")).thenReturn(List.of(overLimit, normal));
+        when(budgetRepository.list("tenant-1")).thenReturn(List.of(overLimit, normal));
 
         when(webhookRepository.listAll(isNull(), isNull(), isNull(), eq(100))).thenReturn(List.of());
         when(eventRepository.list(isNull(), isNull(), isNull(), isNull(), isNull(), any(Instant.class), any(Instant.class), isNull(), eq(100))).thenReturn(List.of());

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/EventServiceTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/EventServiceTest.java
@@ -31,7 +31,7 @@ class EventServiceTest {
     void emit_savesEventAndDispatches() {
         Event event = Event.builder()
             .eventType(EventType.BUDGET_CREATED)
-            .tenantId("t1")
+            .tenantId("tenant-1")
             .source("test")
             .build();
 
@@ -45,7 +45,7 @@ class EventServiceTest {
     void emit_autoGeneratesEventIdIfNull() {
         Event event = Event.builder()
             .eventType(EventType.BUDGET_CREATED)
-            .tenantId("t1")
+            .tenantId("tenant-1")
             .build();
 
         eventService.emit(event);
@@ -58,7 +58,7 @@ class EventServiceTest {
     void emit_autoSetsTimestampIfNull() {
         Event event = Event.builder()
             .eventType(EventType.BUDGET_CREATED)
-            .tenantId("t1")
+            .tenantId("tenant-1")
             .build();
 
         eventService.emit(event);
@@ -70,7 +70,7 @@ class EventServiceTest {
     void emit_autoSetsCategoryFromEventType() {
         Event event = Event.builder()
             .eventType(EventType.BUDGET_CREATED)
-            .tenantId("t1")
+            .tenantId("tenant-1")
             .build();
 
         eventService.emit(event);
@@ -83,7 +83,7 @@ class EventServiceTest {
         Event event = Event.builder()
             .eventId("evt_existing")
             .eventType(EventType.BUDGET_CREATED)
-            .tenantId("t1")
+            .tenantId("tenant-1")
             .build();
 
         eventService.emit(event);
@@ -95,7 +95,7 @@ class EventServiceTest {
     void emit_doesNotThrowOnRepositoryFailure() {
         Event event = Event.builder()
             .eventType(EventType.BUDGET_CREATED)
-            .tenantId("t1")
+            .tenantId("tenant-1")
             .build();
         doThrow(new RuntimeException("DB down")).when(eventRepository).save(any());
 
@@ -109,7 +109,7 @@ class EventServiceTest {
     void emit_doesNotThrowOnDispatchFailure() {
         Event event = Event.builder()
             .eventType(EventType.BUDGET_CREATED)
-            .tenantId("t1")
+            .tenantId("tenant-1")
             .build();
         doThrow(new RuntimeException("Dispatch failed")).when(webhookDispatchService).dispatch(any());
 
@@ -189,12 +189,12 @@ class EventServiceTest {
 
     @Test
     void emit_convenienceOverload_buildsAndEmitsEvent() {
-        eventService.emit(EventType.TENANT_CREATED, "t1", "scope1", "admin",
+        eventService.emit(EventType.TENANT_CREATED, "tenant-1", "scope1", "admin",
             Actor.builder().build(), Map.of("key", "val"), "corr1", "req1");
 
         verify(eventRepository).save(argThat(event ->
             event.getEventType() == EventType.TENANT_CREATED &&
-            "t1".equals(event.getTenantId()) &&
+            "tenant-1".equals(event.getTenantId()) &&
             EventCategory.TENANT == event.getCategory()));
         verify(webhookDispatchService).dispatch(any());
     }
@@ -203,7 +203,7 @@ class EventServiceTest {
     void emit_success_incrementsEmittedCounterWithSuccessTag() {
         Event event = Event.builder()
             .eventType(EventType.BUDGET_CREATED)
-            .tenantId("t1")
+            .tenantId("tenant-1")
             .build();
 
         eventService.emit(event);
@@ -217,7 +217,7 @@ class EventServiceTest {
     void emit_failure_incrementsEmittedCounterWithFailureTag() {
         Event event = Event.builder()
             .eventType(EventType.BUDGET_CREATED)
-            .tenantId("t1")
+            .tenantId("tenant-1")
             .build();
         doThrow(new RuntimeException("DB down")).when(eventRepository).save(any());
 

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookDispatchServiceTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookDispatchServiceTest.java
@@ -48,7 +48,7 @@ class WebhookDispatchServiceTest {
         return Event.builder()
             .eventId("evt_1")
             .eventType(EventType.BUDGET_CREATED)
-            .tenantId("t1")
+            .tenantId("tenant-1")
             .scope("org/team1")
             .timestamp(Instant.now())
             .build();
@@ -57,7 +57,7 @@ class WebhookDispatchServiceTest {
     private WebhookSubscription buildSubscription(String subId) {
         return WebhookSubscription.builder()
             .subscriptionId(subId)
-            .tenantId("t1")
+            .tenantId("tenant-1")
             .url("https://example.com/webhook")
             .eventTypes(List.of(EventType.BUDGET_CREATED))
             .signingSecret("whsec_test")
@@ -70,7 +70,7 @@ class WebhookDispatchServiceTest {
     void dispatch_findsMatchingSubscriptionsAndCreatesDelivery() {
         Event event = buildEvent();
         WebhookSubscription sub = buildSubscription("whsub_1");
-        when(webhookRepository.findMatchingSubscriptions("t1", EventType.BUDGET_CREATED, "org/team1"))
+        when(webhookRepository.findMatchingSubscriptions("tenant-1", EventType.BUDGET_CREATED, "org/team1"))
             .thenReturn(List.of(sub));
 
         webhookDispatchService.dispatch(event);
@@ -85,7 +85,7 @@ class WebhookDispatchServiceTest {
         Event event = buildEvent();
         WebhookSubscription sub1 = buildSubscription("whsub_1");
         WebhookSubscription sub2 = buildSubscription("whsub_2");
-        when(webhookRepository.findMatchingSubscriptions("t1", EventType.BUDGET_CREATED, "org/team1"))
+        when(webhookRepository.findMatchingSubscriptions("tenant-1", EventType.BUDGET_CREATED, "org/team1"))
             .thenReturn(List.of(sub1, sub2));
 
         webhookDispatchService.dispatch(event);
@@ -106,7 +106,7 @@ class WebhookDispatchServiceTest {
     @Test
     void dispatch_handlesEmptySubscriptionList() {
         Event event = buildEvent();
-        when(webhookRepository.findMatchingSubscriptions("t1", EventType.BUDGET_CREATED, "org/team1"))
+        when(webhookRepository.findMatchingSubscriptions("tenant-1", EventType.BUDGET_CREATED, "org/team1"))
             .thenReturn(List.of());
 
         webhookDispatchService.dispatch(event);
@@ -119,7 +119,7 @@ class WebhookDispatchServiceTest {
         Event event = buildEvent();
         WebhookSubscription sub1 = buildSubscription("whsub_1");
         WebhookSubscription sub2 = buildSubscription("whsub_2");
-        when(webhookRepository.findMatchingSubscriptions("t1", EventType.BUDGET_CREATED, "org/team1"))
+        when(webhookRepository.findMatchingSubscriptions("tenant-1", EventType.BUDGET_CREATED, "org/team1"))
             .thenReturn(List.of(sub1, sub2));
         doThrow(new RuntimeException("Delivery failed")).when(deliveryRepository).save(argThat(d ->
             "whsub_1".equals(d.getSubscriptionId())));
@@ -172,7 +172,7 @@ class WebhookDispatchServiceTest {
     void dispatch_success_incrementsQueuedCounter() {
         Event event = buildEvent();
         WebhookSubscription sub = buildSubscription("whsub_1");
-        when(webhookRepository.findMatchingSubscriptions("t1", EventType.BUDGET_CREATED, "org/team1"))
+        when(webhookRepository.findMatchingSubscriptions("tenant-1", EventType.BUDGET_CREATED, "org/team1"))
             .thenReturn(List.of(sub));
 
         webhookDispatchService.dispatch(event);

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookServiceTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookServiceTest.java
@@ -60,7 +60,7 @@ class WebhookServiceTest {
     void create_generatesSubscriptionIdAndSigningSecret() {
         WebhookCreateRequest request = createRequest();
 
-        WebhookCreateResponse response = webhookService.create("t1", request);
+        WebhookCreateResponse response = webhookService.create("tenant-1", request);
 
         assertThat(response.getSubscription().getSubscriptionId()).startsWith("whsub_");
         assertThat(response.getSigningSecret()).startsWith("whsec_");
@@ -73,7 +73,7 @@ class WebhookServiceTest {
         WebhookCreateRequest request = createRequest();
         request.setSigningSecret("whsec_custom");
 
-        WebhookCreateResponse response = webhookService.create("t1", request);
+        WebhookCreateResponse response = webhookService.create("tenant-1", request);
 
         assertThat(response.getSigningSecret()).isEqualTo("whsec_custom");
     }
@@ -82,7 +82,7 @@ class WebhookServiceTest {
     void create_returnsResponseWithSecret() {
         WebhookCreateRequest request = createRequest();
 
-        WebhookCreateResponse response = webhookService.create("t1", request);
+        WebhookCreateResponse response = webhookService.create("tenant-1", request);
 
         assertThat(response.getSubscription()).isNotNull();
         assertThat(response.getSigningSecret()).isNotNull();
@@ -90,7 +90,7 @@ class WebhookServiceTest {
 
     @Test
     void get_masksSigningSecretAndHeaders() {
-        WebhookSubscription sub = buildSubscription("whsub_1", "t1");
+        WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1");
         when(webhookRepository.findById("whsub_1")).thenReturn(sub);
 
         WebhookSubscription result = webhookService.get("whsub_1");
@@ -101,7 +101,7 @@ class WebhookServiceTest {
 
     @Test
     void get_noHeaders_masksOnlySecret() {
-        WebhookSubscription sub = buildSubscription("whsub_1", "t1");
+        WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1");
         sub.setHeaders(null);
         when(webhookRepository.findById("whsub_1")).thenReturn(sub);
 
@@ -113,7 +113,7 @@ class WebhookServiceTest {
 
     @Test
     void update_partialUpdate_onlyModifiesProvidedFields() {
-        WebhookSubscription existing = buildSubscription("whsub_1", "t1");
+        WebhookSubscription existing = buildSubscription("whsub_1", "tenant-1");
         existing.setName("Original");
         when(webhookRepository.findById("whsub_1")).thenReturn(existing);
 
@@ -130,7 +130,7 @@ class WebhookServiceTest {
 
     @Test
     void update_resetsConsecutiveFailuresOnActiveStatus() {
-        WebhookSubscription existing = buildSubscription("whsub_1", "t1");
+        WebhookSubscription existing = buildSubscription("whsub_1", "tenant-1");
         existing.setConsecutiveFailures(5);
         existing.setStatus(WebhookStatus.DISABLED);
         when(webhookRepository.findById("whsub_1")).thenReturn(existing);
@@ -146,7 +146,7 @@ class WebhookServiceTest {
 
     @Test
     void update_rejectsDisabledStatus() {
-        WebhookSubscription existing = buildSubscription("whsub_1", "t1");
+        WebhookSubscription existing = buildSubscription("whsub_1", "tenant-1");
         when(webhookRepository.findById("whsub_1")).thenReturn(existing);
 
         WebhookUpdateRequest request = WebhookUpdateRequest.builder()
@@ -160,7 +160,7 @@ class WebhookServiceTest {
 
     @Test
     void update_validatesUrlIfProvided() {
-        WebhookSubscription existing = buildSubscription("whsub_1", "t1");
+        WebhookSubscription existing = buildSubscription("whsub_1", "tenant-1");
         when(webhookRepository.findById("whsub_1")).thenReturn(existing);
 
         WebhookUpdateRequest request = WebhookUpdateRequest.builder()
@@ -183,7 +183,7 @@ class WebhookServiceTest {
 
     @Test
     void delete_deletesIfFound() {
-        WebhookSubscription existing = buildSubscription("whsub_1", "t1");
+        WebhookSubscription existing = buildSubscription("whsub_1", "tenant-1");
         when(webhookRepository.findById("whsub_1")).thenReturn(existing);
 
         webhookService.delete("whsub_1");
@@ -193,7 +193,7 @@ class WebhookServiceTest {
 
     @Test
     void test_returnsWebhookTestResponse() throws Exception {
-        WebhookSubscription sub = buildSubscription("whsub_1", "t1");
+        WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1");
         when(webhookRepository.findById("whsub_1")).thenReturn(sub);
         when(webhookRepository.getSigningSecret("whsub_1")).thenReturn("test-secret");
         when(objectMapper.writeValueAsString(any())).thenReturn("{\"test\":true}");
@@ -211,11 +211,11 @@ class WebhookServiceTest {
 
     @Test
     void listByTenant_delegatesAndMasksSecrets() {
-        WebhookSubscription sub = buildSubscription("whsub_1", "t1");
-        when(webhookRepository.listByTenant("t1", null, null, null, 50))
+        WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1");
+        when(webhookRepository.listByTenant("tenant-1", null, null, null, 50))
             .thenReturn(List.of(sub));
 
-        WebhookListResponse response = webhookService.listByTenant("t1", null, null, null, 50);
+        WebhookListResponse response = webhookService.listByTenant("tenant-1", null, null, null, 50);
 
         assertThat(response.getSubscriptions()).hasSize(1);
         assertThat(response.getSubscriptions().get(0).getSigningSecret()).isNull();
@@ -223,22 +223,22 @@ class WebhookServiceTest {
 
     @Test
     void listAll_withTenantId_delegatesToListByTenant() {
-        WebhookSubscription sub1 = buildSubscription("whsub_1", "t1");
-        when(webhookRepository.listByTenant("t1", null, null, null, 50))
+        WebhookSubscription sub1 = buildSubscription("whsub_1", "tenant-1");
+        when(webhookRepository.listByTenant("tenant-1", null, null, null, 50))
             .thenReturn(List.of(sub1));
 
-        WebhookListResponse response = webhookService.listAll("t1", null, null, null, 50);
+        WebhookListResponse response = webhookService.listAll("tenant-1", null, null, null, 50);
 
         assertThat(response.getSubscriptions()).hasSize(1);
-        assertThat(response.getSubscriptions().get(0).getTenantId()).isEqualTo("t1");
-        verify(webhookRepository).listByTenant("t1", null, null, null, 50);
+        assertThat(response.getSubscriptions().get(0).getTenantId()).isEqualTo("tenant-1");
+        verify(webhookRepository).listByTenant("tenant-1", null, null, null, 50);
         verify(webhookRepository, never()).listAll(any(), any(), any(), anyInt());
     }
 
     @Test
     void listAll_noTenantFilter_returnsAll() {
-        WebhookSubscription sub1 = buildSubscription("whsub_1", "t1");
-        WebhookSubscription sub2 = buildSubscription("whsub_2", "t2");
+        WebhookSubscription sub1 = buildSubscription("whsub_1", "tenant-1");
+        WebhookSubscription sub2 = buildSubscription("whsub_2", "tenant-2");
         when(webhookRepository.listAll(null, null, null, 50))
             .thenReturn(List.of(sub1, sub2));
 
@@ -258,7 +258,7 @@ class WebhookServiceTest {
 
     @Test
     void listDeliveries_returnsDeliveries() {
-        WebhookSubscription sub = buildSubscription("whsub_1", "t1");
+        WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1");
         when(webhookRepository.findById("whsub_1")).thenReturn(sub);
         WebhookDelivery delivery = WebhookDelivery.builder()
             .deliveryId("del_1").subscriptionId("whsub_1").eventId("evt_1")
@@ -273,10 +273,10 @@ class WebhookServiceTest {
 
     @Test
     void replay_noEvents_returnsZeroQueued() {
-        WebhookSubscription sub = buildSubscription("whsub_1", "t1");
+        WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1");
         when(webhookRepository.findById("whsub_1")).thenReturn(sub);
         when(webhookRepository.acquireReplayLock(eq("whsub_1"), any())).thenReturn(true);
-        when(eventRepository.list(eq("t1"), any(), any(), any(), any(), any(), any(), any(), anyInt()))
+        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt()))
             .thenReturn(List.of());
 
         ReplayRequest request = ReplayRequest.builder()
@@ -292,14 +292,14 @@ class WebhookServiceTest {
 
     @Test
     void replay_withEvents_queuesDeliveries() {
-        WebhookSubscription sub = buildSubscription("whsub_1", "t1");
+        WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1");
         when(webhookRepository.findById("whsub_1")).thenReturn(sub);
         when(webhookRepository.acquireReplayLock(eq("whsub_1"), any())).thenReturn(true);
         io.runcycles.admin.model.event.Event event = io.runcycles.admin.model.event.Event.builder()
             .eventId("evt_1").eventType(io.runcycles.admin.model.event.EventType.BUDGET_CREATED)
             .category(io.runcycles.admin.model.event.EventCategory.BUDGET)
-            .tenantId("t1").source("admin").timestamp(Instant.now()).build();
-        when(eventRepository.list(eq("t1"), any(), any(), any(), any(), any(), any(), any(), anyInt()))
+            .tenantId("tenant-1").source("admin").timestamp(Instant.now()).build();
+        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt()))
             .thenReturn(List.of(event));
 
         ReplayRequest request = ReplayRequest.builder()
@@ -316,18 +316,18 @@ class WebhookServiceTest {
 
     @Test
     void replay_withEventTypeFilter_filtersEvents() {
-        WebhookSubscription sub = buildSubscription("whsub_1", "t1");
+        WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1");
         when(webhookRepository.findById("whsub_1")).thenReturn(sub);
         when(webhookRepository.acquireReplayLock(eq("whsub_1"), any())).thenReturn(true);
         io.runcycles.admin.model.event.Event budgetEvt = io.runcycles.admin.model.event.Event.builder()
             .eventId("evt_1").eventType(io.runcycles.admin.model.event.EventType.BUDGET_CREATED)
             .category(io.runcycles.admin.model.event.EventCategory.BUDGET)
-            .tenantId("t1").source("admin").timestamp(Instant.now()).build();
+            .tenantId("tenant-1").source("admin").timestamp(Instant.now()).build();
         io.runcycles.admin.model.event.Event tenantEvt = io.runcycles.admin.model.event.Event.builder()
             .eventId("evt_2").eventType(io.runcycles.admin.model.event.EventType.TENANT_CREATED)
             .category(io.runcycles.admin.model.event.EventCategory.TENANT)
-            .tenantId("t1").source("admin").timestamp(Instant.now()).build();
-        when(eventRepository.list(eq("t1"), any(), any(), any(), any(), any(), any(), any(), anyInt()))
+            .tenantId("tenant-1").source("admin").timestamp(Instant.now()).build();
+        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt()))
             .thenReturn(List.of(budgetEvt, tenantEvt));
 
         ReplayRequest request = ReplayRequest.builder()
@@ -368,7 +368,7 @@ class WebhookServiceTest {
 
     @Test
     void test_withNoSigningSecret_stillWorks() throws Exception {
-        WebhookSubscription sub = buildSubscription("whsub_1", "t1");
+        WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1");
         when(webhookRepository.findById("whsub_1")).thenReturn(sub);
         when(webhookRepository.getSigningSecret("whsub_1")).thenReturn(null);
         when(objectMapper.writeValueAsString(any())).thenReturn("{\"test\":true}");
@@ -381,7 +381,7 @@ class WebhookServiceTest {
 
     @Test
     void test_serializationError_returnsFailure() throws Exception {
-        WebhookSubscription sub = buildSubscription("whsub_1", "t1");
+        WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1");
         when(webhookRepository.findById("whsub_1")).thenReturn(sub);
         when(webhookRepository.getSigningSecret("whsub_1")).thenReturn("secret");
         when(objectMapper.writeValueAsString(any()))
@@ -396,15 +396,15 @@ class WebhookServiceTest {
 
     @Test
     void replay_withEventTypeFilter_filtersCorrectly() {
-        WebhookSubscription sub = buildSubscription("whsub_1", "t1");
+        WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1");
         when(webhookRepository.findById("whsub_1")).thenReturn(sub);
         when(webhookRepository.acquireReplayLock(eq("whsub_1"), any())).thenReturn(true);
 
         io.runcycles.admin.model.event.Event evt1 = io.runcycles.admin.model.event.Event.builder()
-            .eventId("evt_1").eventType(EventType.BUDGET_CREATED).tenantId("t1")
+            .eventId("evt_1").eventType(EventType.BUDGET_CREATED).tenantId("tenant-1")
             .timestamp(Instant.now()).build();
         io.runcycles.admin.model.event.Event evt2 = io.runcycles.admin.model.event.Event.builder()
-            .eventId("evt_2").eventType(EventType.TENANT_CREATED).tenantId("t1")
+            .eventId("evt_2").eventType(EventType.TENANT_CREATED).tenantId("tenant-1")
             .timestamp(Instant.now()).build();
 
         when(eventRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), anyInt()))
@@ -425,15 +425,15 @@ class WebhookServiceTest {
 
     @Test
     void replay_dispatchFailure_continuesAndCounts() {
-        WebhookSubscription sub = buildSubscription("whsub_1", "t1");
+        WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1");
         when(webhookRepository.findById("whsub_1")).thenReturn(sub);
         when(webhookRepository.acquireReplayLock(eq("whsub_1"), any())).thenReturn(true);
 
         io.runcycles.admin.model.event.Event evt1 = io.runcycles.admin.model.event.Event.builder()
-            .eventId("evt_1").eventType(EventType.BUDGET_CREATED).tenantId("t1")
+            .eventId("evt_1").eventType(EventType.BUDGET_CREATED).tenantId("tenant-1")
             .timestamp(Instant.now()).build();
         io.runcycles.admin.model.event.Event evt2 = io.runcycles.admin.model.event.Event.builder()
-            .eventId("evt_2").eventType(EventType.BUDGET_FUNDED).tenantId("t1")
+            .eventId("evt_2").eventType(EventType.BUDGET_FUNDED).tenantId("tenant-1")
             .timestamp(Instant.now()).build();
 
         when(eventRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), anyInt()))
@@ -455,7 +455,7 @@ class WebhookServiceTest {
 
     @Test
     void replay_lockAlreadyHeld_throws409() {
-        WebhookSubscription sub = buildSubscription("whsub_1", "t1");
+        WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1");
         when(webhookRepository.findById("whsub_1")).thenReturn(sub);
         when(webhookRepository.acquireReplayLock(eq("whsub_1"), any())).thenReturn(false);
 
@@ -472,10 +472,10 @@ class WebhookServiceTest {
 
     @Test
     void replay_releasesLockAfterCompletion() {
-        WebhookSubscription sub = buildSubscription("whsub_1", "t1");
+        WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1");
         when(webhookRepository.findById("whsub_1")).thenReturn(sub);
         when(webhookRepository.acquireReplayLock(eq("whsub_1"), any())).thenReturn(true);
-        when(eventRepository.list(eq("t1"), any(), any(), any(), any(), any(), any(), any(), anyInt()))
+        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt()))
             .thenReturn(List.of());
 
         ReplayRequest request = ReplayRequest.builder()
@@ -490,7 +490,7 @@ class WebhookServiceTest {
 
     @Test
     void update_statusDisabled_throws() {
-        WebhookSubscription existing = buildSubscription("whsub_1", "t1");
+        WebhookSubscription existing = buildSubscription("whsub_1", "tenant-1");
         when(webhookRepository.findById("whsub_1")).thenReturn(existing);
 
         WebhookUpdateRequest request = WebhookUpdateRequest.builder()
@@ -504,7 +504,7 @@ class WebhookServiceTest {
 
     @Test
     void update_statusActive_resetsConsecutiveFailures() {
-        WebhookSubscription existing = buildSubscription("whsub_1", "t1");
+        WebhookSubscription existing = buildSubscription("whsub_1", "tenant-1");
         existing.setConsecutiveFailures(5);
         existing.setStatus(WebhookStatus.PAUSED);
         when(webhookRepository.findById("whsub_1")).thenReturn(existing);
@@ -526,12 +526,12 @@ class WebhookServiceTest {
     void listAll_withTenantFilter_paginatesCorrectly() {
         // Verifies fix for #57: tenant filter now uses tenant-specific Redis set
         // so hasMore and nextCursor reflect tenant-scoped pagination
-        WebhookSubscription sub1 = buildSubscription("whsub_1", "t1");
-        WebhookSubscription sub2 = buildSubscription("whsub_2", "t1");
-        when(webhookRepository.listByTenant("t1", null, null, null, 2))
+        WebhookSubscription sub1 = buildSubscription("whsub_1", "tenant-1");
+        WebhookSubscription sub2 = buildSubscription("whsub_2", "tenant-1");
+        when(webhookRepository.listByTenant("tenant-1", null, null, null, 2))
             .thenReturn(List.of(sub1, sub2));
 
-        WebhookListResponse response = webhookService.listAll("t1", null, null, null, 2);
+        WebhookListResponse response = webhookService.listAll("tenant-1", null, null, null, 2);
 
         assertThat(response.getSubscriptions()).hasSize(2);
         assertThat(response.isHasMore()).isTrue();

--- a/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/ApiKeyRepositoryTest.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/ApiKeyRepositoryTest.java
@@ -154,7 +154,7 @@ class ApiKeyRepositoryTest {
         when(jedis.get("apikey:lookup:cyc_live_abc12")).thenReturn("key_123");
 
         ApiKey key = ApiKey.builder()
-                .keyId("key_123").tenantId("t1").keyPrefix("cyc_live_abc12")
+                .keyId("key_123").tenantId("tenant-1").keyPrefix("cyc_live_abc12")
                 .keyHash("$2a$12$hash").status(ApiKeyStatus.ACTIVE)
                 .permissions(List.of("balances:read"))
                 .expiresAt(Instant.now().plusSeconds(3600))
@@ -163,12 +163,12 @@ class ApiKeyRepositoryTest {
         when(jedis.get("apikey:key_123")).thenReturn(keyJson);
 
         when(keyService.verifyKey(keySecret, "$2a$12$hash")).thenReturn(true);
-        when(jedis.get("tenant:t1")).thenReturn("{\"status\":\"ACTIVE\"}");
+        when(jedis.get("tenant:tenant-1")).thenReturn("{\"status\":\"ACTIVE\"}");
 
         ApiKeyValidationResponse response = repository.validate(keySecret);
 
         assertThat(response.getValid()).isTrue();
-        assertThat(response.getTenantId()).isEqualTo("t1");
+        assertThat(response.getTenantId()).isEqualTo("tenant-1");
         assertThat(response.getKeyId()).isEqualTo("key_123");
     }
 
@@ -189,7 +189,7 @@ class ApiKeyRepositoryTest {
         when(jedis.get("apikey:lookup:cyc_live_revok")).thenReturn("key_rev");
 
         ApiKey key = ApiKey.builder()
-                .keyId("key_rev").tenantId("t1").keyHash("hash")
+                .keyId("key_rev").tenantId("tenant-1").keyHash("hash")
                 .status(ApiKeyStatus.REVOKED).createdAt(Instant.now()).build();
         String keyJson = objectMapper.writeValueAsString(key);
         when(jedis.get("apikey:key_rev")).thenReturn(keyJson);
@@ -206,7 +206,7 @@ class ApiKeyRepositoryTest {
         when(jedis.get("apikey:lookup:cyc_live_expir")).thenReturn("key_exp");
 
         ApiKey key = ApiKey.builder()
-                .keyId("key_exp").tenantId("t1").keyHash("hash")
+                .keyId("key_exp").tenantId("tenant-1").keyHash("hash")
                 .status(ApiKeyStatus.ACTIVE)
                 .expiresAt(Instant.now().minusSeconds(3600))
                 .createdAt(Instant.now()).build();
@@ -225,7 +225,7 @@ class ApiKeyRepositoryTest {
         when(jedis.get("apikey:lookup:cyc_live_wrong")).thenReturn("key_w");
 
         ApiKey key = ApiKey.builder()
-                .keyId("key_w").tenantId("t1").keyHash("$2a$12$real")
+                .keyId("key_w").tenantId("tenant-1").keyHash("$2a$12$real")
                 .status(ApiKeyStatus.ACTIVE)
                 .expiresAt(Instant.now().plusSeconds(3600))
                 .createdAt(Instant.now()).build();
@@ -245,14 +245,14 @@ class ApiKeyRepositoryTest {
         when(jedis.get("apikey:lookup:cyc_live_susp1")).thenReturn("key_s");
 
         ApiKey key = ApiKey.builder()
-                .keyId("key_s").tenantId("t1").keyHash("$2a$12$hash")
+                .keyId("key_s").tenantId("tenant-1").keyHash("$2a$12$hash")
                 .status(ApiKeyStatus.ACTIVE)
                 .expiresAt(Instant.now().plusSeconds(3600))
                 .createdAt(Instant.now()).build();
         String keyJson = objectMapper.writeValueAsString(key);
         when(jedis.get("apikey:key_s")).thenReturn(keyJson);
         when(keyService.verifyKey("cyc_live_susp", "$2a$12$hash")).thenReturn(true);
-        when(jedis.get("tenant:t1")).thenReturn("{\"status\":\"SUSPENDED\"}");
+        when(jedis.get("tenant:tenant-1")).thenReturn("{\"status\":\"SUSPENDED\"}");
 
         ApiKeyValidationResponse response = repository.validate("cyc_live_susp");
 
@@ -266,14 +266,14 @@ class ApiKeyRepositoryTest {
         when(jedis.get("apikey:lookup:cyc_live_close")).thenReturn("key_c");
 
         ApiKey key = ApiKey.builder()
-                .keyId("key_c").tenantId("t1").keyHash("$2a$12$hash")
+                .keyId("key_c").tenantId("tenant-1").keyHash("$2a$12$hash")
                 .status(ApiKeyStatus.ACTIVE)
                 .expiresAt(Instant.now().plusSeconds(3600))
                 .createdAt(Instant.now()).build();
         String keyJson = objectMapper.writeValueAsString(key);
         when(jedis.get("apikey:key_c")).thenReturn(keyJson);
         when(keyService.verifyKey("cyc_live_closed", "$2a$12$hash")).thenReturn(true);
-        when(jedis.get("tenant:t1")).thenReturn("{\"status\":\"CLOSED\"}");
+        when(jedis.get("tenant:tenant-1")).thenReturn("{\"status\":\"CLOSED\"}");
 
         ApiKeyValidationResponse response = repository.validate("cyc_live_closed");
 
@@ -284,7 +284,7 @@ class ApiKeyRepositoryTest {
     @Test
     void revoke_existingKey_setsRevokedStatus() throws Exception {
         ApiKey revoked = ApiKey.builder()
-                .keyId("key_1").tenantId("t1").keyHash("hash")
+                .keyId("key_1").tenantId("tenant-1").keyHash("hash")
                 .status(ApiKeyStatus.REVOKED).revokedReason("No longer needed")
                 .revokedAt(Instant.now()).createdAt(Instant.now()).build();
         String revokedJson = objectMapper.writeValueAsString(revoked);
@@ -312,16 +312,16 @@ class ApiKeyRepositoryTest {
     @Test
     void list_returnsKeysForTenant() throws Exception {
         Set<String> ids = new LinkedHashSet<>(List.of("key_1", "key_2"));
-        when(jedis.smembers("apikeys:t1")).thenReturn(ids);
+        when(jedis.smembers("apikeys:tenant-1")).thenReturn(ids);
 
-        ApiKey k1 = ApiKey.builder().keyId("key_1").tenantId("t1").keyHash("h1").status(ApiKeyStatus.ACTIVE).createdAt(Instant.now()).build();
-        ApiKey k2 = ApiKey.builder().keyId("key_2").tenantId("t1").keyHash("h2").status(ApiKeyStatus.REVOKED).createdAt(Instant.now()).build();
+        ApiKey k1 = ApiKey.builder().keyId("key_1").tenantId("tenant-1").keyHash("h1").status(ApiKeyStatus.ACTIVE).createdAt(Instant.now()).build();
+        ApiKey k2 = ApiKey.builder().keyId("key_2").tenantId("tenant-1").keyHash("h2").status(ApiKeyStatus.REVOKED).createdAt(Instant.now()).build();
         String k1Json = objectMapper.writeValueAsString(k1);
         String k2Json = objectMapper.writeValueAsString(k2);
         when(jedis.get("apikey:key_1")).thenReturn(k1Json);
         when(jedis.get("apikey:key_2")).thenReturn(k2Json);
 
-        List<ApiKey> result = repository.list("t1", null, null, 50);
+        List<ApiKey> result = repository.list("tenant-1", null, null, 50);
 
         assertThat(result).hasSize(2);
     }
@@ -329,16 +329,16 @@ class ApiKeyRepositoryTest {
     @Test
     void list_filtersKeysByStatus() throws Exception {
         Set<String> ids = new LinkedHashSet<>(List.of("key_1", "key_2"));
-        when(jedis.smembers("apikeys:t1")).thenReturn(ids);
+        when(jedis.smembers("apikeys:tenant-1")).thenReturn(ids);
 
-        ApiKey k1 = ApiKey.builder().keyId("key_1").tenantId("t1").keyHash("h1").status(ApiKeyStatus.ACTIVE).createdAt(Instant.now()).build();
-        ApiKey k2 = ApiKey.builder().keyId("key_2").tenantId("t1").keyHash("h2").status(ApiKeyStatus.REVOKED).createdAt(Instant.now()).build();
+        ApiKey k1 = ApiKey.builder().keyId("key_1").tenantId("tenant-1").keyHash("h1").status(ApiKeyStatus.ACTIVE).createdAt(Instant.now()).build();
+        ApiKey k2 = ApiKey.builder().keyId("key_2").tenantId("tenant-1").keyHash("h2").status(ApiKeyStatus.REVOKED).createdAt(Instant.now()).build();
         String k1Json = objectMapper.writeValueAsString(k1);
         String k2Json = objectMapper.writeValueAsString(k2);
         when(jedis.get("apikey:key_1")).thenReturn(k1Json);
         when(jedis.get("apikey:key_2")).thenReturn(k2Json);
 
-        List<ApiKey> result = repository.list("t1", ApiKeyStatus.ACTIVE, null, 50);
+        List<ApiKey> result = repository.list("tenant-1", ApiKeyStatus.ACTIVE, null, 50);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getKeyId()).isEqualTo("key_1");
@@ -347,16 +347,16 @@ class ApiKeyRepositoryTest {
     @Test
     void list_cursorPagination_skipsEntriesBeforeCursor() throws Exception {
         Set<String> ids = new LinkedHashSet<>(List.of("key_1", "key_2", "key_3"));
-        when(jedis.smembers("apikeys:t1")).thenReturn(ids);
+        when(jedis.smembers("apikeys:tenant-1")).thenReturn(ids);
 
-        ApiKey k2 = ApiKey.builder().keyId("key_2").tenantId("t1").keyHash("h2").status(ApiKeyStatus.ACTIVE).createdAt(Instant.now()).build();
-        ApiKey k3 = ApiKey.builder().keyId("key_3").tenantId("t1").keyHash("h3").status(ApiKeyStatus.ACTIVE).createdAt(Instant.now()).build();
+        ApiKey k2 = ApiKey.builder().keyId("key_2").tenantId("tenant-1").keyHash("h2").status(ApiKeyStatus.ACTIVE).createdAt(Instant.now()).build();
+        ApiKey k3 = ApiKey.builder().keyId("key_3").tenantId("tenant-1").keyHash("h3").status(ApiKeyStatus.ACTIVE).createdAt(Instant.now()).build();
         String k2Json = objectMapper.writeValueAsString(k2);
         String k3Json = objectMapper.writeValueAsString(k3);
         when(jedis.get("apikey:key_2")).thenReturn(k2Json);
         when(jedis.get("apikey:key_3")).thenReturn(k3Json);
 
-        List<ApiKey> result = repository.list("t1", null, "key_1", 50);
+        List<ApiKey> result = repository.list("tenant-1", null, "key_1", 50);
 
         assertThat(result).hasSize(2);
         assertThat(result.get(0).getKeyId()).isEqualTo("key_2");
@@ -365,13 +365,13 @@ class ApiKeyRepositoryTest {
     @Test
     void list_respectsLimit() throws Exception {
         Set<String> ids = new LinkedHashSet<>(List.of("key_1", "key_2", "key_3"));
-        when(jedis.smembers("apikeys:t1")).thenReturn(ids);
+        when(jedis.smembers("apikeys:tenant-1")).thenReturn(ids);
 
-        ApiKey k1 = ApiKey.builder().keyId("key_1").tenantId("t1").keyHash("h1").status(ApiKeyStatus.ACTIVE).createdAt(Instant.now()).build();
+        ApiKey k1 = ApiKey.builder().keyId("key_1").tenantId("tenant-1").keyHash("h1").status(ApiKeyStatus.ACTIVE).createdAt(Instant.now()).build();
         String k1Json = objectMapper.writeValueAsString(k1);
         when(jedis.get("apikey:key_1")).thenReturn(k1Json);
 
-        List<ApiKey> result = repository.list("t1", null, null, 1);
+        List<ApiKey> result = repository.list("tenant-1", null, null, 1);
 
         assertThat(result).hasSize(1);
     }
@@ -379,14 +379,14 @@ class ApiKeyRepositoryTest {
     @Test
     void list_missingKeyData_skipsGracefully() throws Exception {
         Set<String> ids = new LinkedHashSet<>(List.of("key_1", "key_2"));
-        when(jedis.smembers("apikeys:t1")).thenReturn(ids);
+        when(jedis.smembers("apikeys:tenant-1")).thenReturn(ids);
 
         when(jedis.get("apikey:key_1")).thenReturn(null);
-        ApiKey k2 = ApiKey.builder().keyId("key_2").tenantId("t1").keyHash("h2").status(ApiKeyStatus.ACTIVE).createdAt(Instant.now()).build();
+        ApiKey k2 = ApiKey.builder().keyId("key_2").tenantId("tenant-1").keyHash("h2").status(ApiKeyStatus.ACTIVE).createdAt(Instant.now()).build();
         String k2Json = objectMapper.writeValueAsString(k2);
         when(jedis.get("apikey:key_2")).thenReturn(k2Json);
 
-        List<ApiKey> result = repository.list("t1", null, null, 50);
+        List<ApiKey> result = repository.list("tenant-1", null, null, 50);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getKeyId()).isEqualTo("key_2");
@@ -394,27 +394,27 @@ class ApiKeyRepositoryTest {
 
     @Test
     void list_emptyKeySet_returnsEmptyList() {
-        when(jedis.smembers("apikeys:t1")).thenReturn(Collections.emptySet());
+        when(jedis.smembers("apikeys:tenant-1")).thenReturn(Collections.emptySet());
 
-        List<ApiKey> result = repository.list("t1", null, null, 50);
+        List<ApiKey> result = repository.list("tenant-1", null, null, 50);
 
         assertThat(result).isEmpty();
     }
 
     @Test
     void list_convenienceMethod_callsFullListWithDefaults() {
-        when(jedis.smembers("apikeys:t1")).thenReturn(Collections.emptySet());
+        when(jedis.smembers("apikeys:tenant-1")).thenReturn(Collections.emptySet());
 
-        List<ApiKey> result = repository.list("t1");
+        List<ApiKey> result = repository.list("tenant-1");
 
         assertThat(result).isEmpty();
-        verify(jedis).smembers("apikeys:t1");
+        verify(jedis).smembers("apikeys:tenant-1");
     }
 
     @Test
     void revoke_alreadyRevoked_returnsRevokedKey() throws Exception {
         ApiKey revoked = ApiKey.builder()
-                .keyId("key_1").tenantId("t1").keyHash("hash")
+                .keyId("key_1").tenantId("tenant-1").keyHash("hash")
                 .status(ApiKeyStatus.REVOKED).revokedAt(Instant.now())
                 .createdAt(Instant.now()).build();
         String revokedJson = objectMapper.writeValueAsString(revoked);
@@ -497,14 +497,14 @@ class ApiKeyRepositoryTest {
         when(jedis.get("apikey:lookup:cyc_live_noper")).thenReturn("key_np");
 
         ApiKey key = ApiKey.builder()
-                .keyId("key_np").tenantId("t1").keyHash("$2a$12$hash")
+                .keyId("key_np").tenantId("tenant-1").keyHash("$2a$12$hash")
                 .status(ApiKeyStatus.ACTIVE).permissions(null)
                 .expiresAt(Instant.now().plusSeconds(3600))
                 .createdAt(Instant.now()).build();
         String keyJson = objectMapper.writeValueAsString(key);
         when(jedis.get("apikey:key_np")).thenReturn(keyJson);
         when(keyService.verifyKey("cyc_live_noperm", "$2a$12$hash")).thenReturn(true);
-        when(jedis.get("tenant:t1")).thenReturn("{\"status\":\"ACTIVE\"}");
+        when(jedis.get("tenant:tenant-1")).thenReturn("{\"status\":\"ACTIVE\"}");
 
         ApiKeyValidationResponse response = repository.validate("cyc_live_noperm");
 
@@ -527,7 +527,7 @@ class ApiKeyRepositoryTest {
         when(keyService.generateKeySecret("cyc_live")).thenThrow(new RuntimeException("Key generation failed"));
 
         ApiKeyCreateRequest request = new ApiKeyCreateRequest();
-        request.setTenantId("t1");
+        request.setTenantId("tenant-1");
         request.setName("Test Key");
 
         assertThatThrownBy(() -> repository.create(request))
@@ -538,14 +538,14 @@ class ApiKeyRepositoryTest {
     @Test
     void list_deserializationFailure_skipsGracefully() throws Exception {
         Set<String> ids = new LinkedHashSet<>(List.of("key_1", "key_2"));
-        when(jedis.smembers("apikeys:t1")).thenReturn(ids);
+        when(jedis.smembers("apikeys:tenant-1")).thenReturn(ids);
 
         when(jedis.get("apikey:key_1")).thenReturn("{invalid json}");
-        ApiKey k2 = ApiKey.builder().keyId("key_2").tenantId("t1").keyHash("h2").status(ApiKeyStatus.ACTIVE).createdAt(Instant.now()).build();
+        ApiKey k2 = ApiKey.builder().keyId("key_2").tenantId("tenant-1").keyHash("h2").status(ApiKeyStatus.ACTIVE).createdAt(Instant.now()).build();
         String k2Json = objectMapper.writeValueAsString(k2);
         when(jedis.get("apikey:key_2")).thenReturn(k2Json);
 
-        List<ApiKey> result = repository.list("t1", null, null, 50);
+        List<ApiKey> result = repository.list("tenant-1", null, null, 50);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getKeyId()).isEqualTo("key_2");
@@ -566,7 +566,7 @@ class ApiKeyRepositoryTest {
         when(jedis.get("apikey:lookup:cyc_live_nodat")).thenReturn("key_nd");
 
         ApiKey key = ApiKey.builder()
-                .keyId("key_nd").tenantId("t1").keyHash("$2a$12$hash")
+                .keyId("key_nd").tenantId("tenant-1").keyHash("$2a$12$hash")
                 .status(ApiKeyStatus.ACTIVE)
                 .permissions(List.of("balances:read"))
                 .expiresAt(Instant.now().plusSeconds(3600))
@@ -574,19 +574,19 @@ class ApiKeyRepositoryTest {
         String keyJson = objectMapper.writeValueAsString(key);
         when(jedis.get("apikey:key_nd")).thenReturn(keyJson);
         when(keyService.verifyKey("cyc_live_nodata", "$2a$12$hash")).thenReturn(true);
-        when(jedis.get("tenant:t1")).thenReturn(null);
+        when(jedis.get("tenant:tenant-1")).thenReturn(null);
 
         ApiKeyValidationResponse response = repository.validate("cyc_live_nodata");
 
         assertThat(response.getValid()).isFalse();
-        assertThat(response.getTenantId()).isEqualTo("t1");
+        assertThat(response.getTenantId()).isEqualTo("tenant-1");
         assertThat(response.getReason()).isEqualTo("TENANT_NOT_FOUND");
     }
 
     @Test
     void revoke_withNullReason_passesEmptyString() throws Exception {
         ApiKey revoked = ApiKey.builder()
-                .keyId("key_1").tenantId("t1").keyHash("hash")
+                .keyId("key_1").tenantId("tenant-1").keyHash("hash")
                 .status(ApiKeyStatus.REVOKED)
                 .revokedAt(Instant.now()).createdAt(Instant.now()).build();
         String revokedJson = objectMapper.writeValueAsString(revoked);
@@ -604,19 +604,19 @@ class ApiKeyRepositoryTest {
         when(jedis.get("apikey:lookup:cyc_live_noexp")).thenReturn("key_ne");
 
         ApiKey key = ApiKey.builder()
-                .keyId("key_ne").tenantId("t1").keyHash("$2a$12$hash")
+                .keyId("key_ne").tenantId("tenant-1").keyHash("$2a$12$hash")
                 .status(ApiKeyStatus.ACTIVE).expiresAt(null)
                 .permissions(List.of("balances:read"))
                 .createdAt(Instant.now()).build();
         String keyJson = objectMapper.writeValueAsString(key);
         when(jedis.get("apikey:key_ne")).thenReturn(keyJson);
         when(keyService.verifyKey("cyc_live_noexp", "$2a$12$hash")).thenReturn(true);
-        when(jedis.get("tenant:t1")).thenReturn("{\"status\":\"ACTIVE\"}");
+        when(jedis.get("tenant:tenant-1")).thenReturn("{\"status\":\"ACTIVE\"}");
 
         ApiKeyValidationResponse response = repository.validate("cyc_live_noexp");
 
         assertThat(response.getValid()).isTrue();
-        assertThat(response.getTenantId()).isEqualTo("t1");
+        assertThat(response.getTenantId()).isEqualTo("tenant-1");
     }
 
     @Test
@@ -681,10 +681,10 @@ class ApiKeyRepositoryTest {
     @Test
     void list_cursorNotFound_returnsNoEntriesAfterCursor() throws Exception {
         Set<String> ids = new LinkedHashSet<>(List.of("key_1", "key_2"));
-        when(jedis.smembers("apikeys:t1")).thenReturn(ids);
+        when(jedis.smembers("apikeys:tenant-1")).thenReturn(ids);
 
         // Cursor points to nonexistent key - nothing comes after it
-        List<ApiKey> result = repository.list("t1", null, "nonexistent", 50);
+        List<ApiKey> result = repository.list("tenant-1", null, "nonexistent", 50);
 
         assertThat(result).isEmpty();
     }
@@ -714,7 +714,7 @@ class ApiKeyRepositoryTest {
     @Test
     void update_success_returnsUpdatedKey() throws Exception {
         ApiKey existing = ApiKey.builder()
-                .keyId("key_1").tenantId("t1").keyPrefix("cyc_live_abc12")
+                .keyId("key_1").tenantId("tenant-1").keyPrefix("cyc_live_abc12")
                 .keyHash("$2a$12$hash").status(ApiKeyStatus.ACTIVE)
                 .permissions(List.of("balances:read"))
                 .createdAt(Instant.now()).expiresAt(Instant.now().plusSeconds(3600)).build();
@@ -751,7 +751,7 @@ class ApiKeyRepositoryTest {
     @Test
     void update_revokedKey_throws409() throws Exception {
         ApiKey revoked = ApiKey.builder()
-                .keyId("key_rev").tenantId("t1").keyPrefix("cyc_live_abc12")
+                .keyId("key_rev").tenantId("tenant-1").keyPrefix("cyc_live_abc12")
                 .keyHash("hash").status(ApiKeyStatus.REVOKED)
                 .createdAt(Instant.now()).build();
         String revokedJson = objectMapper.writeValueAsString(revoked);
@@ -771,7 +771,7 @@ class ApiKeyRepositoryTest {
     @Test
     void update_expiredKey_throws409() throws Exception {
         ApiKey expired = ApiKey.builder()
-                .keyId("key_exp").tenantId("t1").keyPrefix("cyc_live_abc12")
+                .keyId("key_exp").tenantId("tenant-1").keyPrefix("cyc_live_abc12")
                 .keyHash("hash").status(ApiKeyStatus.EXPIRED)
                 .createdAt(Instant.now()).build();
         String expiredJson = objectMapper.writeValueAsString(expired);
@@ -791,7 +791,7 @@ class ApiKeyRepositoryTest {
     @Test
     void update_onlyName_doesNotModifyOtherFields() throws Exception {
         ApiKey existing = ApiKey.builder()
-                .keyId("key_1").tenantId("t1").keyPrefix("cyc_live_abc12")
+                .keyId("key_1").tenantId("tenant-1").keyPrefix("cyc_live_abc12")
                 .keyHash("hash").name("Old Name").status(ApiKeyStatus.ACTIVE)
                 .permissions(List.of("balances:read")).scopeFilter(List.of("workspace:eng"))
                 .createdAt(Instant.now()).build();

--- a/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/AuditRepositoryTest.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/AuditRepositoryTest.java
@@ -45,7 +45,7 @@ class AuditRepositoryTest {
     @Test
     void log_setsLogIdAndTimestamp() {
         AuditLogEntry entry = AuditLogEntry.builder()
-                .tenantId("t1")
+                .tenantId("tenant-1")
                 .operation("createTenant")
                 .status(201)
                 .build();
@@ -60,7 +60,7 @@ class AuditRepositoryTest {
     @Test
     void log_persistsAllFields() throws Exception {
         AuditLogEntry entry = AuditLogEntry.builder()
-                .tenantId("t1")
+                .tenantId("tenant-1")
                 .keyId("key_1")
                 .operation("fundBudget")
                 .status(200)
@@ -85,16 +85,16 @@ class AuditRepositoryTest {
     @Test
     void list_returnsByTenantId() throws Exception {
         List<String> logIds = List.of("log_1", "log_2");
-        when(jedis.zrevrangeByScore(eq("audit:logs:t1"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(logIds);
+        when(jedis.zrevrangeByScore(eq("audit:logs:tenant-1"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(logIds);
 
-        AuditLogEntry e1 = AuditLogEntry.builder().logId("log_1").tenantId("t1").operation("create").status(200).timestamp(Instant.now()).build();
-        AuditLogEntry e2 = AuditLogEntry.builder().logId("log_2").tenantId("t1").operation("update").status(200).timestamp(Instant.now()).build();
+        AuditLogEntry e1 = AuditLogEntry.builder().logId("log_1").tenantId("tenant-1").operation("create").status(200).timestamp(Instant.now()).build();
+        AuditLogEntry e2 = AuditLogEntry.builder().logId("log_2").tenantId("tenant-1").operation("update").status(200).timestamp(Instant.now()).build();
         String e1Json = objectMapper.writeValueAsString(e1);
         String e2Json = objectMapper.writeValueAsString(e2);
         when(jedis.get("audit:log:log_1")).thenReturn(e1Json);
         when(jedis.get("audit:log:log_2")).thenReturn(e2Json);
 
-        List<AuditLogEntry> result = repository.list("t1", null, null, null, null, null, null, null, null, 50);
+        List<AuditLogEntry> result = repository.list("tenant-1", null, null, null, null, null, null, null, null, 50);
 
         assertThat(result).hasSize(2);
     }
@@ -102,16 +102,16 @@ class AuditRepositoryTest {
     @Test
     void list_filtersByKeyId() throws Exception {
         List<String> logIds = List.of("log_1", "log_2");
-        when(jedis.zrevrangeByScore(eq("audit:logs:t1"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(logIds);
+        when(jedis.zrevrangeByScore(eq("audit:logs:tenant-1"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(logIds);
 
-        AuditLogEntry e1 = AuditLogEntry.builder().logId("log_1").tenantId("t1").keyId("key_A").operation("create").status(200).timestamp(Instant.now()).build();
-        AuditLogEntry e2 = AuditLogEntry.builder().logId("log_2").tenantId("t1").keyId("key_B").operation("update").status(200).timestamp(Instant.now()).build();
+        AuditLogEntry e1 = AuditLogEntry.builder().logId("log_1").tenantId("tenant-1").keyId("key_A").operation("create").status(200).timestamp(Instant.now()).build();
+        AuditLogEntry e2 = AuditLogEntry.builder().logId("log_2").tenantId("tenant-1").keyId("key_B").operation("update").status(200).timestamp(Instant.now()).build();
         String e1Json = objectMapper.writeValueAsString(e1);
         String e2Json = objectMapper.writeValueAsString(e2);
         when(jedis.get("audit:log:log_1")).thenReturn(e1Json);
         when(jedis.get("audit:log:log_2")).thenReturn(e2Json);
 
-        List<AuditLogEntry> result = repository.list("t1", "key_A", null, null, null, null, null, null, null, 50);
+        List<AuditLogEntry> result = repository.list("tenant-1", "key_A", null, null, null, null, null, null, null, 50);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getKeyId()).isEqualTo("key_A");
@@ -120,16 +120,16 @@ class AuditRepositoryTest {
     @Test
     void list_filtersByOperation() throws Exception {
         List<String> logIds = List.of("log_1", "log_2");
-        when(jedis.zrevrangeByScore(eq("audit:logs:t1"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(logIds);
+        when(jedis.zrevrangeByScore(eq("audit:logs:tenant-1"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(logIds);
 
-        AuditLogEntry e1 = AuditLogEntry.builder().logId("log_1").tenantId("t1").operation("create").status(200).timestamp(Instant.now()).build();
-        AuditLogEntry e2 = AuditLogEntry.builder().logId("log_2").tenantId("t1").operation("update").status(200).timestamp(Instant.now()).build();
+        AuditLogEntry e1 = AuditLogEntry.builder().logId("log_1").tenantId("tenant-1").operation("create").status(200).timestamp(Instant.now()).build();
+        AuditLogEntry e2 = AuditLogEntry.builder().logId("log_2").tenantId("tenant-1").operation("update").status(200).timestamp(Instant.now()).build();
         String e1Json = objectMapper.writeValueAsString(e1);
         String e2Json = objectMapper.writeValueAsString(e2);
         when(jedis.get("audit:log:log_1")).thenReturn(e1Json);
         when(jedis.get("audit:log:log_2")).thenReturn(e2Json);
 
-        List<AuditLogEntry> result = repository.list("t1", null, "create", null, null, null, null, null, null, 50);
+        List<AuditLogEntry> result = repository.list("tenant-1", null, "create", null, null, null, null, null, null, 50);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getOperation()).isEqualTo("create");
@@ -138,16 +138,16 @@ class AuditRepositoryTest {
     @Test
     void list_filtersByStatus() throws Exception {
         List<String> logIds = List.of("log_1", "log_2");
-        when(jedis.zrevrangeByScore(eq("audit:logs:t1"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(logIds);
+        when(jedis.zrevrangeByScore(eq("audit:logs:tenant-1"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(logIds);
 
-        AuditLogEntry e1 = AuditLogEntry.builder().logId("log_1").tenantId("t1").operation("create").status(201).timestamp(Instant.now()).build();
-        AuditLogEntry e2 = AuditLogEntry.builder().logId("log_2").tenantId("t1").operation("create").status(400).timestamp(Instant.now()).build();
+        AuditLogEntry e1 = AuditLogEntry.builder().logId("log_1").tenantId("tenant-1").operation("create").status(201).timestamp(Instant.now()).build();
+        AuditLogEntry e2 = AuditLogEntry.builder().logId("log_2").tenantId("tenant-1").operation("create").status(400).timestamp(Instant.now()).build();
         String e1Json = objectMapper.writeValueAsString(e1);
         String e2Json = objectMapper.writeValueAsString(e2);
         when(jedis.get("audit:log:log_1")).thenReturn(e1Json);
         when(jedis.get("audit:log:log_2")).thenReturn(e2Json);
 
-        List<AuditLogEntry> result = repository.list("t1", null, null, 201, null, null, null, null, null, 50);
+        List<AuditLogEntry> result = repository.list("tenant-1", null, null, 201, null, null, null, null, null, 50);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getStatus()).isEqualTo(201);
@@ -158,7 +158,7 @@ class AuditRepositoryTest {
         List<String> logIds = List.of("log_1");
         when(jedis.zrevrangeByScore(eq("audit:logs:_all"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(logIds);
 
-        AuditLogEntry e1 = AuditLogEntry.builder().logId("log_1").tenantId("t1").operation("create").status(200).timestamp(Instant.now()).build();
+        AuditLogEntry e1 = AuditLogEntry.builder().logId("log_1").tenantId("tenant-1").operation("create").status(200).timestamp(Instant.now()).build();
         String e1Json = objectMapper.writeValueAsString(e1);
         when(jedis.get("audit:log:log_1")).thenReturn(e1Json);
 
@@ -171,20 +171,20 @@ class AuditRepositoryTest {
     @Test
     void list_respectsLimit() throws Exception {
         List<String> logIds = List.of("log_1", "log_2");
-        when(jedis.zrevrangeByScore(eq("audit:logs:t1"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(logIds);
+        when(jedis.zrevrangeByScore(eq("audit:logs:tenant-1"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(logIds);
 
-        AuditLogEntry e1 = AuditLogEntry.builder().logId("log_1").tenantId("t1").operation("create").status(200).timestamp(Instant.now()).build();
+        AuditLogEntry e1 = AuditLogEntry.builder().logId("log_1").tenantId("tenant-1").operation("create").status(200).timestamp(Instant.now()).build();
         String e1Json = objectMapper.writeValueAsString(e1);
         when(jedis.get("audit:log:log_1")).thenReturn(e1Json);
 
-        List<AuditLogEntry> result = repository.list("t1", null, null, null, null, null, null, null, null, 1);
+        List<AuditLogEntry> result = repository.list("tenant-1", null, null, null, null, null, null, null, null, 1);
 
         assertThat(result).hasSize(1);
     }
 
     @Test
     void list_withZeroLimit_returnsEmpty() {
-        List<AuditLogEntry> result = repository.list("t1", null, null, null, null, null, null, null, null, 0);
+        List<AuditLogEntry> result = repository.list("tenant-1", null, null, null, null, null, null, null, null, 0);
         assertThat(result).isEmpty();
     }
 
@@ -192,20 +192,20 @@ class AuditRepositoryTest {
     void list_respectsCursor() throws Exception {
         // The cursor's score is looked up via zscore, then used as maxScore ceiling
         double cursorScore = 1000.0;
-        when(jedis.zscore("audit:logs:t1", "log_1")).thenReturn(cursorScore);
+        when(jedis.zscore("audit:logs:tenant-1", "log_1")).thenReturn(cursorScore);
 
         List<String> logIds = List.of("log_2", "log_3");
         // maxScore = cursorScore - 1 = 999.0
-        when(jedis.zrevrangeByScore(eq("audit:logs:t1"), eq(999.0), eq(Double.NEGATIVE_INFINITY), eq(0), anyInt())).thenReturn(logIds);
+        when(jedis.zrevrangeByScore(eq("audit:logs:tenant-1"), eq(999.0), eq(Double.NEGATIVE_INFINITY), eq(0), anyInt())).thenReturn(logIds);
 
-        AuditLogEntry e2 = AuditLogEntry.builder().logId("log_2").tenantId("t1").operation("op").status(200).timestamp(Instant.now()).build();
-        AuditLogEntry e3 = AuditLogEntry.builder().logId("log_3").tenantId("t1").operation("op").status(200).timestamp(Instant.now()).build();
+        AuditLogEntry e2 = AuditLogEntry.builder().logId("log_2").tenantId("tenant-1").operation("op").status(200).timestamp(Instant.now()).build();
+        AuditLogEntry e3 = AuditLogEntry.builder().logId("log_3").tenantId("tenant-1").operation("op").status(200).timestamp(Instant.now()).build();
         String e2Json = objectMapper.writeValueAsString(e2);
         String e3Json = objectMapper.writeValueAsString(e3);
         when(jedis.get("audit:log:log_2")).thenReturn(e2Json);
         when(jedis.get("audit:log:log_3")).thenReturn(e3Json);
 
-        List<AuditLogEntry> result = repository.list("t1", null, null, null, null, null, null, null, "log_1", 50);
+        List<AuditLogEntry> result = repository.list("tenant-1", null, null, null, null, null, null, null, "log_1", 50);
 
         assertThat(result).hasSize(2);
         assertThat(result.get(0).getLogId()).isEqualTo("log_2");
@@ -213,26 +213,26 @@ class AuditRepositoryTest {
 
     @Test
     void list_convenienceOverload_delegatesToFullMethod() {
-        when(jedis.zrevrangeByScore(eq("audit:logs:t1"), anyDouble(), anyDouble(), eq(0), anyInt()))
+        when(jedis.zrevrangeByScore(eq("audit:logs:tenant-1"), anyDouble(), anyDouble(), eq(0), anyInt()))
                 .thenReturn(List.of());
 
-        List<AuditLogEntry> result = repository.list("t1", 10);
+        List<AuditLogEntry> result = repository.list("tenant-1", 10);
 
         assertThat(result).isEmpty();
-        verify(jedis).zrevrangeByScore(eq("audit:logs:t1"), anyDouble(), anyDouble(), eq(0), eq(30));
+        verify(jedis).zrevrangeByScore(eq("audit:logs:tenant-1"), anyDouble(), anyDouble(), eq(0), eq(30));
     }
 
     @Test
     void list_missingLogData_skipsGracefully() throws Exception {
         List<String> logIds = List.of("log_1", "log_2");
-        when(jedis.zrevrangeByScore(eq("audit:logs:t1"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(logIds);
+        when(jedis.zrevrangeByScore(eq("audit:logs:tenant-1"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(logIds);
 
         when(jedis.get("audit:log:log_1")).thenReturn(null);
-        AuditLogEntry e2 = AuditLogEntry.builder().logId("log_2").tenantId("t1").operation("op").status(200).timestamp(Instant.now()).build();
+        AuditLogEntry e2 = AuditLogEntry.builder().logId("log_2").tenantId("tenant-1").operation("op").status(200).timestamp(Instant.now()).build();
         String e2Json = objectMapper.writeValueAsString(e2);
         when(jedis.get("audit:log:log_2")).thenReturn(e2Json);
 
-        List<AuditLogEntry> result = repository.list("t1", null, null, null, null, null, null, null, null, 50);
+        List<AuditLogEntry> result = repository.list("tenant-1", null, null, null, null, null, null, null, null, 50);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getLogId()).isEqualTo("log_2");
@@ -243,7 +243,7 @@ class AuditRepositoryTest {
         when(jedisPool.getResource()).thenThrow(new RuntimeException("Redis down"));
 
         AuditLogEntry entry = AuditLogEntry.builder()
-                .tenantId("t1").operation("op").status(200).build();
+                .tenantId("tenant-1").operation("op").status(200).build();
 
         // Should not throw - audit failures are non-fatal
         repository.log(entry);
@@ -251,17 +251,17 @@ class AuditRepositoryTest {
 
     @Test
     void list_cursorNotFoundInIndex_usesDefaultMaxScore() throws Exception {
-        when(jedis.zscore("audit:logs:t1", "nonexistent")).thenReturn(null);
+        when(jedis.zscore("audit:logs:tenant-1", "nonexistent")).thenReturn(null);
 
         List<String> logIds = List.of("log_1");
-        when(jedis.zrevrangeByScore(eq("audit:logs:t1"), eq(Double.POSITIVE_INFINITY), eq(Double.NEGATIVE_INFINITY), eq(0), anyInt()))
+        when(jedis.zrevrangeByScore(eq("audit:logs:tenant-1"), eq(Double.POSITIVE_INFINITY), eq(Double.NEGATIVE_INFINITY), eq(0), anyInt()))
                 .thenReturn(logIds);
 
-        AuditLogEntry e1 = AuditLogEntry.builder().logId("log_1").tenantId("t1").operation("op").status(200).timestamp(Instant.now()).build();
+        AuditLogEntry e1 = AuditLogEntry.builder().logId("log_1").tenantId("tenant-1").operation("op").status(200).timestamp(Instant.now()).build();
         String e1Json = objectMapper.writeValueAsString(e1);
         when(jedis.get("audit:log:log_1")).thenReturn(e1Json);
 
-        List<AuditLogEntry> result = repository.list("t1", null, null, null, null, null, null, null, "nonexistent", 50);
+        List<AuditLogEntry> result = repository.list("tenant-1", null, null, null, null, null, null, null, "nonexistent", 50);
 
         assertThat(result).hasSize(1);
     }
@@ -272,36 +272,36 @@ class AuditRepositoryTest {
         Instant to = Instant.ofEpochMilli(2000);
 
         List<String> logIds = List.of("log_1");
-        when(jedis.zrevrangeByScore(eq("audit:logs:t1"), eq(2000.0), eq(1000.0), eq(0), anyInt()))
+        when(jedis.zrevrangeByScore(eq("audit:logs:tenant-1"), eq(2000.0), eq(1000.0), eq(0), anyInt()))
                 .thenReturn(logIds);
 
-        AuditLogEntry e1 = AuditLogEntry.builder().logId("log_1").tenantId("t1").operation("op").status(200).timestamp(Instant.now()).build();
+        AuditLogEntry e1 = AuditLogEntry.builder().logId("log_1").tenantId("tenant-1").operation("op").status(200).timestamp(Instant.now()).build();
         String e1Json = objectMapper.writeValueAsString(e1);
         when(jedis.get("audit:log:log_1")).thenReturn(e1Json);
 
-        List<AuditLogEntry> result = repository.list("t1", null, null, null, null, null, from, to, null, 50);
+        List<AuditLogEntry> result = repository.list("tenant-1", null, null, null, null, null, from, to, null, 50);
 
         assertThat(result).hasSize(1);
-        verify(jedis).zrevrangeByScore(eq("audit:logs:t1"), eq(2000.0), eq(1000.0), eq(0), anyInt());
+        verify(jedis).zrevrangeByScore(eq("audit:logs:tenant-1"), eq(2000.0), eq(1000.0), eq(0), anyInt());
     }
 
     @Test
     void list_negativeLimit_returnsEmptyList() {
-        List<AuditLogEntry> result = repository.list("t1", null, null, null, null, null, null, null, null, -1);
+        List<AuditLogEntry> result = repository.list("tenant-1", null, null, null, null, null, null, null, null, -1);
         assertThat(result).isEmpty();
     }
 
     @Test
     void list_deserializationFailure_skipsGracefully() throws Exception {
         List<String> logIds = List.of("log_bad", "log_good");
-        when(jedis.zrevrangeByScore(eq("audit:logs:t1"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(logIds);
+        when(jedis.zrevrangeByScore(eq("audit:logs:tenant-1"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(logIds);
 
         when(jedis.get("audit:log:log_bad")).thenReturn("{invalid json}");
-        AuditLogEntry good = AuditLogEntry.builder().logId("log_good").tenantId("t1").operation("op").status(200).timestamp(Instant.now()).build();
+        AuditLogEntry good = AuditLogEntry.builder().logId("log_good").tenantId("tenant-1").operation("op").status(200).timestamp(Instant.now()).build();
         String goodJson = objectMapper.writeValueAsString(good);
         when(jedis.get("audit:log:log_good")).thenReturn(goodJson);
 
-        List<AuditLogEntry> result = repository.list("t1", null, null, null, null, null, null, null, null, 50);
+        List<AuditLogEntry> result = repository.list("tenant-1", null, null, null, null, null, null, null, null, 50);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getLogId()).isEqualTo("log_good");

--- a/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/BudgetRepositoryTest.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/BudgetRepositoryTest.java
@@ -103,7 +103,7 @@ class BudgetRepositoryTest {
         request.setOperation(FundingOperation.CREDIT);
         request.setAmount(new Amount(UnitEnum.USD_MICROCENTS, 1000L));
 
-        BudgetFundingResponse response = repository.fund("t1", "scope", UnitEnum.USD_MICROCENTS, request);
+        BudgetFundingResponse response = repository.fund("tenant-1", "scope", UnitEnum.USD_MICROCENTS, request);
 
         assertThat(response.getOperation()).isEqualTo(FundingOperation.CREDIT);
         assertThat(response.getPreviousAllocated().getAmount()).isEqualTo(1000L);
@@ -121,7 +121,7 @@ class BudgetRepositoryTest {
         request.setOperation(FundingOperation.DEBIT);
         request.setAmount(new Amount(UnitEnum.USD_MICROCENTS, 500L));
 
-        BudgetFundingResponse response = repository.fund("t1", "scope", UnitEnum.USD_MICROCENTS, request);
+        BudgetFundingResponse response = repository.fund("tenant-1", "scope", UnitEnum.USD_MICROCENTS, request);
 
         assertThat(response.getNewAllocated().getAmount()).isEqualTo(1500L);
         assertThat(response.getNewRemaining().getAmount()).isEqualTo(1500L);
@@ -136,7 +136,7 @@ class BudgetRepositoryTest {
         request.setOperation(FundingOperation.CREDIT);
         request.setAmount(new Amount(UnitEnum.USD_MICROCENTS, 1000L));
 
-        assertThatThrownBy(() -> repository.fund("t1", "missing", UnitEnum.USD_MICROCENTS, request))
+        assertThatThrownBy(() -> repository.fund("tenant-1", "missing", UnitEnum.USD_MICROCENTS, request))
                 .isInstanceOf(GovernanceException.class)
                 .satisfies(e -> assertThat(((GovernanceException) e).getErrorCode()).isEqualTo(ErrorCode.BUDGET_NOT_FOUND));
     }
@@ -150,7 +150,7 @@ class BudgetRepositoryTest {
         request.setOperation(FundingOperation.DEBIT);
         request.setAmount(new Amount(UnitEnum.USD_MICROCENTS, 99999L));
 
-        assertThatThrownBy(() -> repository.fund("t1", "scope", UnitEnum.USD_MICROCENTS, request))
+        assertThatThrownBy(() -> repository.fund("tenant-1", "scope", UnitEnum.USD_MICROCENTS, request))
                 .isInstanceOf(GovernanceException.class)
                 .satisfies(e -> assertThat(((GovernanceException) e).getErrorCode()).isEqualTo(ErrorCode.BUDGET_EXCEEDED));
     }
@@ -164,7 +164,7 @@ class BudgetRepositoryTest {
         request.setOperation(FundingOperation.CREDIT);
         request.setAmount(new Amount(UnitEnum.USD_MICROCENTS, 1000L));
 
-        assertThatThrownBy(() -> repository.fund("t1", "scope", UnitEnum.USD_MICROCENTS, request))
+        assertThatThrownBy(() -> repository.fund("tenant-1", "scope", UnitEnum.USD_MICROCENTS, request))
                 .isInstanceOf(GovernanceException.class)
                 .satisfies(e -> assertThat(((GovernanceException) e).getErrorCode()).isEqualTo(ErrorCode.BUDGET_FROZEN));
     }
@@ -178,7 +178,7 @@ class BudgetRepositoryTest {
         request.setOperation(FundingOperation.CREDIT);
         request.setAmount(new Amount(UnitEnum.USD_MICROCENTS, 1000L));
 
-        assertThatThrownBy(() -> repository.fund("t1", "scope", UnitEnum.USD_MICROCENTS, request))
+        assertThatThrownBy(() -> repository.fund("tenant-1", "scope", UnitEnum.USD_MICROCENTS, request))
                 .isInstanceOf(GovernanceException.class)
                 .satisfies(e -> assertThat(((GovernanceException) e).getErrorCode()).isEqualTo(ErrorCode.BUDGET_CLOSED));
     }
@@ -192,7 +192,7 @@ class BudgetRepositoryTest {
         request.setOperation(FundingOperation.CREDIT);
         request.setAmount(new Amount(UnitEnum.USD_MICROCENTS, 1000L));
 
-        assertThatThrownBy(() -> repository.fund("t1", "scope", UnitEnum.USD_MICROCENTS, request))
+        assertThatThrownBy(() -> repository.fund("tenant-1", "scope", UnitEnum.USD_MICROCENTS, request))
                 .isInstanceOf(GovernanceException.class)
                 .satisfies(e -> assertThat(((GovernanceException) e).getErrorCode()).isEqualTo(ErrorCode.FORBIDDEN));
     }
@@ -208,7 +208,7 @@ class BudgetRepositoryTest {
         request.setAmount(new Amount(UnitEnum.USD_MICROCENTS, 1000L));
         request.setIdempotencyKey("idem-1");
 
-        BudgetFundingResponse response = repository.fund("t1", "scope", UnitEnum.USD_MICROCENTS, request);
+        BudgetFundingResponse response = repository.fund("tenant-1", "scope", UnitEnum.USD_MICROCENTS, request);
 
         assertThat(response.getNewAllocated().getAmount()).isEqualTo(1000L);
         verify(jedis).eval(anyString(), anyList(), anyList());
@@ -225,7 +225,7 @@ class BudgetRepositoryTest {
         request.setAmount(new Amount(UnitEnum.USD_MICROCENTS, 1000L));
         request.setIdempotencyKey("idem-1");
 
-        BudgetFundingResponse response = repository.fund("t1", "scope", UnitEnum.USD_MICROCENTS, request);
+        BudgetFundingResponse response = repository.fund("tenant-1", "scope", UnitEnum.USD_MICROCENTS, request);
 
         assertThat(response.getNewAllocated().getAmount()).isEqualTo(1000L);
         assertThat(response.getPreviousAllocated().getAmount()).isEqualTo(0L);
@@ -240,7 +240,7 @@ class BudgetRepositoryTest {
         request.setOperation(FundingOperation.REPAY_DEBT);
         request.setAmount(new Amount(UnitEnum.USD_MICROCENTS, 1000L));
 
-        BudgetFundingResponse response = repository.fund("t1", "scope", UnitEnum.USD_MICROCENTS, request);
+        BudgetFundingResponse response = repository.fund("tenant-1", "scope", UnitEnum.USD_MICROCENTS, request);
 
         assertThat(response.getPreviousDebt().getAmount()).isEqualTo(1000L);
         assertThat(response.getNewDebt().getAmount()).isEqualTo(500L);
@@ -250,11 +250,11 @@ class BudgetRepositoryTest {
     @Test
     void list_returnsBudgetsForTenant() {
         Set<String> keys = new LinkedHashSet<>(List.of("budget:org/team1:USD_MICROCENTS"));
-        when(jedis.smembers("budgets:t1")).thenReturn(keys);
+        when(jedis.smembers("budgets:tenant-1")).thenReturn(keys);
 
         Map<String, String> hash = new LinkedHashMap<>();
         hash.put("ledger_id", "led-1");
-        hash.put("tenant_id", "t1");
+        hash.put("tenant_id", "tenant-1");
         hash.put("scope", "org/team1");
         hash.put("unit", "USD_MICROCENTS");
         hash.put("allocated", "1000");
@@ -268,7 +268,7 @@ class BudgetRepositoryTest {
         hash.put("created_at", String.valueOf(System.currentTimeMillis()));
         when(jedis.hgetAll("budget:org/team1:USD_MICROCENTS")).thenReturn(hash);
 
-        List<BudgetLedger> result = repository.list("t1", null, null, null, null, 50);
+        List<BudgetLedger> result = repository.list("tenant-1", null, null, null, null, 50);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getScope()).isEqualTo("org/team1");
@@ -278,14 +278,14 @@ class BudgetRepositoryTest {
     @Test
     void list_filtersByScopePrefix() {
         Set<String> keys = new LinkedHashSet<>(List.of("budget:org/team1:USD_MICROCENTS", "budget:other/team2:USD_MICROCENTS"));
-        when(jedis.smembers("budgets:t1")).thenReturn(keys);
+        when(jedis.smembers("budgets:tenant-1")).thenReturn(keys);
 
         Map<String, String> hash1 = createBudgetHash("led-1", "org/team1", "USD_MICROCENTS");
         Map<String, String> hash2 = createBudgetHash("led-2", "other/team2", "USD_MICROCENTS");
         when(jedis.hgetAll("budget:org/team1:USD_MICROCENTS")).thenReturn(hash1);
         when(jedis.hgetAll("budget:other/team2:USD_MICROCENTS")).thenReturn(hash2);
 
-        List<BudgetLedger> result = repository.list("t1", "org/", null, null, null, 50);
+        List<BudgetLedger> result = repository.list("tenant-1", "org/", null, null, null, 50);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getScope()).isEqualTo("org/team1");
@@ -294,14 +294,14 @@ class BudgetRepositoryTest {
     @Test
     void list_filtersByUnit() {
         Set<String> keys = new LinkedHashSet<>(List.of("budget:scope:USD_MICROCENTS", "budget:scope:TOKENS"));
-        when(jedis.smembers("budgets:t1")).thenReturn(keys);
+        when(jedis.smembers("budgets:tenant-1")).thenReturn(keys);
 
         Map<String, String> hash1 = createBudgetHash("led-1", "scope", "USD_MICROCENTS");
         Map<String, String> hash2 = createBudgetHash("led-2", "scope", "TOKENS");
         when(jedis.hgetAll("budget:scope:USD_MICROCENTS")).thenReturn(hash1);
         when(jedis.hgetAll("budget:scope:TOKENS")).thenReturn(hash2);
 
-        List<BudgetLedger> result = repository.list("t1", null, UnitEnum.TOKENS, null, null, 50);
+        List<BudgetLedger> result = repository.list("tenant-1", null, UnitEnum.TOKENS, null, null, 50);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getUnit()).isEqualTo(UnitEnum.TOKENS);
@@ -310,7 +310,7 @@ class BudgetRepositoryTest {
     @Test
     void list_filtersByStatus() {
         Set<String> keys = new LinkedHashSet<>(List.of("budget:a:USD_MICROCENTS", "budget:b:USD_MICROCENTS"));
-        when(jedis.smembers("budgets:t1")).thenReturn(keys);
+        when(jedis.smembers("budgets:tenant-1")).thenReturn(keys);
 
         Map<String, String> hash1 = createBudgetHash("led-1", "a", "USD_MICROCENTS");
         Map<String, String> hash2 = createBudgetHash("led-2", "b", "USD_MICROCENTS");
@@ -318,7 +318,7 @@ class BudgetRepositoryTest {
         when(jedis.hgetAll("budget:a:USD_MICROCENTS")).thenReturn(hash1);
         when(jedis.hgetAll("budget:b:USD_MICROCENTS")).thenReturn(hash2);
 
-        List<BudgetLedger> result = repository.list("t1", null, null, BudgetStatus.ACTIVE, null, 50);
+        List<BudgetLedger> result = repository.list("tenant-1", null, null, BudgetStatus.ACTIVE, null, 50);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getScope()).isEqualTo("a");
@@ -334,7 +334,7 @@ class BudgetRepositoryTest {
         request.setAmount(new Amount(UnitEnum.USD_MICROCENTS, 1000L));
         request.setIdempotencyKey("idem-1");
 
-        assertThatThrownBy(() -> repository.fund("t1", "scope", UnitEnum.USD_MICROCENTS, request))
+        assertThatThrownBy(() -> repository.fund("tenant-1", "scope", UnitEnum.USD_MICROCENTS, request))
                 .isInstanceOf(GovernanceException.class)
                 .satisfies(e -> assertThat(((GovernanceException) e).getErrorCode()).isEqualTo(ErrorCode.IDEMPOTENCY_MISMATCH));
     }
@@ -348,7 +348,7 @@ class BudgetRepositoryTest {
         request.setOperation(FundingOperation.RESET);
         request.setAmount(new Amount(UnitEnum.USD_MICROCENTS, 5000L));
 
-        BudgetFundingResponse response = repository.fund("t1", "scope", UnitEnum.USD_MICROCENTS, request);
+        BudgetFundingResponse response = repository.fund("tenant-1", "scope", UnitEnum.USD_MICROCENTS, request);
 
         assertThat(response.getOperation()).isEqualTo(FundingOperation.RESET);
         assertThat(response.getPreviousAllocated().getAmount()).isEqualTo(1000L);
@@ -359,7 +359,7 @@ class BudgetRepositoryTest {
     @Test
     void list_cursorPagination_skipsEntriesBeforeCursor() {
         Set<String> keys = new LinkedHashSet<>(List.of("budget:a:USD_MICROCENTS", "budget:b:USD_MICROCENTS", "budget:c:USD_MICROCENTS"));
-        when(jedis.smembers("budgets:t1")).thenReturn(keys);
+        when(jedis.smembers("budgets:tenant-1")).thenReturn(keys);
 
         Map<String, String> hashA = createBudgetHash("led-a", "a", "USD_MICROCENTS");
         Map<String, String> hashB = createBudgetHash("led-b", "b", "USD_MICROCENTS");
@@ -368,7 +368,7 @@ class BudgetRepositoryTest {
         when(jedis.hgetAll("budget:b:USD_MICROCENTS")).thenReturn(hashB);
         when(jedis.hgetAll("budget:c:USD_MICROCENTS")).thenReturn(hashC);
 
-        List<BudgetLedger> result = repository.list("t1", null, null, null, "led-a", 50);
+        List<BudgetLedger> result = repository.list("tenant-1", null, null, null, "led-a", 50);
 
         assertThat(result).hasSize(2);
         assertThat(result.get(0).getLedgerId()).isEqualTo("led-b");
@@ -378,37 +378,37 @@ class BudgetRepositoryTest {
     @Test
     void list_emptyHashData_cleansIndexAndSkips() {
         Set<String> keys = new LinkedHashSet<>(List.of("budget:stale:USD_MICROCENTS", "budget:valid:USD_MICROCENTS"));
-        when(jedis.smembers("budgets:t1")).thenReturn(keys);
+        when(jedis.smembers("budgets:tenant-1")).thenReturn(keys);
 
         when(jedis.hgetAll("budget:stale:USD_MICROCENTS")).thenReturn(Collections.emptyMap());
         Map<String, String> validHash = createBudgetHash("led-1", "valid", "USD_MICROCENTS");
         when(jedis.hgetAll("budget:valid:USD_MICROCENTS")).thenReturn(validHash);
 
-        List<BudgetLedger> result = repository.list("t1", null, null, null, null, 50);
+        List<BudgetLedger> result = repository.list("tenant-1", null, null, null, null, 50);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getScope()).isEqualTo("valid");
-        verify(jedis).srem("budgets:t1", "budget:stale:USD_MICROCENTS");
+        verify(jedis).srem("budgets:tenant-1", "budget:stale:USD_MICROCENTS");
     }
 
     @Test
     void list_respectsLimit() {
         Set<String> keys = new LinkedHashSet<>(List.of("budget:a:USD_MICROCENTS", "budget:b:USD_MICROCENTS", "budget:c:USD_MICROCENTS"));
-        when(jedis.smembers("budgets:t1")).thenReturn(keys);
+        when(jedis.smembers("budgets:tenant-1")).thenReturn(keys);
 
         when(jedis.hgetAll("budget:a:USD_MICROCENTS")).thenReturn(createBudgetHash("led-a", "a", "USD_MICROCENTS"));
         when(jedis.hgetAll("budget:b:USD_MICROCENTS")).thenReturn(createBudgetHash("led-b", "b", "USD_MICROCENTS"));
 
-        List<BudgetLedger> result = repository.list("t1", null, null, null, null, 2);
+        List<BudgetLedger> result = repository.list("tenant-1", null, null, null, null, 2);
 
         assertThat(result).hasSize(2);
     }
 
     @Test
     void list_noKeys_returnsEmptyList() {
-        when(jedis.smembers("budgets:t1")).thenReturn(Collections.emptySet());
+        when(jedis.smembers("budgets:tenant-1")).thenReturn(Collections.emptySet());
 
-        List<BudgetLedger> result = repository.list("t1", null, null, null, null, 50);
+        List<BudgetLedger> result = repository.list("tenant-1", null, null, null, null, 50);
 
         assertThat(result).isEmpty();
     }
@@ -432,18 +432,18 @@ class BudgetRepositoryTest {
 
     @Test
     void list_convenienceMethod_callsFullListWithDefaults() {
-        when(jedis.smembers("budgets:t1")).thenReturn(Collections.emptySet());
+        when(jedis.smembers("budgets:tenant-1")).thenReturn(Collections.emptySet());
 
-        List<BudgetLedger> result = repository.list("t1");
+        List<BudgetLedger> result = repository.list("tenant-1");
 
         assertThat(result).isEmpty();
-        verify(jedis).smembers("budgets:t1");
+        verify(jedis).smembers("budgets:tenant-1");
     }
 
     @Test
     void list_corruptHashMissingScopeOrUnit_skipsGracefully() {
         Set<String> keys = new LinkedHashSet<>(List.of("budget:corrupt:USD_MICROCENTS", "budget:valid:USD_MICROCENTS"));
-        when(jedis.smembers("budgets:t1")).thenReturn(keys);
+        when(jedis.smembers("budgets:tenant-1")).thenReturn(keys);
 
         // Corrupt hash missing 'scope' and 'unit' fields
         Map<String, String> corruptHash = new LinkedHashMap<>();
@@ -454,7 +454,7 @@ class BudgetRepositoryTest {
         Map<String, String> validHash = createBudgetHash("led-1", "valid", "USD_MICROCENTS");
         when(jedis.hgetAll("budget:valid:USD_MICROCENTS")).thenReturn(validHash);
 
-        List<BudgetLedger> result = repository.list("t1", null, null, null, null, 50);
+        List<BudgetLedger> result = repository.list("tenant-1", null, null, null, null, 50);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getScope()).isEqualTo("valid");
@@ -469,7 +469,7 @@ class BudgetRepositoryTest {
         request.setUnit(UnitEnum.USD_MICROCENTS);
         request.setAllocated(new Amount(UnitEnum.USD_MICROCENTS, 1000L));
 
-        assertThatThrownBy(() -> repository.create("t1", request))
+        assertThatThrownBy(() -> repository.create("tenant-1", request))
                 .isInstanceOf(RuntimeException.class)
                 .hasCauseInstanceOf(RuntimeException.class);
     }
@@ -477,7 +477,7 @@ class BudgetRepositoryTest {
     @Test
     void list_deserializationFailure_skipsGracefully() {
         Set<String> keys = new LinkedHashSet<>(List.of("budget:bad:USD_MICROCENTS", "budget:valid:USD_MICROCENTS"));
-        when(jedis.smembers("budgets:t1")).thenReturn(keys);
+        when(jedis.smembers("budgets:tenant-1")).thenReturn(keys);
 
         // Return a hash that will cause an exception in hashToBudgetLedger (bad unit value)
         Map<String, String> badHash = new LinkedHashMap<>();
@@ -489,7 +489,7 @@ class BudgetRepositoryTest {
         Map<String, String> validHash = createBudgetHash("led-1", "valid", "USD_MICROCENTS");
         when(jedis.hgetAll("budget:valid:USD_MICROCENTS")).thenReturn(validHash);
 
-        List<BudgetLedger> result = repository.list("t1", null, null, null, null, 50);
+        List<BudgetLedger> result = repository.list("tenant-1", null, null, null, null, 50);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getScope()).isEqualTo("valid");
@@ -503,7 +503,7 @@ class BudgetRepositoryTest {
         request.setOperation(FundingOperation.CREDIT);
         request.setAmount(new Amount(UnitEnum.USD_MICROCENTS, 1000L));
 
-        assertThatThrownBy(() -> repository.fund("t1", "scope", UnitEnum.USD_MICROCENTS, request))
+        assertThatThrownBy(() -> repository.fund("tenant-1", "scope", UnitEnum.USD_MICROCENTS, request))
                 .isInstanceOf(RuntimeException.class)
                 .hasCauseInstanceOf(RuntimeException.class);
     }
@@ -530,7 +530,7 @@ class BudgetRepositoryTest {
     @Test
     void list_hashWithAllOptionalFields_parsesCorrectly() {
         Set<String> keys = new LinkedHashSet<>(List.of("budget:org/full:USD_MICROCENTS"));
-        when(jedis.smembers("budgets:t1")).thenReturn(keys);
+        when(jedis.smembers("budgets:tenant-1")).thenReturn(keys);
 
         Map<String, String> hash = createBudgetHash("led-full", "org/full", "USD_MICROCENTS");
         hash.put("commit_overage_policy", "ALLOW_WITH_OVERDRAFT");
@@ -540,7 +540,7 @@ class BudgetRepositoryTest {
         hash.put("updated_at", String.valueOf(System.currentTimeMillis()));
         when(jedis.hgetAll("budget:org/full:USD_MICROCENTS")).thenReturn(hash);
 
-        List<BudgetLedger> result = repository.list("t1", null, null, null, null, 50);
+        List<BudgetLedger> result = repository.list("tenant-1", null, null, null, null, 50);
 
         assertThat(result).hasSize(1);
         BudgetLedger ledger = result.get(0);
@@ -576,7 +576,7 @@ class BudgetRepositoryTest {
         request.setOperation(FundingOperation.CREDIT);
         request.setAmount(new Amount(UnitEnum.USD_MICROCENTS, 1000L));
 
-        assertThatThrownBy(() -> repository.fund("t1", "test", UnitEnum.USD_MICROCENTS, request))
+        assertThatThrownBy(() -> repository.fund("tenant-1", "test", UnitEnum.USD_MICROCENTS, request))
                 .isSameAs(expected);
     }
 
@@ -590,7 +590,7 @@ class BudgetRepositoryTest {
         request.setUnit(UnitEnum.USD_MICROCENTS);
         request.setAllocated(new Amount(UnitEnum.USD_MICROCENTS, 1000L));
 
-        assertThatThrownBy(() -> repository.create("t1", request))
+        assertThatThrownBy(() -> repository.create("tenant-1", request))
                 .isSameAs(expected);
     }
 
@@ -604,7 +604,7 @@ class BudgetRepositoryTest {
         request.setAmount(new Amount(UnitEnum.USD_MICROCENTS, 1000L));
         request.setIdempotencyKey("   ");
 
-        BudgetFundingResponse response = repository.fund("t1", "scope", UnitEnum.USD_MICROCENTS, request);
+        BudgetFundingResponse response = repository.fund("tenant-1", "scope", UnitEnum.USD_MICROCENTS, request);
 
         assertThat(response.getNewAllocated().getAmount()).isEqualTo(1000L);
     }
@@ -612,13 +612,13 @@ class BudgetRepositoryTest {
     @Test
     void list_cursorNotFound_includesAllEntries() {
         Set<String> keys = new LinkedHashSet<>(List.of("budget:a:USD_MICROCENTS", "budget:b:USD_MICROCENTS"));
-        when(jedis.smembers("budgets:t1")).thenReturn(keys);
+        when(jedis.smembers("budgets:tenant-1")).thenReturn(keys);
 
         when(jedis.hgetAll("budget:a:USD_MICROCENTS")).thenReturn(createBudgetHash("led-a", "a", "USD_MICROCENTS"));
         when(jedis.hgetAll("budget:b:USD_MICROCENTS")).thenReturn(createBudgetHash("led-b", "b", "USD_MICROCENTS"));
 
         // Cursor "nonexistent" won't match any ledger_id, so nothing is returned after the cursor
-        List<BudgetLedger> result = repository.list("t1", null, null, null, "nonexistent", 50);
+        List<BudgetLedger> result = repository.list("tenant-1", null, null, null, "nonexistent", 50);
 
         assertThat(result).isEmpty();
     }
@@ -626,7 +626,7 @@ class BudgetRepositoryTest {
     private Map<String, String> createBudgetHash(String ledgerId, String scope, String unit) {
         Map<String, String> hash = new LinkedHashMap<>();
         hash.put("ledger_id", ledgerId);
-        hash.put("tenant_id", "t1");
+        hash.put("tenant_id", "tenant-1");
         hash.put("scope", scope);
         hash.put("unit", unit);
         hash.put("allocated", "1000");

--- a/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/EventRepositoryTest.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/EventRepositoryTest.java
@@ -51,7 +51,7 @@ class EventRepositoryTest {
     @Test
     void save_setsEventIdAndTimestamp() {
         Event event = Event.builder()
-                .tenantId("t1")
+                .tenantId("tenant-1")
                 .eventType(EventType.TENANT_CREATED)
                 .category(EventCategory.TENANT)
                 .source("cycles-admin")
@@ -67,7 +67,7 @@ class EventRepositoryTest {
     @Test
     void save_callsLuaWithCorrectKeysAndArgs() throws Exception {
         Event event = Event.builder()
-                .tenantId("t1")
+                .tenantId("tenant-1")
                 .eventType(EventType.BUDGET_CREATED)
                 .category(EventCategory.BUDGET)
                 .source("cycles-admin")
@@ -78,13 +78,13 @@ class EventRepositoryTest {
         verify(jedis).eval(anyString(), argThat((List<String> keys) -> {
             return keys.size() == 3
                 && keys.get(0).startsWith("event:evt_")
-                && keys.get(1).equals("events:t1")
+                && keys.get(1).equals("events:tenant-1")
                 && keys.get(2).equals("events:_all");
         }), argThat((List<String> args) -> {
             try {
                 // ARGV[0] is JSON, ARGV[1] is score, ARGV[2] is eventId
                 Event stored = objectMapper.readValue(args.get(0), Event.class);
-                return "t1".equals(stored.getTenantId())
+                return "tenant-1".equals(stored.getTenantId())
                     && stored.getEventType() == EventType.BUDGET_CREATED;
             } catch (Exception e) {
                 return false;
@@ -95,7 +95,7 @@ class EventRepositoryTest {
     @Test
     void save_withCorrelationId_addsCorrelationKey() {
         Event event = Event.builder()
-                .tenantId("t1")
+                .tenantId("tenant-1")
                 .eventType(EventType.BUDGET_FUNDED)
                 .category(EventCategory.BUDGET)
                 .source("cycles-admin")
@@ -113,7 +113,7 @@ class EventRepositoryTest {
     void save_preservesExistingTimestamp() {
         Instant fixedTime = Instant.parse("2025-06-15T10:00:00Z");
         Event event = Event.builder()
-                .tenantId("t1")
+                .tenantId("tenant-1")
                 .eventType(EventType.TENANT_CREATED)
                 .category(EventCategory.TENANT)
                 .source("cycles-admin")
@@ -133,7 +133,7 @@ class EventRepositoryTest {
                 .eventId("evt_abc123")
                 .eventType(EventType.TENANT_CREATED)
                 .category(EventCategory.TENANT)
-                .tenantId("t1")
+                .tenantId("tenant-1")
                 .source("cycles-admin")
                 .timestamp(Instant.now())
                 .build();
@@ -144,7 +144,7 @@ class EventRepositoryTest {
 
         assertThat(result.getEventId()).isEqualTo("evt_abc123");
         assertThat(result.getEventType()).isEqualTo(EventType.TENANT_CREATED);
-        assertThat(result.getTenantId()).isEqualTo("t1");
+        assertThat(result.getTenantId()).isEqualTo("tenant-1");
     }
 
     @Test
@@ -166,19 +166,19 @@ class EventRepositoryTest {
     @Test
     void list_withTenantFilter_usesCorrectIndex() throws Exception {
         List<String> ids = List.of("evt_1", "evt_2");
-        when(jedis.zrevrangeByScore(eq("events:t1"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(ids);
+        when(jedis.zrevrangeByScore(eq("events:tenant-1"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(ids);
 
-        Event e1 = Event.builder().eventId("evt_1").tenantId("t1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
-        Event e2 = Event.builder().eventId("evt_2").tenantId("t1").eventType(EventType.BUDGET_CREATED).category(EventCategory.BUDGET).source("s").timestamp(Instant.now()).build();
+        Event e1 = Event.builder().eventId("evt_1").tenantId("tenant-1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
+        Event e2 = Event.builder().eventId("evt_2").tenantId("tenant-1").eventType(EventType.BUDGET_CREATED).category(EventCategory.BUDGET).source("s").timestamp(Instant.now()).build();
         String e1Json = objectMapper.writeValueAsString(e1);
         String e2Json = objectMapper.writeValueAsString(e2);
         when(jedis.get("event:evt_1")).thenReturn(e1Json);
         when(jedis.get("event:evt_2")).thenReturn(e2Json);
 
-        List<Event> result = repository.list("t1", null, null, null, null, null, null, null, 50);
+        List<Event> result = repository.list("tenant-1", null, null, null, null, null, null, null, 50);
 
         assertThat(result).hasSize(2);
-        verify(jedis).zrevrangeByScore(eq("events:t1"), anyDouble(), anyDouble(), eq(0), anyInt());
+        verify(jedis).zrevrangeByScore(eq("events:tenant-1"), anyDouble(), anyDouble(), eq(0), anyInt());
     }
 
     @Test
@@ -186,7 +186,7 @@ class EventRepositoryTest {
         List<String> ids = List.of("evt_1");
         when(jedis.zrevrangeByScore(eq("events:_all"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(ids);
 
-        Event e1 = Event.builder().eventId("evt_1").tenantId("t1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
+        Event e1 = Event.builder().eventId("evt_1").tenantId("tenant-1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
         String e1Json = objectMapper.writeValueAsString(e1);
         when(jedis.get("event:evt_1")).thenReturn(e1Json);
 
@@ -198,16 +198,16 @@ class EventRepositoryTest {
 
     @Test
     void list_withCursorPagination_adjustsMaxScore() throws Exception {
-        when(jedis.zscore("events:t1", "evt_cursor")).thenReturn(5000.0);
+        when(jedis.zscore("events:tenant-1", "evt_cursor")).thenReturn(5000.0);
 
         List<String> ids = List.of("evt_2");
-        when(jedis.zrevrangeByScore(eq("events:t1"), eq(4999.0), eq(Double.NEGATIVE_INFINITY), eq(0), anyInt())).thenReturn(ids);
+        when(jedis.zrevrangeByScore(eq("events:tenant-1"), eq(4999.0), eq(Double.NEGATIVE_INFINITY), eq(0), anyInt())).thenReturn(ids);
 
-        Event e2 = Event.builder().eventId("evt_2").tenantId("t1").eventType(EventType.TENANT_UPDATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
+        Event e2 = Event.builder().eventId("evt_2").tenantId("tenant-1").eventType(EventType.TENANT_UPDATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
         String e2Json = objectMapper.writeValueAsString(e2);
         when(jedis.get("event:evt_2")).thenReturn(e2Json);
 
-        List<Event> result = repository.list("t1", null, null, null, null, null, null, "evt_cursor", 50);
+        List<Event> result = repository.list("tenant-1", null, null, null, null, null, null, "evt_cursor", 50);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getEventId()).isEqualTo("evt_2");
@@ -216,16 +216,16 @@ class EventRepositoryTest {
     @Test
     void list_filtersByEventType() throws Exception {
         List<String> ids = List.of("evt_1", "evt_2");
-        when(jedis.zrevrangeByScore(eq("events:t1"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(ids);
+        when(jedis.zrevrangeByScore(eq("events:tenant-1"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(ids);
 
-        Event e1 = Event.builder().eventId("evt_1").tenantId("t1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
-        Event e2 = Event.builder().eventId("evt_2").tenantId("t1").eventType(EventType.BUDGET_CREATED).category(EventCategory.BUDGET).source("s").timestamp(Instant.now()).build();
+        Event e1 = Event.builder().eventId("evt_1").tenantId("tenant-1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
+        Event e2 = Event.builder().eventId("evt_2").tenantId("tenant-1").eventType(EventType.BUDGET_CREATED).category(EventCategory.BUDGET).source("s").timestamp(Instant.now()).build();
         String e1Json = objectMapper.writeValueAsString(e1);
         String e2Json = objectMapper.writeValueAsString(e2);
         when(jedis.get("event:evt_1")).thenReturn(e1Json);
         when(jedis.get("event:evt_2")).thenReturn(e2Json);
 
-        List<Event> result = repository.list("t1", "tenant.created", null, null, null, null, null, null, 50);
+        List<Event> result = repository.list("tenant-1", "tenant.created", null, null, null, null, null, null, 50);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getEventType()).isEqualTo(EventType.TENANT_CREATED);
@@ -234,16 +234,16 @@ class EventRepositoryTest {
     @Test
     void list_filtersByCategory() throws Exception {
         List<String> ids = List.of("evt_1", "evt_2");
-        when(jedis.zrevrangeByScore(eq("events:t1"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(ids);
+        when(jedis.zrevrangeByScore(eq("events:tenant-1"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(ids);
 
-        Event e1 = Event.builder().eventId("evt_1").tenantId("t1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
-        Event e2 = Event.builder().eventId("evt_2").tenantId("t1").eventType(EventType.BUDGET_CREATED).category(EventCategory.BUDGET).source("s").timestamp(Instant.now()).build();
+        Event e1 = Event.builder().eventId("evt_1").tenantId("tenant-1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
+        Event e2 = Event.builder().eventId("evt_2").tenantId("tenant-1").eventType(EventType.BUDGET_CREATED).category(EventCategory.BUDGET).source("s").timestamp(Instant.now()).build();
         String e1Json = objectMapper.writeValueAsString(e1);
         String e2Json = objectMapper.writeValueAsString(e2);
         when(jedis.get("event:evt_1")).thenReturn(e1Json);
         when(jedis.get("event:evt_2")).thenReturn(e2Json);
 
-        List<Event> result = repository.list("t1", null, "budget", null, null, null, null, null, 50);
+        List<Event> result = repository.list("tenant-1", null, "budget", null, null, null, null, null, 50);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getCategory()).isEqualTo(EventCategory.BUDGET);
@@ -252,16 +252,16 @@ class EventRepositoryTest {
     @Test
     void list_filtersByScopePrefix() throws Exception {
         List<String> ids = List.of("evt_1", "evt_2");
-        when(jedis.zrevrangeByScore(eq("events:t1"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(ids);
+        when(jedis.zrevrangeByScore(eq("events:tenant-1"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(ids);
 
-        Event e1 = Event.builder().eventId("evt_1").tenantId("t1").eventType(EventType.BUDGET_CREATED).category(EventCategory.BUDGET).source("s").scope("org/eng/team1").timestamp(Instant.now()).build();
-        Event e2 = Event.builder().eventId("evt_2").tenantId("t1").eventType(EventType.BUDGET_CREATED).category(EventCategory.BUDGET).source("s").scope("org/sales").timestamp(Instant.now()).build();
+        Event e1 = Event.builder().eventId("evt_1").tenantId("tenant-1").eventType(EventType.BUDGET_CREATED).category(EventCategory.BUDGET).source("s").scope("org/eng/team1").timestamp(Instant.now()).build();
+        Event e2 = Event.builder().eventId("evt_2").tenantId("tenant-1").eventType(EventType.BUDGET_CREATED).category(EventCategory.BUDGET).source("s").scope("org/sales").timestamp(Instant.now()).build();
         String e1Json = objectMapper.writeValueAsString(e1);
         String e2Json = objectMapper.writeValueAsString(e2);
         when(jedis.get("event:evt_1")).thenReturn(e1Json);
         when(jedis.get("event:evt_2")).thenReturn(e2Json);
 
-        List<Event> result = repository.list("t1", null, null, "org/eng", null, null, null, null, 50);
+        List<Event> result = repository.list("tenant-1", null, null, "org/eng", null, null, null, null, 50);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getScope()).startsWith("org/eng");
@@ -269,16 +269,16 @@ class EventRepositoryTest {
 
     @Test
     void list_emptyResults_returnsEmptyList() {
-        when(jedis.zrevrangeByScore(eq("events:t1"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(List.of());
+        when(jedis.zrevrangeByScore(eq("events:tenant-1"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(List.of());
 
-        List<Event> result = repository.list("t1", null, null, null, null, null, null, null, 50);
+        List<Event> result = repository.list("tenant-1", null, null, null, null, null, null, null, 50);
 
         assertThat(result).isEmpty();
     }
 
     @Test
     void list_zeroLimit_returnsEmpty() {
-        List<Event> result = repository.list("t1", null, null, null, null, null, null, null, 0);
+        List<Event> result = repository.list("tenant-1", null, null, null, null, null, null, null, 0);
         assertThat(result).isEmpty();
     }
 
@@ -288,30 +288,30 @@ class EventRepositoryTest {
         Instant to = Instant.ofEpochMilli(2000);
 
         List<String> ids = List.of("evt_1");
-        when(jedis.zrevrangeByScore(eq("events:t1"), eq(2000.0), eq(1000.0), eq(0), anyInt())).thenReturn(ids);
+        when(jedis.zrevrangeByScore(eq("events:tenant-1"), eq(2000.0), eq(1000.0), eq(0), anyInt())).thenReturn(ids);
 
-        Event e1 = Event.builder().eventId("evt_1").tenantId("t1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
+        Event e1 = Event.builder().eventId("evt_1").tenantId("tenant-1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
         String e1Json = objectMapper.writeValueAsString(e1);
         when(jedis.get("event:evt_1")).thenReturn(e1Json);
 
-        List<Event> result = repository.list("t1", null, null, null, null, from, to, null, 50);
+        List<Event> result = repository.list("tenant-1", null, null, null, null, from, to, null, 50);
 
         assertThat(result).hasSize(1);
-        verify(jedis).zrevrangeByScore(eq("events:t1"), eq(2000.0), eq(1000.0), eq(0), anyInt());
+        verify(jedis).zrevrangeByScore(eq("events:tenant-1"), eq(2000.0), eq(1000.0), eq(0), anyInt());
     }
 
     @Test
     void list_withCursorNotInIndex_ignoresCursor() throws Exception {
-        when(jedis.zscore("events:t1", "evt_unknown")).thenReturn(null);
+        when(jedis.zscore("events:tenant-1", "evt_unknown")).thenReturn(null);
 
         List<String> ids = List.of("evt_1");
-        when(jedis.zrevrangeByScore(eq("events:t1"), eq(Double.POSITIVE_INFINITY), eq(Double.NEGATIVE_INFINITY), eq(0), anyInt())).thenReturn(ids);
+        when(jedis.zrevrangeByScore(eq("events:tenant-1"), eq(Double.POSITIVE_INFINITY), eq(Double.NEGATIVE_INFINITY), eq(0), anyInt())).thenReturn(ids);
 
-        Event e1 = Event.builder().eventId("evt_1").tenantId("t1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
+        Event e1 = Event.builder().eventId("evt_1").tenantId("tenant-1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
         String e1Json = objectMapper.writeValueAsString(e1);
         when(jedis.get("event:evt_1")).thenReturn(e1Json);
 
-        List<Event> result = repository.list("t1", null, null, null, null, null, null, "evt_unknown", 50);
+        List<Event> result = repository.list("tenant-1", null, null, null, null, null, null, "evt_unknown", 50);
 
         assertThat(result).hasSize(1);
     }
@@ -319,17 +319,17 @@ class EventRepositoryTest {
     @Test
     void list_cursorWithTimeRange_usesMinOfCursorAndTo() throws Exception {
         Instant to = Instant.ofEpochMilli(8000);
-        when(jedis.zscore("events:t1", "evt_cursor")).thenReturn(5000.0);
+        when(jedis.zscore("events:tenant-1", "evt_cursor")).thenReturn(5000.0);
 
         List<String> ids = List.of("evt_2");
         // cursorScore - 1 = 4999, to = 8000, min(4999, 8000) = 4999
-        when(jedis.zrevrangeByScore(eq("events:t1"), eq(4999.0), eq(Double.NEGATIVE_INFINITY), eq(0), anyInt())).thenReturn(ids);
+        when(jedis.zrevrangeByScore(eq("events:tenant-1"), eq(4999.0), eq(Double.NEGATIVE_INFINITY), eq(0), anyInt())).thenReturn(ids);
 
-        Event e2 = Event.builder().eventId("evt_2").tenantId("t1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
+        Event e2 = Event.builder().eventId("evt_2").tenantId("tenant-1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
         String e2Json = objectMapper.writeValueAsString(e2);
         when(jedis.get("event:evt_2")).thenReturn(e2Json);
 
-        List<Event> result = repository.list("t1", null, null, null, null, null, to, "evt_cursor", 50);
+        List<Event> result = repository.list("tenant-1", null, null, null, null, null, to, "evt_cursor", 50);
 
         assertThat(result).hasSize(1);
     }
@@ -339,17 +339,17 @@ class EventRepositoryTest {
         Set<String> ids = new LinkedHashSet<>(List.of("evt_1", "evt_2"));
         when(jedis.smembers("events:correlation:corr_abc")).thenReturn(ids);
 
-        Event e1 = Event.builder().eventId("evt_1").tenantId("t1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").scope("org/eng").timestamp(Instant.now()).build();
-        Event e2 = Event.builder().eventId("evt_2").tenantId("t2").eventType(EventType.BUDGET_CREATED).category(EventCategory.BUDGET).source("s").scope("org/sales").timestamp(Instant.now()).build();
+        Event e1 = Event.builder().eventId("evt_1").tenantId("tenant-1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").scope("org/eng").timestamp(Instant.now()).build();
+        Event e2 = Event.builder().eventId("evt_2").tenantId("tenant-2").eventType(EventType.BUDGET_CREATED).category(EventCategory.BUDGET).source("s").scope("org/sales").timestamp(Instant.now()).build();
         String e1Json = objectMapper.writeValueAsString(e1);
         String e2Json = objectMapper.writeValueAsString(e2);
         when(jedis.get("event:evt_1")).thenReturn(e1Json);
         when(jedis.get("event:evt_2")).thenReturn(e2Json);
 
-        List<Event> result = repository.list("t1", null, null, null, "corr_abc", null, null, null, 50);
+        List<Event> result = repository.list("tenant-1", null, null, null, "corr_abc", null, null, null, 50);
 
         assertThat(result).hasSize(1);
-        assertThat(result.get(0).getTenantId()).isEqualTo("t1");
+        assertThat(result.get(0).getTenantId()).isEqualTo("tenant-1");
     }
 
     @Test
@@ -357,8 +357,8 @@ class EventRepositoryTest {
         Set<String> ids = new LinkedHashSet<>(List.of("evt_1", "evt_2"));
         when(jedis.smembers("events:correlation:corr_abc")).thenReturn(ids);
 
-        Event e1 = Event.builder().eventId("evt_1").tenantId("t1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
-        Event e2 = Event.builder().eventId("evt_2").tenantId("t1").eventType(EventType.BUDGET_CREATED).category(EventCategory.BUDGET).source("s").timestamp(Instant.now()).build();
+        Event e1 = Event.builder().eventId("evt_1").tenantId("tenant-1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
+        Event e2 = Event.builder().eventId("evt_2").tenantId("tenant-1").eventType(EventType.BUDGET_CREATED).category(EventCategory.BUDGET).source("s").timestamp(Instant.now()).build();
         String e1Json = objectMapper.writeValueAsString(e1);
         String e2Json = objectMapper.writeValueAsString(e2);
         when(jedis.get("event:evt_1")).thenReturn(e1Json);
@@ -375,8 +375,8 @@ class EventRepositoryTest {
         Set<String> ids = new LinkedHashSet<>(List.of("evt_1", "evt_2"));
         when(jedis.smembers("events:correlation:corr_abc")).thenReturn(ids);
 
-        Event e1 = Event.builder().eventId("evt_1").tenantId("t1").eventType(EventType.BUDGET_CREATED).category(EventCategory.BUDGET).source("s").scope("org/eng").timestamp(Instant.now()).build();
-        Event e2 = Event.builder().eventId("evt_2").tenantId("t1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").scope("org/sales").timestamp(Instant.now()).build();
+        Event e1 = Event.builder().eventId("evt_1").tenantId("tenant-1").eventType(EventType.BUDGET_CREATED).category(EventCategory.BUDGET).source("s").scope("org/eng").timestamp(Instant.now()).build();
+        Event e2 = Event.builder().eventId("evt_2").tenantId("tenant-1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").scope("org/sales").timestamp(Instant.now()).build();
         String e1Json = objectMapper.writeValueAsString(e1);
         String e2Json = objectMapper.writeValueAsString(e2);
         when(jedis.get("event:evt_1")).thenReturn(e1Json);
@@ -394,7 +394,7 @@ class EventRepositoryTest {
         when(jedis.smembers("events:correlation:corr_abc")).thenReturn(ids);
 
         when(jedis.get("event:evt_1")).thenReturn(null);
-        Event e2 = Event.builder().eventId("evt_2").tenantId("t1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
+        Event e2 = Event.builder().eventId("evt_2").tenantId("tenant-1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
         String e2Json = objectMapper.writeValueAsString(e2);
         when(jedis.get("event:evt_2")).thenReturn(e2Json);
 
@@ -408,8 +408,8 @@ class EventRepositoryTest {
         Set<String> ids = new LinkedHashSet<>(List.of("evt_1", "evt_2"));
         when(jedis.smembers("events:correlation:corr_abc")).thenReturn(ids);
 
-        Event e1 = Event.builder().eventId("evt_1").tenantId("t1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
-        Event e2 = Event.builder().eventId("evt_2").tenantId("t1").eventType(EventType.BUDGET_CREATED).category(EventCategory.BUDGET).source("s").timestamp(Instant.now()).build();
+        Event e1 = Event.builder().eventId("evt_1").tenantId("tenant-1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
+        Event e2 = Event.builder().eventId("evt_2").tenantId("tenant-1").eventType(EventType.BUDGET_CREATED).category(EventCategory.BUDGET).source("s").timestamp(Instant.now()).build();
         String e1Json = objectMapper.writeValueAsString(e1);
         String e2Json = objectMapper.writeValueAsString(e2);
         when(jedis.get("event:evt_1")).thenReturn(e1Json);
@@ -425,7 +425,7 @@ class EventRepositoryTest {
         Set<String> ids = new LinkedHashSet<>(List.of("evt_1"));
         when(jedis.smembers("events:correlation:corr_abc")).thenReturn(ids);
 
-        Event e1 = Event.builder().eventId("evt_1").tenantId("t1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
+        Event e1 = Event.builder().eventId("evt_1").tenantId("tenant-1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
         // scope is null
         String e1Json = objectMapper.writeValueAsString(e1);
         when(jedis.get("event:evt_1")).thenReturn(e1Json);
@@ -438,14 +438,14 @@ class EventRepositoryTest {
     @Test
     void list_scopeFilterWithNullScopeOnEvent_filtersOut() throws Exception {
         List<String> ids = List.of("evt_1");
-        when(jedis.zrevrangeByScore(eq("events:t1"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(ids);
+        when(jedis.zrevrangeByScore(eq("events:tenant-1"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(ids);
 
-        Event e1 = Event.builder().eventId("evt_1").tenantId("t1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
+        Event e1 = Event.builder().eventId("evt_1").tenantId("tenant-1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
         // scope is null
         String e1Json = objectMapper.writeValueAsString(e1);
         when(jedis.get("event:evt_1")).thenReturn(e1Json);
 
-        List<Event> result = repository.list("t1", null, null, "org/eng", null, null, null, null, 50);
+        List<Event> result = repository.list("tenant-1", null, null, "org/eng", null, null, null, null, 50);
 
         assertThat(result).isEmpty();
     }
@@ -453,11 +453,11 @@ class EventRepositoryTest {
     @Test
     void list_respectsLimitDuringIteration() throws Exception {
         List<String> ids = List.of("evt_1", "evt_2", "evt_3");
-        when(jedis.zrevrangeByScore(eq("events:t1"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(ids);
+        when(jedis.zrevrangeByScore(eq("events:tenant-1"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(ids);
 
-        Event e1 = Event.builder().eventId("evt_1").tenantId("t1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
-        Event e2 = Event.builder().eventId("evt_2").tenantId("t1").eventType(EventType.TENANT_UPDATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
-        Event e3 = Event.builder().eventId("evt_3").tenantId("t1").eventType(EventType.BUDGET_CREATED).category(EventCategory.BUDGET).source("s").timestamp(Instant.now()).build();
+        Event e1 = Event.builder().eventId("evt_1").tenantId("tenant-1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
+        Event e2 = Event.builder().eventId("evt_2").tenantId("tenant-1").eventType(EventType.TENANT_UPDATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
+        Event e3 = Event.builder().eventId("evt_3").tenantId("tenant-1").eventType(EventType.BUDGET_CREATED).category(EventCategory.BUDGET).source("s").timestamp(Instant.now()).build();
         String e1Json = objectMapper.writeValueAsString(e1);
         String e2Json = objectMapper.writeValueAsString(e2);
         String e3Json = objectMapper.writeValueAsString(e3);
@@ -465,7 +465,7 @@ class EventRepositoryTest {
         when(jedis.get("event:evt_2")).thenReturn(e2Json);
         lenient().when(jedis.get("event:evt_3")).thenReturn(e3Json);
 
-        List<Event> result = repository.list("t1", null, null, null, null, null, null, null, 2);
+        List<Event> result = repository.list("tenant-1", null, null, null, null, null, null, null, 2);
 
         assertThat(result).hasSize(2);
     }
@@ -473,14 +473,14 @@ class EventRepositoryTest {
     @Test
     void list_parseFailure_skipsGracefully() throws Exception {
         List<String> ids = List.of("evt_bad", "evt_good");
-        when(jedis.zrevrangeByScore(eq("events:t1"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(ids);
+        when(jedis.zrevrangeByScore(eq("events:tenant-1"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(ids);
 
-        Event good = Event.builder().eventId("evt_good").tenantId("t1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
+        Event good = Event.builder().eventId("evt_good").tenantId("tenant-1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
         String goodJson = objectMapper.writeValueAsString(good);
         when(jedis.get("event:evt_bad")).thenReturn("{invalid json}");
         when(jedis.get("event:evt_good")).thenReturn(goodJson);
 
-        List<Event> result = repository.list("t1", null, null, null, null, null, null, null, 50);
+        List<Event> result = repository.list("tenant-1", null, null, null, null, null, null, null, 50);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getEventId()).isEqualTo("evt_good");
@@ -489,7 +489,7 @@ class EventRepositoryTest {
     @Test
     void save_withBlankCorrelationId_noCorrelationKey() {
         Event event = Event.builder()
-                .tenantId("t1")
+                .tenantId("tenant-1")
                 .eventType(EventType.BUDGET_FUNDED)
                 .category(EventCategory.BUDGET)
                 .source("cycles-admin")
@@ -508,7 +508,7 @@ class EventRepositoryTest {
         when(jedis.eval(anyString(), anyList(), anyList())).thenThrow(new RuntimeException("Redis down"));
 
         Event event = Event.builder()
-                .tenantId("t1")
+                .tenantId("tenant-1")
                 .eventType(EventType.TENANT_CREATED)
                 .category(EventCategory.TENANT)
                 .source("cycles-admin")
@@ -531,14 +531,14 @@ class EventRepositoryTest {
     @Test
     void list_missingEventData_skipsGracefully() throws Exception {
         List<String> ids = List.of("evt_1", "evt_2");
-        when(jedis.zrevrangeByScore(eq("events:t1"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(ids);
+        when(jedis.zrevrangeByScore(eq("events:tenant-1"), anyDouble(), anyDouble(), eq(0), anyInt())).thenReturn(ids);
 
         when(jedis.get("event:evt_1")).thenReturn(null);
-        Event e2 = Event.builder().eventId("evt_2").tenantId("t1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
+        Event e2 = Event.builder().eventId("evt_2").tenantId("tenant-1").eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT).source("s").timestamp(Instant.now()).build();
         String e2Json = objectMapper.writeValueAsString(e2);
         when(jedis.get("event:evt_2")).thenReturn(e2Json);
 
-        List<Event> result = repository.list("t1", null, null, null, null, null, null, null, 50);
+        List<Event> result = repository.list("tenant-1", null, null, null, null, null, null, null, 50);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getEventId()).isEqualTo("evt_2");

--- a/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/TenantRepositoryTest.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/TenantRepositoryTest.java
@@ -100,14 +100,14 @@ class TenantRepositoryTest {
     @Test
     void get_existingTenant_returnsTenant() throws Exception {
         Tenant tenant = Tenant.builder()
-                .tenantId("t1").name("Tenant 1").status(TenantStatus.ACTIVE)
+                .tenantId("tenant-1").name("Tenant 1").status(TenantStatus.ACTIVE)
                 .createdAt(Instant.now()).build();
         String tenantJson = objectMapper.writeValueAsString(tenant);
-        when(jedis.get("tenant:t1")).thenReturn(tenantJson);
+        when(jedis.get("tenant:tenant-1")).thenReturn(tenantJson);
 
-        Tenant result = repository.get("t1");
+        Tenant result = repository.get("tenant-1");
 
-        assertThat(result.getTenantId()).isEqualTo("t1");
+        assertThat(result.getTenantId()).isEqualTo("tenant-1");
         assertThat(result.getName()).isEqualTo("Tenant 1");
     }
 
@@ -126,48 +126,48 @@ class TenantRepositoryTest {
 
     @Test
     void list_returnsFilteredByStatus() throws Exception {
-        Set<String> ids = new LinkedHashSet<>(List.of("t1", "t2"));
+        Set<String> ids = new LinkedHashSet<>(List.of("tenant-1", "tenant-2"));
         when(jedis.smembers("tenants")).thenReturn(ids);
 
-        Tenant t1 = Tenant.builder().tenantId("t1").name("A").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build();
-        Tenant t2 = Tenant.builder().tenantId("t2").name("B").status(TenantStatus.SUSPENDED).createdAt(Instant.now()).build();
+        Tenant t1 = Tenant.builder().tenantId("tenant-1").name("A").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build();
+        Tenant t2 = Tenant.builder().tenantId("tenant-2").name("B").status(TenantStatus.SUSPENDED).createdAt(Instant.now()).build();
         String t1Json = objectMapper.writeValueAsString(t1);
         String t2Json = objectMapper.writeValueAsString(t2);
-        when(jedis.get("tenant:t1")).thenReturn(t1Json);
-        when(jedis.get("tenant:t2")).thenReturn(t2Json);
+        when(jedis.get("tenant:tenant-1")).thenReturn(t1Json);
+        when(jedis.get("tenant:tenant-2")).thenReturn(t2Json);
 
         List<Tenant> result = repository.list(TenantStatus.ACTIVE, null, null, 50);
 
         assertThat(result).hasSize(1);
-        assertThat(result.get(0).getTenantId()).isEqualTo("t1");
+        assertThat(result.get(0).getTenantId()).isEqualTo("tenant-1");
     }
 
     @Test
     void list_respectsCursorPagination() throws Exception {
-        Set<String> ids = new LinkedHashSet<>(List.of("t1", "t2", "t3"));
+        Set<String> ids = new LinkedHashSet<>(List.of("tenant-1", "tenant-2", "tenant-3"));
         when(jedis.smembers("tenants")).thenReturn(ids);
 
-        Tenant t2 = Tenant.builder().tenantId("t2").name("B").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build();
-        Tenant t3 = Tenant.builder().tenantId("t3").name("C").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build();
+        Tenant t2 = Tenant.builder().tenantId("tenant-2").name("B").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build();
+        Tenant t3 = Tenant.builder().tenantId("tenant-3").name("C").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build();
         String t2Json = objectMapper.writeValueAsString(t2);
         String t3Json = objectMapper.writeValueAsString(t3);
-        when(jedis.get("tenant:t2")).thenReturn(t2Json);
-        when(jedis.get("tenant:t3")).thenReturn(t3Json);
+        when(jedis.get("tenant:tenant-2")).thenReturn(t2Json);
+        when(jedis.get("tenant:tenant-3")).thenReturn(t3Json);
 
-        List<Tenant> result = repository.list(null, null, "t1", 50);
+        List<Tenant> result = repository.list(null, null, "tenant-1", 50);
 
         assertThat(result).hasSize(2);
-        assertThat(result.get(0).getTenantId()).isEqualTo("t2");
+        assertThat(result.get(0).getTenantId()).isEqualTo("tenant-2");
     }
 
     @Test
     void list_respectsLimit() throws Exception {
-        Set<String> ids = new LinkedHashSet<>(List.of("t1", "t2", "t3"));
+        Set<String> ids = new LinkedHashSet<>(List.of("tenant-1", "tenant-2", "tenant-3"));
         when(jedis.smembers("tenants")).thenReturn(ids);
 
-        Tenant t1 = Tenant.builder().tenantId("t1").name("A").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build();
+        Tenant t1 = Tenant.builder().tenantId("tenant-1").name("A").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build();
         String t1Json = objectMapper.writeValueAsString(t1);
-        when(jedis.get("tenant:t1")).thenReturn(t1Json);
+        when(jedis.get("tenant:tenant-1")).thenReturn(t1Json);
 
         List<Tenant> result = repository.list(null, null, null, 1);
 
@@ -176,39 +176,39 @@ class TenantRepositoryTest {
 
     @Test
     void list_filtersByParentTenantId() throws Exception {
-        Set<String> ids = new LinkedHashSet<>(List.of("t1", "t2"));
+        Set<String> ids = new LinkedHashSet<>(List.of("tenant-1", "tenant-2"));
         when(jedis.smembers("tenants")).thenReturn(ids);
 
-        Tenant t1 = Tenant.builder().tenantId("t1").name("A").status(TenantStatus.ACTIVE).parentTenantId("parent1").createdAt(Instant.now()).build();
-        Tenant t2 = Tenant.builder().tenantId("t2").name("B").status(TenantStatus.ACTIVE).parentTenantId("parent2").createdAt(Instant.now()).build();
+        Tenant t1 = Tenant.builder().tenantId("tenant-1").name("A").status(TenantStatus.ACTIVE).parentTenantId("parent1").createdAt(Instant.now()).build();
+        Tenant t2 = Tenant.builder().tenantId("tenant-2").name("B").status(TenantStatus.ACTIVE).parentTenantId("parent2").createdAt(Instant.now()).build();
         String t1Json = objectMapper.writeValueAsString(t1);
         String t2Json = objectMapper.writeValueAsString(t2);
-        when(jedis.get("tenant:t1")).thenReturn(t1Json);
-        when(jedis.get("tenant:t2")).thenReturn(t2Json);
+        when(jedis.get("tenant:tenant-1")).thenReturn(t1Json);
+        when(jedis.get("tenant:tenant-2")).thenReturn(t2Json);
 
         List<Tenant> result = repository.list(null, "parent1", null, 50);
 
         assertThat(result).hasSize(1);
-        assertThat(result.get(0).getTenantId()).isEqualTo("t1");
+        assertThat(result.get(0).getTenantId()).isEqualTo("tenant-1");
     }
 
     @Test
     void update_name_updatesSuccessfully() throws Exception {
-        Tenant updated = Tenant.builder().tenantId("t1").name("New Name").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build();
+        Tenant updated = Tenant.builder().tenantId("tenant-1").name("New Name").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build();
         String updatedJson = objectMapper.writeValueAsString(updated);
         when(jedis.eval(anyString(), anyList(), anyList())).thenReturn(List.of("OK", updatedJson));
 
         TenantUpdateRequest req = new TenantUpdateRequest();
         req.setName("New Name");
 
-        Tenant result = repository.update("t1", req);
+        Tenant result = repository.update("tenant-1", req);
 
         assertThat(result.getName()).isEqualTo("New Name");
     }
 
     @Test
     void update_statusActiveToSuspended_succeeds() throws Exception {
-        Tenant updated = Tenant.builder().tenantId("t1").name("T").status(TenantStatus.SUSPENDED)
+        Tenant updated = Tenant.builder().tenantId("tenant-1").name("T").status(TenantStatus.SUSPENDED)
                 .suspendedAt(Instant.now()).createdAt(Instant.now()).build();
         String updatedJson = objectMapper.writeValueAsString(updated);
         when(jedis.eval(anyString(), anyList(), anyList())).thenReturn(List.of("OK", updatedJson));
@@ -216,7 +216,7 @@ class TenantRepositoryTest {
         TenantUpdateRequest req = new TenantUpdateRequest();
         req.setStatus(TenantStatus.SUSPENDED);
 
-        Tenant result = repository.update("t1", req);
+        Tenant result = repository.update("tenant-1", req);
 
         assertThat(result.getStatus()).isEqualTo(TenantStatus.SUSPENDED);
         assertThat(result.getSuspendedAt()).isNotNull();
@@ -224,7 +224,7 @@ class TenantRepositoryTest {
 
     @Test
     void update_statusActiveToClosed_succeeds() throws Exception {
-        Tenant updated = Tenant.builder().tenantId("t1").name("T").status(TenantStatus.CLOSED)
+        Tenant updated = Tenant.builder().tenantId("tenant-1").name("T").status(TenantStatus.CLOSED)
                 .closedAt(Instant.now()).createdAt(Instant.now()).build();
         String updatedJson = objectMapper.writeValueAsString(updated);
         when(jedis.eval(anyString(), anyList(), anyList())).thenReturn(List.of("OK", updatedJson));
@@ -232,7 +232,7 @@ class TenantRepositoryTest {
         TenantUpdateRequest req = new TenantUpdateRequest();
         req.setStatus(TenantStatus.CLOSED);
 
-        Tenant result = repository.update("t1", req);
+        Tenant result = repository.update("tenant-1", req);
 
         assertThat(result.getStatus()).isEqualTo(TenantStatus.CLOSED);
         assertThat(result.getClosedAt()).isNotNull();
@@ -240,14 +240,14 @@ class TenantRepositoryTest {
 
     @Test
     void update_statusSuspendedToActive_succeeds() throws Exception {
-        Tenant updated = Tenant.builder().tenantId("t1").name("T").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build();
+        Tenant updated = Tenant.builder().tenantId("tenant-1").name("T").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build();
         String updatedJson = objectMapper.writeValueAsString(updated);
         when(jedis.eval(anyString(), anyList(), anyList())).thenReturn(List.of("OK", updatedJson));
 
         TenantUpdateRequest req = new TenantUpdateRequest();
         req.setStatus(TenantStatus.ACTIVE);
 
-        Tenant result = repository.update("t1", req);
+        Tenant result = repository.update("tenant-1", req);
 
         assertThat(result.getStatus()).isEqualTo(TenantStatus.ACTIVE);
     }
@@ -260,7 +260,7 @@ class TenantRepositoryTest {
         TenantUpdateRequest req = new TenantUpdateRequest();
         req.setStatus(TenantStatus.ACTIVE);
 
-        assertThatThrownBy(() -> repository.update("t1", req))
+        assertThatThrownBy(() -> repository.update("tenant-1", req))
                 .isInstanceOf(GovernanceException.class)
                 .satisfies(e -> {
                     GovernanceException ge = (GovernanceException) e;
@@ -277,7 +277,7 @@ class TenantRepositoryTest {
         TenantUpdateRequest req = new TenantUpdateRequest();
         req.setStatus(TenantStatus.SUSPENDED);
 
-        assertThatThrownBy(() -> repository.update("t1", req))
+        assertThatThrownBy(() -> repository.update("tenant-1", req))
                 .isInstanceOf(GovernanceException.class)
                 .satisfies(e -> {
                     GovernanceException ge = (GovernanceException) e;
@@ -288,7 +288,7 @@ class TenantRepositoryTest {
 
     @Test
     void update_metadata_updatesSuccessfully() throws Exception {
-        Tenant updated = Tenant.builder().tenantId("t1").name("T").status(TenantStatus.ACTIVE)
+        Tenant updated = Tenant.builder().tenantId("tenant-1").name("T").status(TenantStatus.ACTIVE)
                 .metadata(Map.of("env", "prod")).createdAt(Instant.now()).build();
         String updatedJson = objectMapper.writeValueAsString(updated);
         when(jedis.eval(anyString(), anyList(), anyList())).thenReturn(List.of("OK", updatedJson));
@@ -296,7 +296,7 @@ class TenantRepositoryTest {
         TenantUpdateRequest req = new TenantUpdateRequest();
         req.setMetadata(Map.of("env", "prod"));
 
-        Tenant result = repository.update("t1", req);
+        Tenant result = repository.update("tenant-1", req);
 
         assertThat(result.getMetadata()).containsEntry("env", "prod");
     }
@@ -325,7 +325,7 @@ class TenantRepositoryTest {
         TenantUpdateRequest req = new TenantUpdateRequest();
         req.setStatus(TenantStatus.ACTIVE);
 
-        assertThatThrownBy(() -> repository.update("t1", req))
+        assertThatThrownBy(() -> repository.update("tenant-1", req))
                 .isInstanceOf(GovernanceException.class)
                 .satisfies(e -> {
                     GovernanceException ge = (GovernanceException) e;
@@ -337,18 +337,18 @@ class TenantRepositoryTest {
 
     @Test
     void list_missingTenantData_skipsGracefully() throws Exception {
-        Set<String> ids = new LinkedHashSet<>(List.of("t1", "t2"));
+        Set<String> ids = new LinkedHashSet<>(List.of("tenant-1", "tenant-2"));
         when(jedis.smembers("tenants")).thenReturn(ids);
 
-        when(jedis.get("tenant:t1")).thenReturn(null);
-        Tenant t2 = Tenant.builder().tenantId("t2").name("B").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build();
+        when(jedis.get("tenant:tenant-1")).thenReturn(null);
+        Tenant t2 = Tenant.builder().tenantId("tenant-2").name("B").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build();
         String t2Json = objectMapper.writeValueAsString(t2);
-        when(jedis.get("tenant:t2")).thenReturn(t2Json);
+        when(jedis.get("tenant:tenant-2")).thenReturn(t2Json);
 
         List<Tenant> result = repository.list(null, null, null, 50);
 
         assertThat(result).hasSize(1);
-        assertThat(result.get(0).getTenantId()).isEqualTo("t2");
+        assertThat(result.get(0).getTenantId()).isEqualTo("tenant-2");
     }
 
     @Test
@@ -362,28 +362,28 @@ class TenantRepositoryTest {
 
     @Test
     void list_combinedStatusAndParentFilter() throws Exception {
-        Set<String> ids = new LinkedHashSet<>(List.of("t1", "t2", "t3"));
+        Set<String> ids = new LinkedHashSet<>(List.of("tenant-1", "tenant-2", "tenant-3"));
         when(jedis.smembers("tenants")).thenReturn(ids);
 
-        Tenant t1 = Tenant.builder().tenantId("t1").name("A").status(TenantStatus.ACTIVE).parentTenantId("parent1").createdAt(Instant.now()).build();
-        Tenant t2 = Tenant.builder().tenantId("t2").name("B").status(TenantStatus.SUSPENDED).parentTenantId("parent1").createdAt(Instant.now()).build();
-        Tenant t3 = Tenant.builder().tenantId("t3").name("C").status(TenantStatus.ACTIVE).parentTenantId("parent2").createdAt(Instant.now()).build();
+        Tenant t1 = Tenant.builder().tenantId("tenant-1").name("A").status(TenantStatus.ACTIVE).parentTenantId("parent1").createdAt(Instant.now()).build();
+        Tenant t2 = Tenant.builder().tenantId("tenant-2").name("B").status(TenantStatus.SUSPENDED).parentTenantId("parent1").createdAt(Instant.now()).build();
+        Tenant t3 = Tenant.builder().tenantId("tenant-3").name("C").status(TenantStatus.ACTIVE).parentTenantId("parent2").createdAt(Instant.now()).build();
         String t1Json = objectMapper.writeValueAsString(t1);
         String t2Json = objectMapper.writeValueAsString(t2);
         String t3Json = objectMapper.writeValueAsString(t3);
-        when(jedis.get("tenant:t1")).thenReturn(t1Json);
-        when(jedis.get("tenant:t2")).thenReturn(t2Json);
-        when(jedis.get("tenant:t3")).thenReturn(t3Json);
+        when(jedis.get("tenant:tenant-1")).thenReturn(t1Json);
+        when(jedis.get("tenant:tenant-2")).thenReturn(t2Json);
+        when(jedis.get("tenant:tenant-3")).thenReturn(t3Json);
 
         List<Tenant> result = repository.list(TenantStatus.ACTIVE, "parent1", null, 50);
 
         assertThat(result).hasSize(1);
-        assertThat(result.get(0).getTenantId()).isEqualTo("t1");
+        assertThat(result.get(0).getTenantId()).isEqualTo("tenant-1");
     }
 
     @Test
     void update_nameAndStatusTogether_succeeds() throws Exception {
-        Tenant updated = Tenant.builder().tenantId("t1").name("New Name").status(TenantStatus.SUSPENDED)
+        Tenant updated = Tenant.builder().tenantId("tenant-1").name("New Name").status(TenantStatus.SUSPENDED)
                 .suspendedAt(Instant.now()).createdAt(Instant.now()).build();
         String updatedJson = objectMapper.writeValueAsString(updated);
         when(jedis.eval(anyString(), anyList(), anyList())).thenReturn(List.of("OK", updatedJson));
@@ -392,7 +392,7 @@ class TenantRepositoryTest {
         req.setName("New Name");
         req.setStatus(TenantStatus.SUSPENDED);
 
-        Tenant result = repository.update("t1", req);
+        Tenant result = repository.update("tenant-1", req);
 
         assertThat(result.getName()).isEqualTo("New Name");
         assertThat(result.getStatus()).isEqualTo(TenantStatus.SUSPENDED);
@@ -403,7 +403,7 @@ class TenantRepositoryTest {
         when(jedis.eval(anyString(), anyList(), anyList())).thenThrow(new RuntimeException("Redis down"));
 
         TenantCreateRequest request = new TenantCreateRequest();
-        request.setTenantId("t1");
+        request.setTenantId("tenant-1");
         request.setName("Test");
 
         assertThatThrownBy(() -> repository.create(request))
@@ -415,25 +415,25 @@ class TenantRepositoryTest {
     void get_genericException_wrappedInRuntimeException() {
         when(jedis.get(anyString())).thenThrow(new RuntimeException("Redis down"));
 
-        assertThatThrownBy(() -> repository.get("t1"))
+        assertThatThrownBy(() -> repository.get("tenant-1"))
                 .isInstanceOf(RuntimeException.class)
                 .hasCauseInstanceOf(RuntimeException.class);
     }
 
     @Test
     void list_deserializationFailure_skipsGracefully() throws Exception {
-        Set<String> ids = new LinkedHashSet<>(List.of("t1", "t2"));
+        Set<String> ids = new LinkedHashSet<>(List.of("tenant-1", "tenant-2"));
         when(jedis.smembers("tenants")).thenReturn(ids);
 
-        when(jedis.get("tenant:t1")).thenReturn("{invalid json}");
-        Tenant t2 = Tenant.builder().tenantId("t2").name("B").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build();
+        when(jedis.get("tenant:tenant-1")).thenReturn("{invalid json}");
+        Tenant t2 = Tenant.builder().tenantId("tenant-2").name("B").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build();
         String t2Json = objectMapper.writeValueAsString(t2);
-        when(jedis.get("tenant:t2")).thenReturn(t2Json);
+        when(jedis.get("tenant:tenant-2")).thenReturn(t2Json);
 
         List<Tenant> result = repository.list(null, null, null, 50);
 
         assertThat(result).hasSize(1);
-        assertThat(result.get(0).getTenantId()).isEqualTo("t2");
+        assertThat(result.get(0).getTenantId()).isEqualTo("tenant-2");
     }
 
     @Test
@@ -443,7 +443,7 @@ class TenantRepositoryTest {
         TenantUpdateRequest req = new TenantUpdateRequest();
         req.setName("New Name");
 
-        assertThatThrownBy(() -> repository.update("t1", req))
+        assertThatThrownBy(() -> repository.update("tenant-1", req))
                 .isInstanceOf(RuntimeException.class)
                 .hasCauseInstanceOf(RuntimeException.class);
     }

--- a/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/WebhookRepositoryTest.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/WebhookRepositoryTest.java
@@ -54,7 +54,7 @@ class WebhookRepositoryTest {
     @Test
     void save_setsSubscriptionIdAndDefaults() {
         WebhookSubscription sub = WebhookSubscription.builder()
-                .tenantId("t1")
+                .tenantId("tenant-1")
                 .url("https://example.com/hook")
                 .eventTypes(List.of(EventType.TENANT_CREATED))
                 .build();
@@ -71,7 +71,7 @@ class WebhookRepositoryTest {
     @Test
     void save_callsLuaWithCorrectKeysAndSerializedJson() throws Exception {
         WebhookSubscription sub = WebhookSubscription.builder()
-                .tenantId("t1")
+                .tenantId("tenant-1")
                 .url("https://example.com/hook")
                 .eventTypes(List.of(EventType.BUDGET_CREATED))
                 .build();
@@ -81,12 +81,12 @@ class WebhookRepositoryTest {
         verify(jedis).eval(anyString(), argThat((List<String> keys) -> {
             return keys.size() == 3
                 && keys.get(0).startsWith("webhook:whsub_")
-                && keys.get(1).equals("webhooks:t1")
+                && keys.get(1).equals("webhooks:tenant-1")
                 && keys.get(2).equals("webhooks:_all");
         }), argThat((List<String> args) -> {
             try {
                 WebhookSubscription stored = objectMapper.readValue(args.get(0), WebhookSubscription.class);
-                return "t1".equals(stored.getTenantId())
+                return "tenant-1".equals(stored.getTenantId())
                     && "https://example.com/hook".equals(stored.getUrl());
             } catch (Exception e) {
                 return false;
@@ -100,7 +100,7 @@ class WebhookRepositoryTest {
     void findById_success_returnsSubscription() throws Exception {
         WebhookSubscription sub = WebhookSubscription.builder()
                 .subscriptionId("whsub_abc123")
-                .tenantId("t1")
+                .tenantId("tenant-1")
                 .url("https://example.com/hook")
                 .status(WebhookStatus.ACTIVE)
                 .eventTypes(List.of(EventType.TENANT_CREATED))
@@ -113,7 +113,7 @@ class WebhookRepositoryTest {
         WebhookSubscription result = repository.findById("whsub_abc123");
 
         assertThat(result.getSubscriptionId()).isEqualTo("whsub_abc123");
-        assertThat(result.getTenantId()).isEqualTo("t1");
+        assertThat(result.getTenantId()).isEqualTo("tenant-1");
         assertThat(result.getStatus()).isEqualTo(WebhookStatus.ACTIVE);
     }
 
@@ -137,7 +137,7 @@ class WebhookRepositoryTest {
     void update_callsSetWithUpdatedJson() throws Exception {
         WebhookSubscription updated = WebhookSubscription.builder()
                 .subscriptionId("whsub_abc123")
-                .tenantId("t1")
+                .tenantId("tenant-1")
                 .url("https://updated.example.com/hook")
                 .status(WebhookStatus.PAUSED)
                 .eventTypes(List.of(EventType.TENANT_CREATED))
@@ -157,7 +157,7 @@ class WebhookRepositoryTest {
     void delete_callsLuaWithCorrectKeys() throws Exception {
         WebhookSubscription sub = WebhookSubscription.builder()
                 .subscriptionId("whsub_abc123")
-                .tenantId("t1")
+                .tenantId("tenant-1")
                 .url("https://example.com/hook")
                 .status(WebhookStatus.ACTIVE)
                 .eventTypes(List.of(EventType.TENANT_CREATED))
@@ -172,7 +172,7 @@ class WebhookRepositoryTest {
         verify(jedis).eval(anyString(), argThat((List<String> keys) -> {
             return keys.size() == 3
                 && keys.get(0).equals("webhook:whsub_abc123")
-                && keys.get(1).equals("webhooks:t1")
+                && keys.get(1).equals("webhooks:tenant-1")
                 && keys.get(2).equals("webhooks:_all");
         }), argThat((List<String> args) -> "whsub_abc123".equals(args.get(0))));
     }
@@ -194,16 +194,16 @@ class WebhookRepositoryTest {
     @Test
     void listByTenant_returnsTenantSubscriptions() throws Exception {
         Set<String> ids = new LinkedHashSet<>(List.of("whsub_1", "whsub_2"));
-        when(jedis.smembers("webhooks:t1")).thenReturn(ids);
+        when(jedis.smembers("webhooks:tenant-1")).thenReturn(ids);
 
-        WebhookSubscription s1 = WebhookSubscription.builder().subscriptionId("whsub_1").tenantId("t1").url("https://a.com").status(WebhookStatus.ACTIVE).eventTypes(List.of(EventType.TENANT_CREATED)).createdAt(Instant.now()).consecutiveFailures(0).build();
-        WebhookSubscription s2 = WebhookSubscription.builder().subscriptionId("whsub_2").tenantId("t1").url("https://b.com").status(WebhookStatus.PAUSED).eventTypes(List.of(EventType.BUDGET_CREATED)).createdAt(Instant.now()).consecutiveFailures(0).build();
+        WebhookSubscription s1 = WebhookSubscription.builder().subscriptionId("whsub_1").tenantId("tenant-1").url("https://a.com").status(WebhookStatus.ACTIVE).eventTypes(List.of(EventType.TENANT_CREATED)).createdAt(Instant.now()).consecutiveFailures(0).build();
+        WebhookSubscription s2 = WebhookSubscription.builder().subscriptionId("whsub_2").tenantId("tenant-1").url("https://b.com").status(WebhookStatus.PAUSED).eventTypes(List.of(EventType.BUDGET_CREATED)).createdAt(Instant.now()).consecutiveFailures(0).build();
         String s1Json = objectMapper.writeValueAsString(s1);
         String s2Json = objectMapper.writeValueAsString(s2);
         when(jedis.get("webhook:whsub_1")).thenReturn(s1Json);
         when(jedis.get("webhook:whsub_2")).thenReturn(s2Json);
 
-        List<WebhookSubscription> result = repository.listByTenant("t1", null, null, null, 50);
+        List<WebhookSubscription> result = repository.listByTenant("tenant-1", null, null, null, 50);
 
         assertThat(result).hasSize(2);
     }
@@ -211,16 +211,16 @@ class WebhookRepositoryTest {
     @Test
     void listByTenant_filtersByStatus() throws Exception {
         Set<String> ids = new LinkedHashSet<>(List.of("whsub_1", "whsub_2"));
-        when(jedis.smembers("webhooks:t1")).thenReturn(ids);
+        when(jedis.smembers("webhooks:tenant-1")).thenReturn(ids);
 
-        WebhookSubscription s1 = WebhookSubscription.builder().subscriptionId("whsub_1").tenantId("t1").url("https://a.com").status(WebhookStatus.ACTIVE).eventTypes(List.of(EventType.TENANT_CREATED)).createdAt(Instant.now()).consecutiveFailures(0).build();
-        WebhookSubscription s2 = WebhookSubscription.builder().subscriptionId("whsub_2").tenantId("t1").url("https://b.com").status(WebhookStatus.PAUSED).eventTypes(List.of(EventType.BUDGET_CREATED)).createdAt(Instant.now()).consecutiveFailures(0).build();
+        WebhookSubscription s1 = WebhookSubscription.builder().subscriptionId("whsub_1").tenantId("tenant-1").url("https://a.com").status(WebhookStatus.ACTIVE).eventTypes(List.of(EventType.TENANT_CREATED)).createdAt(Instant.now()).consecutiveFailures(0).build();
+        WebhookSubscription s2 = WebhookSubscription.builder().subscriptionId("whsub_2").tenantId("tenant-1").url("https://b.com").status(WebhookStatus.PAUSED).eventTypes(List.of(EventType.BUDGET_CREATED)).createdAt(Instant.now()).consecutiveFailures(0).build();
         String s1Json = objectMapper.writeValueAsString(s1);
         String s2Json = objectMapper.writeValueAsString(s2);
         when(jedis.get("webhook:whsub_1")).thenReturn(s1Json);
         when(jedis.get("webhook:whsub_2")).thenReturn(s2Json);
 
-        List<WebhookSubscription> result = repository.listByTenant("t1", "ACTIVE", null, null, 50);
+        List<WebhookSubscription> result = repository.listByTenant("tenant-1", "ACTIVE", null, null, 50);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getStatus()).isEqualTo(WebhookStatus.ACTIVE);
@@ -229,16 +229,16 @@ class WebhookRepositoryTest {
     @Test
     void listByTenant_filtersByEventType() throws Exception {
         Set<String> ids = new LinkedHashSet<>(List.of("whsub_1", "whsub_2"));
-        when(jedis.smembers("webhooks:t1")).thenReturn(ids);
+        when(jedis.smembers("webhooks:tenant-1")).thenReturn(ids);
 
-        WebhookSubscription s1 = WebhookSubscription.builder().subscriptionId("whsub_1").tenantId("t1").url("https://a.com").status(WebhookStatus.ACTIVE).eventTypes(List.of(EventType.TENANT_CREATED)).createdAt(Instant.now()).consecutiveFailures(0).build();
-        WebhookSubscription s2 = WebhookSubscription.builder().subscriptionId("whsub_2").tenantId("t1").url("https://b.com").status(WebhookStatus.ACTIVE).eventTypes(List.of(EventType.BUDGET_CREATED)).createdAt(Instant.now()).consecutiveFailures(0).build();
+        WebhookSubscription s1 = WebhookSubscription.builder().subscriptionId("whsub_1").tenantId("tenant-1").url("https://a.com").status(WebhookStatus.ACTIVE).eventTypes(List.of(EventType.TENANT_CREATED)).createdAt(Instant.now()).consecutiveFailures(0).build();
+        WebhookSubscription s2 = WebhookSubscription.builder().subscriptionId("whsub_2").tenantId("tenant-1").url("https://b.com").status(WebhookStatus.ACTIVE).eventTypes(List.of(EventType.BUDGET_CREATED)).createdAt(Instant.now()).consecutiveFailures(0).build();
         String s1Json = objectMapper.writeValueAsString(s1);
         String s2Json = objectMapper.writeValueAsString(s2);
         when(jedis.get("webhook:whsub_1")).thenReturn(s1Json);
         when(jedis.get("webhook:whsub_2")).thenReturn(s2Json);
 
-        List<WebhookSubscription> result = repository.listByTenant("t1", null, "budget.created", null, 50);
+        List<WebhookSubscription> result = repository.listByTenant("tenant-1", null, "budget.created", null, 50);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getSubscriptionId()).isEqualTo("whsub_2");
@@ -251,7 +251,7 @@ class WebhookRepositoryTest {
         Set<String> ids = new LinkedHashSet<>(List.of("whsub_1"));
         when(jedis.smembers("webhooks:_all")).thenReturn(ids);
 
-        WebhookSubscription s1 = WebhookSubscription.builder().subscriptionId("whsub_1").tenantId("t1").url("https://a.com").status(WebhookStatus.ACTIVE).eventTypes(List.of(EventType.TENANT_CREATED)).createdAt(Instant.now()).consecutiveFailures(0).build();
+        WebhookSubscription s1 = WebhookSubscription.builder().subscriptionId("whsub_1").tenantId("tenant-1").url("https://a.com").status(WebhookStatus.ACTIVE).eventTypes(List.of(EventType.TENANT_CREATED)).createdAt(Instant.now()).consecutiveFailures(0).build();
         String s1Json = objectMapper.writeValueAsString(s1);
         when(jedis.get("webhook:whsub_1")).thenReturn(s1Json);
 
@@ -281,18 +281,18 @@ class WebhookRepositoryTest {
     @Test
     void findMatchingSubscriptions_matchesByEventType() throws Exception {
         Set<String> tenantIds = new LinkedHashSet<>(List.of("whsub_1"));
-        when(jedis.smembers("webhooks:t1")).thenReturn(tenantIds);
+        when(jedis.smembers("webhooks:tenant-1")).thenReturn(tenantIds);
         when(jedis.smembers("webhooks:__system__")).thenReturn(Set.of());
 
         WebhookSubscription sub = WebhookSubscription.builder()
-                .subscriptionId("whsub_1").tenantId("t1").url("https://a.com")
+                .subscriptionId("whsub_1").tenantId("tenant-1").url("https://a.com")
                 .status(WebhookStatus.ACTIVE)
                 .eventTypes(List.of(EventType.BUDGET_CREATED))
                 .createdAt(Instant.now()).consecutiveFailures(0).build();
         String subJson = objectMapper.writeValueAsString(sub);
         when(jedis.get("webhook:whsub_1")).thenReturn(subJson);
 
-        List<WebhookSubscription> result = repository.findMatchingSubscriptions("t1", EventType.BUDGET_CREATED, null);
+        List<WebhookSubscription> result = repository.findMatchingSubscriptions("tenant-1", EventType.BUDGET_CREATED, null);
 
         assertThat(result).hasSize(1);
     }
@@ -300,18 +300,18 @@ class WebhookRepositoryTest {
     @Test
     void findMatchingSubscriptions_matchesByEventCategory() throws Exception {
         Set<String> tenantIds = new LinkedHashSet<>(List.of("whsub_1"));
-        when(jedis.smembers("webhooks:t1")).thenReturn(tenantIds);
+        when(jedis.smembers("webhooks:tenant-1")).thenReturn(tenantIds);
         when(jedis.smembers("webhooks:__system__")).thenReturn(Set.of());
 
         WebhookSubscription sub = WebhookSubscription.builder()
-                .subscriptionId("whsub_1").tenantId("t1").url("https://a.com")
+                .subscriptionId("whsub_1").tenantId("tenant-1").url("https://a.com")
                 .status(WebhookStatus.ACTIVE)
                 .eventCategories(List.of(EventCategory.BUDGET))
                 .createdAt(Instant.now()).consecutiveFailures(0).build();
         String subJson = objectMapper.writeValueAsString(sub);
         when(jedis.get("webhook:whsub_1")).thenReturn(subJson);
 
-        List<WebhookSubscription> result = repository.findMatchingSubscriptions("t1", EventType.BUDGET_FUNDED, null);
+        List<WebhookSubscription> result = repository.findMatchingSubscriptions("tenant-1", EventType.BUDGET_FUNDED, null);
 
         assertThat(result).hasSize(1);
     }
@@ -319,11 +319,11 @@ class WebhookRepositoryTest {
     @Test
     void findMatchingSubscriptions_scopeFilterMatching() throws Exception {
         Set<String> tenantIds = new LinkedHashSet<>(List.of("whsub_1"));
-        when(jedis.smembers("webhooks:t1")).thenReturn(tenantIds);
+        when(jedis.smembers("webhooks:tenant-1")).thenReturn(tenantIds);
         when(jedis.smembers("webhooks:__system__")).thenReturn(Set.of());
 
         WebhookSubscription sub = WebhookSubscription.builder()
-                .subscriptionId("whsub_1").tenantId("t1").url("https://a.com")
+                .subscriptionId("whsub_1").tenantId("tenant-1").url("https://a.com")
                 .status(WebhookStatus.ACTIVE)
                 .eventTypes(List.of(EventType.BUDGET_CREATED))
                 .scopeFilter("org/eng")
@@ -331,26 +331,26 @@ class WebhookRepositoryTest {
         String subJson = objectMapper.writeValueAsString(sub);
         when(jedis.get("webhook:whsub_1")).thenReturn(subJson);
 
-        List<WebhookSubscription> matchResult = repository.findMatchingSubscriptions("t1", EventType.BUDGET_CREATED, "org/eng/team1");
+        List<WebhookSubscription> matchResult = repository.findMatchingSubscriptions("tenant-1", EventType.BUDGET_CREATED, "org/eng/team1");
         assertThat(matchResult).hasSize(1);
 
-        List<WebhookSubscription> noMatchResult = repository.findMatchingSubscriptions("t1", EventType.BUDGET_CREATED, "org/sales/team1");
+        List<WebhookSubscription> noMatchResult = repository.findMatchingSubscriptions("tenant-1", EventType.BUDGET_CREATED, "org/sales/team1");
         assertThat(noMatchResult).isEmpty();
     }
 
     @Test
     void findMatchingSubscriptions_skipsPausedAndDisabled() throws Exception {
         Set<String> tenantIds = new LinkedHashSet<>(List.of("whsub_paused", "whsub_disabled"));
-        when(jedis.smembers("webhooks:t1")).thenReturn(tenantIds);
+        when(jedis.smembers("webhooks:tenant-1")).thenReturn(tenantIds);
         when(jedis.smembers("webhooks:__system__")).thenReturn(Set.of());
 
         WebhookSubscription paused = WebhookSubscription.builder()
-                .subscriptionId("whsub_paused").tenantId("t1").url("https://a.com")
+                .subscriptionId("whsub_paused").tenantId("tenant-1").url("https://a.com")
                 .status(WebhookStatus.PAUSED)
                 .eventTypes(List.of(EventType.BUDGET_CREATED))
                 .createdAt(Instant.now()).consecutiveFailures(0).build();
         WebhookSubscription disabled = WebhookSubscription.builder()
-                .subscriptionId("whsub_disabled").tenantId("t1").url("https://b.com")
+                .subscriptionId("whsub_disabled").tenantId("tenant-1").url("https://b.com")
                 .status(WebhookStatus.DISABLED)
                 .eventTypes(List.of(EventType.BUDGET_CREATED))
                 .createdAt(Instant.now()).consecutiveFailures(0).build();
@@ -359,14 +359,14 @@ class WebhookRepositoryTest {
         when(jedis.get("webhook:whsub_paused")).thenReturn(pausedJson);
         when(jedis.get("webhook:whsub_disabled")).thenReturn(disabledJson);
 
-        List<WebhookSubscription> result = repository.findMatchingSubscriptions("t1", EventType.BUDGET_CREATED, null);
+        List<WebhookSubscription> result = repository.findMatchingSubscriptions("tenant-1", EventType.BUDGET_CREATED, null);
 
         assertThat(result).isEmpty();
     }
 
     @Test
     void findMatchingSubscriptions_includesSystemSubscriptions() throws Exception {
-        when(jedis.smembers("webhooks:t1")).thenReturn(Set.of());
+        when(jedis.smembers("webhooks:tenant-1")).thenReturn(Set.of());
         Set<String> systemIds = new LinkedHashSet<>(List.of("whsub_sys1"));
         when(jedis.smembers("webhooks:__system__")).thenReturn(systemIds);
 
@@ -378,7 +378,7 @@ class WebhookRepositoryTest {
         String sysJson = objectMapper.writeValueAsString(sysSub);
         when(jedis.get("webhook:whsub_sys1")).thenReturn(sysJson);
 
-        List<WebhookSubscription> result = repository.findMatchingSubscriptions("t1", EventType.TENANT_CREATED, null);
+        List<WebhookSubscription> result = repository.findMatchingSubscriptions("tenant-1", EventType.TENANT_CREATED, null);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getTenantId()).isEqualTo("__system__");
@@ -387,11 +387,11 @@ class WebhookRepositoryTest {
     @Test
     void findMatchingSubscriptions_wildcardScopeFilter_matchesAll() throws Exception {
         Set<String> tenantIds = new LinkedHashSet<>(List.of("whsub_1"));
-        when(jedis.smembers("webhooks:t1")).thenReturn(tenantIds);
+        when(jedis.smembers("webhooks:tenant-1")).thenReturn(tenantIds);
         when(jedis.smembers("webhooks:__system__")).thenReturn(Set.of());
 
         WebhookSubscription sub = WebhookSubscription.builder()
-                .subscriptionId("whsub_1").tenantId("t1").url("https://a.com")
+                .subscriptionId("whsub_1").tenantId("tenant-1").url("https://a.com")
                 .status(WebhookStatus.ACTIVE)
                 .eventTypes(List.of(EventType.BUDGET_CREATED))
                 .scopeFilter("*")
@@ -399,7 +399,7 @@ class WebhookRepositoryTest {
         String subJson = objectMapper.writeValueAsString(sub);
         when(jedis.get("webhook:whsub_1")).thenReturn(subJson);
 
-        List<WebhookSubscription> result = repository.findMatchingSubscriptions("t1", EventType.BUDGET_CREATED, "any/scope/here");
+        List<WebhookSubscription> result = repository.findMatchingSubscriptions("tenant-1", EventType.BUDGET_CREATED, "any/scope/here");
 
         assertThat(result).hasSize(1);
     }
@@ -407,11 +407,11 @@ class WebhookRepositoryTest {
     @Test
     void findMatchingSubscriptions_missingData_skipsGracefully() throws Exception {
         Set<String> tenantIds = new LinkedHashSet<>(List.of("whsub_gone", "whsub_ok"));
-        when(jedis.smembers("webhooks:t1")).thenReturn(tenantIds);
+        when(jedis.smembers("webhooks:tenant-1")).thenReturn(tenantIds);
         when(jedis.smembers("webhooks:__system__")).thenReturn(Set.of());
 
         WebhookSubscription sub = WebhookSubscription.builder()
-                .subscriptionId("whsub_ok").tenantId("t1").url("https://a.com")
+                .subscriptionId("whsub_ok").tenantId("tenant-1").url("https://a.com")
                 .status(WebhookStatus.ACTIVE)
                 .eventTypes(List.of(EventType.BUDGET_CREATED))
                 .createdAt(Instant.now()).consecutiveFailures(0).build();
@@ -419,7 +419,7 @@ class WebhookRepositoryTest {
         when(jedis.get("webhook:whsub_gone")).thenReturn(null);
         when(jedis.get("webhook:whsub_ok")).thenReturn(subJson);
 
-        List<WebhookSubscription> result = repository.findMatchingSubscriptions("t1", EventType.BUDGET_CREATED, null);
+        List<WebhookSubscription> result = repository.findMatchingSubscriptions("tenant-1", EventType.BUDGET_CREATED, null);
 
         assertThat(result).hasSize(1);
     }
@@ -427,18 +427,18 @@ class WebhookRepositoryTest {
     @Test
     void findMatchingSubscriptions_eventTypeNotMatched_excluded() throws Exception {
         Set<String> tenantIds = new LinkedHashSet<>(List.of("whsub_1"));
-        when(jedis.smembers("webhooks:t1")).thenReturn(tenantIds);
+        when(jedis.smembers("webhooks:tenant-1")).thenReturn(tenantIds);
         when(jedis.smembers("webhooks:__system__")).thenReturn(Set.of());
 
         WebhookSubscription sub = WebhookSubscription.builder()
-                .subscriptionId("whsub_1").tenantId("t1").url("https://a.com")
+                .subscriptionId("whsub_1").tenantId("tenant-1").url("https://a.com")
                 .status(WebhookStatus.ACTIVE)
                 .eventTypes(List.of(EventType.BUDGET_CREATED))
                 .createdAt(Instant.now()).consecutiveFailures(0).build();
         String subJson = objectMapper.writeValueAsString(sub);
         when(jedis.get("webhook:whsub_1")).thenReturn(subJson);
 
-        List<WebhookSubscription> result = repository.findMatchingSubscriptions("t1", EventType.TENANT_CREATED, null);
+        List<WebhookSubscription> result = repository.findMatchingSubscriptions("tenant-1", EventType.TENANT_CREATED, null);
 
         assertThat(result).isEmpty();
     }
@@ -446,11 +446,11 @@ class WebhookRepositoryTest {
     @Test
     void findMatchingSubscriptions_nullScopeWithScopeFilter_matches() throws Exception {
         Set<String> tenantIds = new LinkedHashSet<>(List.of("whsub_1"));
-        when(jedis.smembers("webhooks:t1")).thenReturn(tenantIds);
+        when(jedis.smembers("webhooks:tenant-1")).thenReturn(tenantIds);
         when(jedis.smembers("webhooks:__system__")).thenReturn(Set.of());
 
         WebhookSubscription sub = WebhookSubscription.builder()
-                .subscriptionId("whsub_1").tenantId("t1").url("https://a.com")
+                .subscriptionId("whsub_1").tenantId("tenant-1").url("https://a.com")
                 .status(WebhookStatus.ACTIVE)
                 .eventTypes(List.of(EventType.BUDGET_CREATED))
                 .scopeFilter("org/eng")
@@ -459,7 +459,7 @@ class WebhookRepositoryTest {
         when(jedis.get("webhook:whsub_1")).thenReturn(subJson);
 
         // null scope should match (matchesScope returns true when scope is null)
-        List<WebhookSubscription> result = repository.findMatchingSubscriptions("t1", EventType.BUDGET_CREATED, null);
+        List<WebhookSubscription> result = repository.findMatchingSubscriptions("tenant-1", EventType.BUDGET_CREATED, null);
 
         assertThat(result).hasSize(1);
     }
@@ -467,11 +467,11 @@ class WebhookRepositoryTest {
     @Test
     void findMatchingSubscriptions_blankScopeFilter_matchesAll() throws Exception {
         Set<String> tenantIds = new LinkedHashSet<>(List.of("whsub_1"));
-        when(jedis.smembers("webhooks:t1")).thenReturn(tenantIds);
+        when(jedis.smembers("webhooks:tenant-1")).thenReturn(tenantIds);
         when(jedis.smembers("webhooks:__system__")).thenReturn(Set.of());
 
         WebhookSubscription sub = WebhookSubscription.builder()
-                .subscriptionId("whsub_1").tenantId("t1").url("https://a.com")
+                .subscriptionId("whsub_1").tenantId("tenant-1").url("https://a.com")
                 .status(WebhookStatus.ACTIVE)
                 .eventTypes(List.of(EventType.BUDGET_CREATED))
                 .scopeFilter("   ")
@@ -479,7 +479,7 @@ class WebhookRepositoryTest {
         String subJson = objectMapper.writeValueAsString(sub);
         when(jedis.get("webhook:whsub_1")).thenReturn(subJson);
 
-        List<WebhookSubscription> result = repository.findMatchingSubscriptions("t1", EventType.BUDGET_CREATED, "any/scope");
+        List<WebhookSubscription> result = repository.findMatchingSubscriptions("tenant-1", EventType.BUDGET_CREATED, "any/scope");
 
         assertThat(result).hasSize(1);
     }
@@ -487,16 +487,16 @@ class WebhookRepositoryTest {
     @Test
     void listByTenant_withCursor_skipsIdsUpToCursor() throws Exception {
         Set<String> ids = new LinkedHashSet<>(List.of("whsub_1", "whsub_2", "whsub_3"));
-        when(jedis.smembers("webhooks:t1")).thenReturn(ids);
+        when(jedis.smembers("webhooks:tenant-1")).thenReturn(ids);
 
-        WebhookSubscription s2 = WebhookSubscription.builder().subscriptionId("whsub_2").tenantId("t1").url("https://b.com").status(WebhookStatus.ACTIVE).eventTypes(List.of(EventType.TENANT_CREATED)).createdAt(Instant.now()).consecutiveFailures(0).build();
-        WebhookSubscription s3 = WebhookSubscription.builder().subscriptionId("whsub_3").tenantId("t1").url("https://c.com").status(WebhookStatus.ACTIVE).eventTypes(List.of(EventType.BUDGET_CREATED)).createdAt(Instant.now()).consecutiveFailures(0).build();
+        WebhookSubscription s2 = WebhookSubscription.builder().subscriptionId("whsub_2").tenantId("tenant-1").url("https://b.com").status(WebhookStatus.ACTIVE).eventTypes(List.of(EventType.TENANT_CREATED)).createdAt(Instant.now()).consecutiveFailures(0).build();
+        WebhookSubscription s3 = WebhookSubscription.builder().subscriptionId("whsub_3").tenantId("tenant-1").url("https://c.com").status(WebhookStatus.ACTIVE).eventTypes(List.of(EventType.BUDGET_CREATED)).createdAt(Instant.now()).consecutiveFailures(0).build();
         String s2Json = objectMapper.writeValueAsString(s2);
         String s3Json = objectMapper.writeValueAsString(s3);
         when(jedis.get("webhook:whsub_2")).thenReturn(s2Json);
         when(jedis.get("webhook:whsub_3")).thenReturn(s3Json);
 
-        List<WebhookSubscription> result = repository.listByTenant("t1", null, null, "whsub_1", 50);
+        List<WebhookSubscription> result = repository.listByTenant("tenant-1", null, null, "whsub_1", 50);
 
         assertThat(result).hasSize(2);
         assertThat(result.get(0).getSubscriptionId()).isEqualTo("whsub_2");
@@ -507,8 +507,8 @@ class WebhookRepositoryTest {
         Set<String> ids = new LinkedHashSet<>(List.of("whsub_1", "whsub_2"));
         when(jedis.smembers("webhooks:_all")).thenReturn(ids);
 
-        WebhookSubscription s1 = WebhookSubscription.builder().subscriptionId("whsub_1").tenantId("t1").url("https://a.com").status(WebhookStatus.ACTIVE).eventTypes(List.of(EventType.TENANT_CREATED)).createdAt(Instant.now()).consecutiveFailures(0).build();
-        WebhookSubscription s2 = WebhookSubscription.builder().subscriptionId("whsub_2").tenantId("t1").url("https://b.com").status(WebhookStatus.ACTIVE).eventTypes(List.of(EventType.BUDGET_CREATED)).createdAt(Instant.now()).consecutiveFailures(0).build();
+        WebhookSubscription s1 = WebhookSubscription.builder().subscriptionId("whsub_1").tenantId("tenant-1").url("https://a.com").status(WebhookStatus.ACTIVE).eventTypes(List.of(EventType.TENANT_CREATED)).createdAt(Instant.now()).consecutiveFailures(0).build();
+        WebhookSubscription s2 = WebhookSubscription.builder().subscriptionId("whsub_2").tenantId("tenant-1").url("https://b.com").status(WebhookStatus.ACTIVE).eventTypes(List.of(EventType.BUDGET_CREATED)).createdAt(Instant.now()).consecutiveFailures(0).build();
         String s1Json = objectMapper.writeValueAsString(s1);
         String s2Json = objectMapper.writeValueAsString(s2);
         when(jedis.get("webhook:whsub_1")).thenReturn(s1Json);
@@ -532,14 +532,14 @@ class WebhookRepositoryTest {
     @Test
     void listFromSet_missingData_skipsGracefully() throws Exception {
         Set<String> ids = new LinkedHashSet<>(List.of("whsub_gone", "whsub_ok"));
-        when(jedis.smembers("webhooks:t1")).thenReturn(ids);
+        when(jedis.smembers("webhooks:tenant-1")).thenReturn(ids);
 
-        WebhookSubscription s = WebhookSubscription.builder().subscriptionId("whsub_ok").tenantId("t1").url("https://a.com").status(WebhookStatus.ACTIVE).eventTypes(List.of(EventType.TENANT_CREATED)).createdAt(Instant.now()).consecutiveFailures(0).build();
+        WebhookSubscription s = WebhookSubscription.builder().subscriptionId("whsub_ok").tenantId("tenant-1").url("https://a.com").status(WebhookStatus.ACTIVE).eventTypes(List.of(EventType.TENANT_CREATED)).createdAt(Instant.now()).consecutiveFailures(0).build();
         String sJson = objectMapper.writeValueAsString(s);
         when(jedis.get("webhook:whsub_gone")).thenReturn(null);
         when(jedis.get("webhook:whsub_ok")).thenReturn(sJson);
 
-        List<WebhookSubscription> result = repository.listByTenant("t1", null, null, null, 50);
+        List<WebhookSubscription> result = repository.listByTenant("tenant-1", null, null, null, 50);
 
         assertThat(result).hasSize(1);
     }
@@ -547,13 +547,13 @@ class WebhookRepositoryTest {
     @Test
     void listFromSet_respectsLimit() throws Exception {
         Set<String> ids = new LinkedHashSet<>(List.of("whsub_1", "whsub_2", "whsub_3"));
-        when(jedis.smembers("webhooks:t1")).thenReturn(ids);
+        when(jedis.smembers("webhooks:tenant-1")).thenReturn(ids);
 
-        WebhookSubscription s1 = WebhookSubscription.builder().subscriptionId("whsub_1").tenantId("t1").url("https://a.com").status(WebhookStatus.ACTIVE).eventTypes(List.of(EventType.TENANT_CREATED)).createdAt(Instant.now()).consecutiveFailures(0).build();
+        WebhookSubscription s1 = WebhookSubscription.builder().subscriptionId("whsub_1").tenantId("tenant-1").url("https://a.com").status(WebhookStatus.ACTIVE).eventTypes(List.of(EventType.TENANT_CREATED)).createdAt(Instant.now()).consecutiveFailures(0).build();
         String s1Json = objectMapper.writeValueAsString(s1);
         when(jedis.get("webhook:whsub_1")).thenReturn(s1Json);
 
-        List<WebhookSubscription> result = repository.listByTenant("t1", null, null, null, 1);
+        List<WebhookSubscription> result = repository.listByTenant("tenant-1", null, null, null, 1);
 
         assertThat(result).hasSize(1);
     }
@@ -563,7 +563,7 @@ class WebhookRepositoryTest {
         when(jedis.eval(anyString(), anyList(), anyList())).thenThrow(new RuntimeException("Redis down"));
 
         WebhookSubscription sub = WebhookSubscription.builder()
-                .tenantId("t1")
+                .tenantId("tenant-1")
                 .url("https://example.com/hook")
                 .eventTypes(List.of(EventType.TENANT_CREATED))
                 .build();
@@ -578,7 +578,7 @@ class WebhookRepositoryTest {
         when(jedis.set(anyString(), anyString())).thenThrow(new RuntimeException("Redis down"));
 
         WebhookSubscription sub = WebhookSubscription.builder()
-                .subscriptionId("whsub_1").tenantId("t1").url("https://a.com")
+                .subscriptionId("whsub_1").tenantId("tenant-1").url("https://a.com")
                 .status(WebhookStatus.ACTIVE).createdAt(Instant.now()).consecutiveFailures(0).build();
 
         assertThatThrownBy(() -> repository.update("whsub_1", sub))
@@ -589,7 +589,7 @@ class WebhookRepositoryTest {
     @Test
     void delete_redisException_throwsRuntimeException() throws Exception {
         WebhookSubscription sub = WebhookSubscription.builder()
-                .subscriptionId("whsub_1").tenantId("t1").url("https://a.com")
+                .subscriptionId("whsub_1").tenantId("tenant-1").url("https://a.com")
                 .status(WebhookStatus.ACTIVE).createdAt(Instant.now()).consecutiveFailures(0).build();
         String subJson = objectMapper.writeValueAsString(sub);
         when(jedis.get("webhook:whsub_1")).thenReturn(subJson);
@@ -612,18 +612,18 @@ class WebhookRepositoryTest {
     @Test
     void findMatchingSubscriptions_wildcardSubscription_matchesAllEvents() throws Exception {
         Set<String> tenantIds = new LinkedHashSet<>(List.of("whsub_1"));
-        when(jedis.smembers("webhooks:t1")).thenReturn(tenantIds);
+        when(jedis.smembers("webhooks:tenant-1")).thenReturn(tenantIds);
         when(jedis.smembers("webhooks:__system__")).thenReturn(Set.of());
 
         // No eventTypes and no eventCategories means match all
         WebhookSubscription sub = WebhookSubscription.builder()
-                .subscriptionId("whsub_1").tenantId("t1").url("https://a.com")
+                .subscriptionId("whsub_1").tenantId("tenant-1").url("https://a.com")
                 .status(WebhookStatus.ACTIVE)
                 .createdAt(Instant.now()).consecutiveFailures(0).build();
         String subJson = objectMapper.writeValueAsString(sub);
         when(jedis.get("webhook:whsub_1")).thenReturn(subJson);
 
-        List<WebhookSubscription> result = repository.findMatchingSubscriptions("t1", EventType.TENANT_CREATED, null);
+        List<WebhookSubscription> result = repository.findMatchingSubscriptions("tenant-1", EventType.TENANT_CREATED, null);
 
         assertThat(result).hasSize(1);
     }

--- a/cycles-admin-service/cycles-admin-service-model/src/test/java/io/runcycles/admin/model/AuthModelTest.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/test/java/io/runcycles/admin/model/AuthModelTest.java
@@ -85,7 +85,7 @@ class AuthModelTest {
     @Test
     void apiKeyCreateRequest_rejectsUnknownFields() {
         String json = """
-            {"tenant_id":"t1","name":"k","unknown":true}
+            {"tenant_id":"tenant-1","name":"k","unknown":true}
             """;
         assertThrows(UnrecognizedPropertyException.class, () -> mapper.readValue(json, ApiKeyCreateRequest.class));
     }
@@ -93,7 +93,7 @@ class AuthModelTest {
     @Test
     void apiKeyCreateRequest_nameTooLong_fails() {
         ApiKeyCreateRequest request = new ApiKeyCreateRequest();
-        request.setTenantId("t1");
+        request.setTenantId("tenant-1");
         request.setName("x".repeat(257));
         Set<ConstraintViolation<ApiKeyCreateRequest>> violations = validator.validate(request);
         assertFalse(violations.isEmpty());
@@ -102,7 +102,7 @@ class AuthModelTest {
     @Test
     void apiKeyCreateRequest_unknownPermission_rejected() {
         String json = """
-            {"tenant_id":"t1","name":"k","permissions":["budgets:wirte"]}
+            {"tenant_id":"tenant-1","name":"k","permissions":["budgets:wirte"]}
             """;
         com.fasterxml.jackson.databind.JsonMappingException ex = assertThrows(
                 com.fasterxml.jackson.databind.JsonMappingException.class,
@@ -114,7 +114,7 @@ class AuthModelTest {
     @Test
     void apiKeyCreateRequest_validPermissions_deserialize() throws Exception {
         String json = """
-            {"tenant_id":"t1","name":"k","permissions":["budgets:read","admin:audit:read"]}
+            {"tenant_id":"tenant-1","name":"k","permissions":["budgets:read","admin:audit:read"]}
             """;
         ApiKeyCreateRequest req = mapper.readValue(json, ApiKeyCreateRequest.class);
         assertEquals(List.of(Permission.BUDGETS_READ, Permission.ADMIN_AUDIT_READ), req.getPermissions());
@@ -124,7 +124,7 @@ class AuthModelTest {
     @Test
     void apiKeyCreateRequest_descriptionTooLong_fails() {
         ApiKeyCreateRequest request = new ApiKeyCreateRequest();
-        request.setTenantId("t1");
+        request.setTenantId("tenant-1");
         request.setName("valid");
         request.setDescription("x".repeat(1025));
         Set<ConstraintViolation<ApiKeyCreateRequest>> violations = validator.validate(request);
@@ -136,7 +136,7 @@ class AuthModelTest {
     @Test
     void apiKeyResponse_doesNotContainKeyHash() throws Exception {
         ApiKey key = ApiKey.builder()
-                .keyId("key_1").tenantId("t1").keyPrefix("cyc_live_abc12")
+                .keyId("key_1").tenantId("tenant-1").keyPrefix("cyc_live_abc12")
                 .keyHash("$2a$12$secret_hash_value")
                 .name("test").status(ApiKeyStatus.ACTIVE)
                 .permissions(List.of("balances:read"))
@@ -155,7 +155,7 @@ class AuthModelTest {
     void apiKey_internalModel_containsKeyHashForRedis() throws Exception {
         // ApiKey is the internal model used for Redis serialization — key_hash MUST be present
         ApiKey key = ApiKey.builder()
-                .keyId("key_1").tenantId("t1").keyPrefix("cyc_live_abc12")
+                .keyId("key_1").tenantId("tenant-1").keyPrefix("cyc_live_abc12")
                 .keyHash("$2a$12$secret_hash")
                 .status(ApiKeyStatus.ACTIVE)
                 .createdAt(Instant.now()).expiresAt(Instant.now().plusSeconds(3600))

--- a/cycles-admin-service/cycles-admin-service-model/src/test/java/io/runcycles/admin/model/EventModelTest.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/test/java/io/runcycles/admin/model/EventModelTest.java
@@ -134,7 +134,7 @@ class EventModelTest {
                 .eventType(EventType.TENANT_CREATED)
                 .category(EventCategory.TENANT)
                 .timestamp(now)
-                .tenantId("t1")
+                .tenantId("tenant-1")
                 .source("cycles-admin")
                 .scope("org/eng")
                 .correlationId("corr_1")
@@ -163,7 +163,7 @@ class EventModelTest {
                 .eventType(EventType.BUDGET_FUNDED)
                 .category(EventCategory.BUDGET)
                 .timestamp(Instant.now())
-                .tenantId("t1")
+                .tenantId("tenant-1")
                 .source("test")
                 .build();
 
@@ -182,7 +182,7 @@ class EventModelTest {
                 .eventType(EventType.TENANT_CREATED)
                 .category(EventCategory.TENANT)
                 .timestamp(Instant.now())
-                .tenantId("t1")
+                .tenantId("tenant-1")
                 .source("test")
                 .build();
 

--- a/cycles-admin-service/cycles-admin-service-model/src/test/java/io/runcycles/admin/model/WebhookModelTest.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/test/java/io/runcycles/admin/model/WebhookModelTest.java
@@ -43,7 +43,7 @@ class WebhookModelTest {
         Instant now = Instant.now();
         WebhookSubscription sub = WebhookSubscription.builder()
                 .subscriptionId("whsub_abc123")
-                .tenantId("t1")
+                .tenantId("tenant-1")
                 .name("My Webhook")
                 .description("Test webhook")
                 .url("https://example.com/hook")
@@ -77,7 +77,7 @@ class WebhookModelTest {
     void webhookSubscription_signingSecretIgnoredInJson() throws Exception {
         WebhookSubscription sub = WebhookSubscription.builder()
                 .subscriptionId("whsub_1")
-                .tenantId("t1")
+                .tenantId("tenant-1")
                 .url("https://example.com/hook")
                 .status(WebhookStatus.ACTIVE)
                 .signingSecret("super_secret")


### PR DESCRIPTION
## Summary

The spec defines `Tenant.tenant_id` with `minLength: 3`, but tests were using 2-character literals (`"t1"`, `"t2"`, `"t3"`). The server didn't enforce the constraint, so the drift was invisible until contract testing against the live spec surfaced it — `/v1/admin/tenants` response bodies containing `tenant_id="t1"` failed strict validation.

Pure test-fixture hygiene. **No production code changes. No wire shape changes.**

## Changes

Scripted rename across all test `.java` files under `*/src/test/*`:

| Pattern | From | To | Files |
|---|---|---|---|
| Java string literal | `"t1"` | `"tenant-1"` | 26 |
| URL path | `tenants/t1` | `tenants/tenant-1` | 1 |
| Redis key prefix | `"tenant:t1"`, `"apikeys:t1"`, `"budgets:t1"`, `"events:t1"`, `"logs:t1"`, `"webhooks:t1"` | `"tenant:tenant-1"`, etc. | 5 |
| Escaped JSON | `\"t1\"` in `.content("{\"tenant_id\":\"t1\"…}")` | `\"tenant-1\"` | 1 |

**Total: 719 substitutions across 26 test files.**

Local variable names (`Tenant t1`, `String t1Json`) intentionally left alone — they're test-scope identifiers, not on-the-wire data.

## Test plan

- [x] `mvn -B verify --file cycles-admin-service/pom.xml -Dtest='!*IntegrationTest' -Dsurefire.failIfNoSpecifiedTests=false` — 432 tests, 0 failures, JaCoCo 95%+ coverage all met
- [x] No production code changed (`git diff main -- cycles-admin-service/*/src/main` is empty)
- [ ] Integration tests (require Docker / Testcontainers) — run in CI

## Context

One of three fixes from a full-schema contract-test audit. Related:
- runcycles/cycles-protocol#32 — spec-side fixes (SignedAmount, BalanceListResponse, strict PATCH bodies)
- Upcoming cycles-server-admin PR — contract-testing infrastructure itself