### PR TITLE
test: contract-testing infrastructure — MockMvc validation against cycles-protocol@main (OFF by default)

### DIFF
--- a/cycles-admin-service/cycles-admin-service-api/pom.xml
+++ b/cycles-admin-service/cycles-admin-service-api/pom.xml
@@ -59,6 +59,20 @@
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Contract testing: runtime schema validation on MockMvc -->
+        <dependency>
+            <groupId>com.atlassian.oai</groupId>
+            <artifactId>swagger-request-validator-mockmvc</artifactId>
+            <version>2.44.9</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Contract testing: structural diff between SpringDoc /api-docs and pinned spec -->
+        <dependency>
+            <groupId>org.openapitools.openapidiff</groupId>
+            <artifactId>openapi-diff-core</artifactId>
+            <version>2.1.7</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/contract/ContractSpecLoader.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/contract/ContractSpecLoader.java
@@ -1,0 +1,78 @@
+package io.runcycles.admin.api.contract;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * Loads the authoritative admin OpenAPI spec from cycles-protocol@main for
+ * contract tests. Caches per-build to {@code target/contract/spec.yaml} so
+ * repeated test runs within the same build don't re-download.
+ *
+ * <p>Refresh policy: if the cached file exists and was written within the
+ * last {@link #CACHE_TTL}, use it; otherwise re-fetch. This lets local
+ * {@code mvn test} cycles skip the download while still catching drift on CI
+ * (fresh workspace => cache miss => fresh fetch).
+ *
+ * <p>Override via system property {@code contract.spec.url} for local spec
+ * development.
+ */
+public final class ContractSpecLoader {
+
+    public static final String DEFAULT_SPEC_URL =
+            "https://raw.githubusercontent.com/runcycles/cycles-protocol/main/cycles-governance-admin-v0.1.25.yaml";
+    public static final Duration CACHE_TTL = Duration.ofHours(1);
+    private static final Path CACHE_PATH = Path.of("target", "contract", "spec.yaml");
+
+    private static String cached;
+
+    private ContractSpecLoader() {}
+
+    /** Returns the YAML content as a String. Blocks on first call per JVM. */
+    public static synchronized String loadSpec() {
+        if (cached != null) return cached;
+        try {
+            if (isCacheFresh()) {
+                cached = Files.readString(CACHE_PATH);
+                return cached;
+            }
+            String specUrl = System.getProperty("contract.spec.url", DEFAULT_SPEC_URL);
+            cached = fetch(specUrl);
+            Files.createDirectories(CACHE_PATH.getParent());
+            Files.writeString(CACHE_PATH, cached,
+                    StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+            return cached;
+        } catch (Exception e) {
+            throw new IllegalStateException(
+                "Failed to load contract spec. If offline, provide -Dcontract.spec.url=file:///path/to/spec.yaml",
+                e);
+        }
+    }
+
+    private static boolean isCacheFresh() throws IOException {
+        if (!Files.exists(CACHE_PATH)) return false;
+        Instant mtime = Files.getLastModifiedTime(CACHE_PATH).toInstant();
+        return Instant.now().isBefore(mtime.plus(CACHE_TTL));
+    }
+
+    private static String fetch(String url) throws IOException, InterruptedException {
+        HttpClient client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(15))
+                .build();
+        HttpRequest req = HttpRequest.newBuilder(URI.create(url))
+                .timeout(Duration.ofSeconds(30))
+                .GET().build();
+        HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
+        if (resp.statusCode() != 200) {
+            throw new IOException("Spec fetch " + url + " returned HTTP " + resp.statusCode());
+        }
+        return resp.body();
+    }
+}

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/contract/ContractValidationConfig.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/contract/ContractValidationConfig.java
@@ -1,0 +1,77 @@
+package io.runcycles.admin.api.contract;
+
+import com.atlassian.oai.validator.OpenApiInteractionValidator;
+import com.atlassian.oai.validator.mockmvc.OpenApiMatchers;
+import com.atlassian.oai.validator.report.LevelResolver;
+import com.atlassian.oai.validator.report.ValidationReport;
+import org.springframework.boot.test.autoconfigure.web.servlet.MockMvcBuilderCustomizer;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.web.servlet.ResultMatcher;
+
+/**
+ * Test configuration that attaches a Swagger Request Validator matcher to
+ * every MockMvc request. When enabled, any 2xx response whose body doesn't
+ * conform to the pinned admin spec fails the test.
+ *
+ * <p>Import from controller tests via {@code @Import(ContractValidationConfig.class)}
+ * alongside the existing {@code MetricsTestConfiguration}.
+ *
+ * <p><b>Enablement gate:</b> OFF by default. Flip on with the system
+ * property {@code -Dcontract.validation.enabled=true} (or env var
+ * {@code CONTRACT_VALIDATION_ENABLED=true}). The gate lets the
+ * infrastructure land as a dormant capability, and PR-E flips it on once
+ * cycles-protocol@main + the admin server are confirmed drift-free.
+ *
+ * <p>When the gate is OFF the customizer is a no-op — no spec fetch, no
+ * matcher attached — so tests are unaffected by network or cache state.
+ *
+ * <p>The spec itself is fetched by {@link ContractSpecLoader} from
+ * cycles-protocol@main and cached to {@code target/contract/}.
+ */
+@TestConfiguration
+public class ContractValidationConfig {
+
+    /** Flip this on via -Dcontract.validation.enabled=true or env CONTRACT_VALIDATION_ENABLED=true. */
+    public static boolean validationEnabled() {
+        String prop = System.getProperty("contract.validation.enabled");
+        if (prop != null) return Boolean.parseBoolean(prop);
+        String env = System.getenv("CONTRACT_VALIDATION_ENABLED");
+        return env != null && Boolean.parseBoolean(env);
+    }
+
+    @Bean
+    public MockMvcBuilderCustomizer contractValidatingCustomizer() {
+        if (!validationEnabled()) {
+            // No-op: don't fetch the spec, don't attach a matcher. Keeps
+            // default test runs hermetic and independent of cycles-protocol
+            // network availability.
+            return builder -> { };
+        }
+        // Request-side validation is noisy in tests: @Valid already enforces real request
+        // constraints in production, and several tests deliberately send out-of-range query
+        // params to verify server clamping. The contract we're enforcing here is the
+        // RESPONSE shape — when the server says 200, does the body match the spec?
+        LevelResolver levels = LevelResolver.create()
+                .withLevel("validation.request.parameter.schema.maximum", ValidationReport.Level.IGNORE)
+                .withLevel("validation.request.parameter.schema.minimum", ValidationReport.Level.IGNORE)
+                .withLevel("validation.request.parameter.schema.invalidJson", ValidationReport.Level.IGNORE)
+                .build();
+        OpenApiInteractionValidator validator = OpenApiInteractionValidator
+                .createForInlineApiSpecification(ContractSpecLoader.loadSpec())
+                .withLevelResolver(levels)
+                .build();
+        ResultMatcher full = new OpenApiMatchers().isValid(validator);
+        // Only validate 2xx responses. 4xx/5xx are error paths — the server correctly
+        // rejected a bad request, and re-validating the deliberately-broken request is
+        // noise. What we DO catch: 2xx responses whose body shape drifts from the spec,
+        // and 2xx requests whose body violates spec constraints.
+        ResultMatcher onlyOnSuccess = result -> {
+            int status = result.getResponse().getStatus();
+            if (status >= 200 && status < 300) {
+                full.match(result);
+            }
+        };
+        return builder -> builder.alwaysExpect(onlyOnSuccess);
+    }
+}

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/AdminOverviewControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/AdminOverviewControllerTest.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import io.runcycles.admin.api.support.MetricsTestConfiguration;
+import io.runcycles.admin.api.contract.ContractValidationConfig;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import redis.clients.jedis.JedisPool;
@@ -22,7 +23,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(AdminOverviewController.class)
-@Import(MetricsTestConfiguration.class)
+@Import({MetricsTestConfiguration.class, ContractValidationConfig.class})
 class AdminOverviewControllerTest {
 
     @Autowired private MockMvc mockMvc;

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/ApiKeyControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/ApiKeyControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import io.runcycles.admin.api.support.MetricsTestConfiguration;
+import io.runcycles.admin.api.contract.ContractValidationConfig;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -25,7 +26,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(ApiKeyController.class)
-@Import(MetricsTestConfiguration.class)
+@Import({MetricsTestConfiguration.class, ContractValidationConfig.class})
 class ApiKeyControllerTest {
 
     @Autowired private MockMvc mockMvc;

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/AuditControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/AuditControllerTest.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import io.runcycles.admin.api.support.MetricsTestConfiguration;
+import io.runcycles.admin.api.contract.ContractValidationConfig;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import redis.clients.jedis.JedisPool;
@@ -21,7 +22,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(AuditController.class)
-@Import(MetricsTestConfiguration.class)
+@Import({MetricsTestConfiguration.class, ContractValidationConfig.class})
 class AuditControllerTest {
 
     @Autowired private MockMvc mockMvc;

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/AuthControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/AuthControllerTest.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import io.runcycles.admin.api.support.MetricsTestConfiguration;
+import io.runcycles.admin.api.contract.ContractValidationConfig;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -21,7 +22,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(AuthController.class)
-@Import(MetricsTestConfiguration.class)
+@Import({MetricsTestConfiguration.class, ContractValidationConfig.class})
 class AuthControllerTest {
 
     @Autowired private MockMvc mockMvc;

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BalanceControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BalanceControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import io.runcycles.admin.api.support.MetricsTestConfiguration;
+import io.runcycles.admin.api.contract.ContractValidationConfig;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import redis.clients.jedis.JedisPool;
@@ -24,7 +25,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(BalanceController.class)
-@Import(MetricsTestConfiguration.class)
+@Import({MetricsTestConfiguration.class, ContractValidationConfig.class})
 class BalanceControllerTest {
 
     @Autowired private MockMvc mockMvc;

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BudgetControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BudgetControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import io.runcycles.admin.api.support.MetricsTestConfiguration;
+import io.runcycles.admin.api.contract.ContractValidationConfig;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -30,7 +31,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(BudgetController.class)
-@Import(MetricsTestConfiguration.class)
+@Import({MetricsTestConfiguration.class, ContractValidationConfig.class})
 class BudgetControllerTest {
 
     @Autowired private MockMvc mockMvc;

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/EventAdminControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/EventAdminControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import io.runcycles.admin.api.support.MetricsTestConfiguration;
+import io.runcycles.admin.api.contract.ContractValidationConfig;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import redis.clients.jedis.JedisPool;
@@ -23,7 +24,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(EventAdminController.class)
-@Import(MetricsTestConfiguration.class)
+@Import({MetricsTestConfiguration.class, ContractValidationConfig.class})
 class EventAdminControllerTest {
 
     @Autowired private MockMvc mockMvc;

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/EventTenantControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/EventTenantControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import io.runcycles.admin.api.support.MetricsTestConfiguration;
+import io.runcycles.admin.api.contract.ContractValidationConfig;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import redis.clients.jedis.JedisPool;
@@ -23,7 +24,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(EventTenantController.class)
-@Import(MetricsTestConfiguration.class)
+@Import({MetricsTestConfiguration.class, ContractValidationConfig.class})
 class EventTenantControllerTest {
 
     @Autowired private MockMvc mockMvc;

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/PolicyControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/PolicyControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import io.runcycles.admin.api.support.MetricsTestConfiguration;
+import io.runcycles.admin.api.contract.ContractValidationConfig;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -26,7 +27,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(PolicyController.class)
-@Import(MetricsTestConfiguration.class)
+@Import({MetricsTestConfiguration.class, ContractValidationConfig.class})
 class PolicyControllerTest {
 
     @Autowired private MockMvc mockMvc;

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/TenantControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/TenantControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import io.runcycles.admin.api.support.MetricsTestConfiguration;
+import io.runcycles.admin.api.contract.ContractValidationConfig;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -29,7 +30,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(TenantController.class)
-@Import(MetricsTestConfiguration.class)
+@Import({MetricsTestConfiguration.class, ContractValidationConfig.class})
 class TenantControllerTest {
 
     @Autowired private MockMvc mockMvc;

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookAdminControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookAdminControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import io.runcycles.admin.api.support.MetricsTestConfiguration;
+import io.runcycles.admin.api.contract.ContractValidationConfig;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -26,7 +27,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(WebhookAdminController.class)
-@Import(MetricsTestConfiguration.class)
+@Import({MetricsTestConfiguration.class, ContractValidationConfig.class})
 class WebhookAdminControllerTest {
 
     @Autowired private MockMvc mockMvc;

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookSecurityConfigControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookSecurityConfigControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import io.runcycles.admin.api.support.MetricsTestConfiguration;
+import io.runcycles.admin.api.contract.ContractValidationConfig;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -23,7 +24,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(WebhookSecurityConfigController.class)
-@Import(MetricsTestConfiguration.class)
+@Import({MetricsTestConfiguration.class, ContractValidationConfig.class})
 class WebhookSecurityConfigControllerTest {
 
     @Autowired private MockMvc mockMvc;

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookTenantControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookTenantControllerTest.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import io.runcycles.admin.api.support.MetricsTestConfiguration;
+import io.runcycles.admin.api.contract.ContractValidationConfig;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -27,7 +28,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(WebhookTenantController.class)
-@Import(MetricsTestConfiguration.class)
+@Import({MetricsTestConfiguration.class, ContractValidationConfig.class})
 class WebhookTenantControllerTest {
 
     @Autowired private MockMvc mockMvc;

--- a/docs/contract-testing.md
+++ b/docs/contract-testing.md
@@ -1,0 +1,98 @@
+# Contract Testing
+
+Runtime validation of admin-server MockMvc responses against the authoritative OpenAPI spec.
+
+## What it catches
+
+Any 2xx response whose body drifts from `cycles-governance-admin-v0.1.25.yaml` on `cycles-protocol@main` — missing required fields, extra fields (when `additionalProperties: false`), type mismatches, enum violations, `minLength`/`maxLength`/`minimum`/`maximum` constraint violations. Applies to every controller whose test imports `ContractValidationConfig`.
+
+## What it doesn't catch
+
+- **Endpoints that don't exist.** If the server is missing a spec endpoint entirely, no test hits it, so nothing validates. Structural diff (`OpenApiContractDiffTest` — planned Phase 2) closes this.
+- **4xx / 5xx responses.** Only 2xx is validated. Error shapes are deliberately out of scope — they're negative-path tests and the server's error paths are already covered by unit tests.
+- **Request-side parameter constraints.** Ignored by design — `@Valid` enforces them in production, and several tests deliberately send out-of-range query params to verify server clamping.
+
+## Enablement gate
+
+Disabled by default. Enable via one of:
+
+```bash
+# System property (preferred in Maven commands)
+mvn verify -Dcontract.validation.enabled=true
+
+# Environment variable (preferred in CI)
+CONTRACT_VALIDATION_ENABLED=true mvn verify
+```
+
+When the gate is off, `ContractValidationConfig` becomes a no-op: no spec fetch, no matcher attached. Tests run exactly as they did before the infrastructure landed.
+
+## How to opt a controller test in
+
+One-line change:
+
+```java
+@WebMvcTest(FooController.class)
+@Import({MetricsTestConfiguration.class, ContractValidationConfig.class})  // <-- add
+class FooControllerTest {
+    ...
+}
+```
+
+That's it. No per-test-method changes — the validator auto-applies to every `mockMvc.perform(...)` via the `MockMvcBuilderCustomizer` Spring picks up from the imported config.
+
+## Where the spec comes from
+
+`ContractSpecLoader.loadSpec()` fetches `https://raw.githubusercontent.com/runcycles/cycles-protocol/main/cycles-governance-admin-v0.1.25.yaml` on first use, caches to `target/contract/spec.yaml` with a 1-hour TTL.
+
+- **Local dev:** fetch once per hour. Fast iteration, light on network.
+- **CI:** fresh workspace = cache miss = always fetch. Catches cross-repo drift on every build.
+- **Air-gapped / override:** `-Dcontract.spec.url=file:///path/to/local.yaml`
+
+Per-build cache lives under `target/`, cleaned by `mvn clean`.
+
+## Debugging a failure
+
+When a test fails with `OpenApiValidationException`, the exception body is a structured JSON list of `messages`. The important fields per message:
+
+- `key` — rule name, e.g. `validation.response.body.schema.required`
+- `message` — human-readable detail with the exact JSON path
+- `context.requestPath`, `requestMethod`, `responseStatus` — where the drift happened
+- `context.pointers.instance` — JSON Pointer into the response body
+
+Example:
+
+```json
+{
+  "key": "validation.response.body.schema.required",
+  "message": "Object has missing required properties ([\"ledgers\"])",
+  "context": {
+    "requestPath": "/v1/balances",
+    "responseStatus": 200,
+    "requestMethod": "GET"
+  }
+}
+```
+
+## Why two distinct validation layers are planned
+
+1. **Runtime validation (this doc).** Wraps MockMvc. Catches "the server returned the wrong shape for this endpoint." Requires a test that exercises the endpoint.
+2. **Structural diff (Phase 2, not yet built).** Compares SpringDoc's `/api-docs` output against the pinned spec at build time. Catches "the server doesn't declare endpoint X at all." Doesn't need a test to exist.
+
+Together they cover both "wrong shape" and "wrong surface". Individually each has meaningful blind spots.
+
+## Dependencies
+
+- `com.atlassian.oai:swagger-request-validator-mockmvc:2.44.9` — the validator. Known incompat with `swagger-request-validator-springmvc` on Spring Framework 6 (`HandlerInterceptorAdapter` removed) — we use the MockMvc variant instead, which wires via `MockMvcBuilderCustomizer.alwaysExpect()`.
+- `org.openapitools.openapidiff:openapi-diff-core:2.1.7` — planned Phase 2 structural diff.
+
+Both are test-scope in `cycles-admin-service-api/pom.xml`.
+
+## Turning it on permanently
+
+When `cycles-protocol@main` and the admin server are both confirmed drift-free:
+
+1. In `ContractValidationConfig.validationEnabled()`, swap the default from `false` to `true`.
+2. Add a `-Dcontract.validation.enabled=false` escape hatch documentation for anyone needing to bypass locally (e.g. offline).
+3. Bump the server patch version, record in AUDIT.md.
+
+That's PR-E.


### PR DESCRIPTION
## Summary

Phase 1 of contract testing: wire runtime spec validation into the MockMvc pipeline for every controller test. Infrastructure lands **dormant** — default is OFF behind `-Dcontract.validation.enabled=true` (or env `CONTRACT_VALIDATION_ENABLED=true`) — so existing test runs are unaffected. PR-E flips the default to ON in a one-line follow-up commit.

When enabled, every 2xx response body is validated against the authoritative admin spec fetched from `cycles-protocol@main`. Drift fails the test.

## What's in the box

- **`ContractSpecLoader`** — fetches `cycles-governance-admin-v0.1.25.yaml` from `raw.githubusercontent.com/runcycles/cycles-protocol/main/...` with per-build caching to `target/contract/spec.yaml` (1-hour TTL). Override for offline dev: `-Dcontract.spec.url=file:///path/to/spec.yaml`.
- **`ContractValidationConfig`** — `@TestConfiguration` registering a `MockMvcBuilderCustomizer`. Applies `OpenApiMatchers.isValid(validator)` on every response. **Gate OFF = no-op** (no network, no matcher). Gate ON = validation on every 2xx. Request-side parameter clamping rules demoted to IGNORE (noisy; tests deliberately out-of-range to verify clamping).
- **All 13 controller tests** `@Import({MetricsTestConfiguration.class, ContractValidationConfig.class})` — one-line swap each.
- **`docs/contract-testing.md`** — enablement, debugging, Phase 2 roadmap.

## What it catches / doesn't

| Catches | Doesn't |
|---|---|
| 2xx body shape drift | Missing endpoints (→ Phase 2 structural diff) |
| Missing required fields | 4xx/5xx error shapes (deliberately out of scope) |
| Extra fields when `additionalProperties: false` | Request param clamping (covered by `@Valid`) |
| Type / enum / min/max violations | |

## Dependencies

- `com.atlassian.oai:swagger-request-validator-mockmvc:2.44.9` — runtime validator. The `-springmvc` variant refs the Spring-Framework-6-removed `HandlerInterceptorAdapter`; `-mockmvc` wires cleanly via `alwaysExpect()`.
- `org.openapitools.openapidiff:openapi-diff-core:2.1.7` — reserved for Phase 2, unused in Phase 1.

## Verification

```
mvn -B test (default, gate OFF):                     432/432 pass
mvn -B test -Dcontract.validation.enabled=true:      432/432 pass
                                                      (every 2xx body validated
                                                       against cycles-protocol@main)
```

Gate-ON run proved out end-to-end: **zero drift remaining**. The three pre-existing drifts surfaced by the original full schema audit are all resolved upstream:
- runcycles/cycles-protocol#32 (merged) — spec-side fixes: `SignedAmount`, `BalanceListResponse`, strict PATCH bodies
- runcycles/cycles-server-admin#77 (merged) — v0.1.25.10 release: `Permission` enum, `Capabilities` class
- runcycles/cycles-server-admin#78 (merged) — test fixture `tenant_id` minLength

## Test plan

- [x] Default (gate OFF): `mvn verify` — 432/432, JaCoCo 95%+ coverage
- [x] Opt-in (gate ON): 432/432 with every 2xx body validated
- [x] Offline dev path: `-Dcontract.spec.url=file:///...` honored by ContractSpecLoader
- [ ] CI wiring: add a matrix job that runs gate-ON (proposed in PR-E)
- [ ] Phase 2 structural diff: `OpenApiContractDiffTest` (separate PR)

## Follow-up (PR-E)

One-line flip: `ContractValidationConfig.validationEnabled()` default `false → true`. With all known drift resolved, the flip is a no-op for tests but makes fail-hard the default for any future drift. Version bump to 0.1.25.11 + AUDIT entry.