### PR TITLE
release: v0.1.25.11 — enable fail-hard contract testing by default

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,9 +1,30 @@
 # Complete Budget Governance v0.1.25.8 — Admin Server Audit
 
-**Server version:** 0.1.25.10 (2026-04-12 patch release — spec-compliance hardening: `Permission` enum + typed `Capabilities`)
-**Date:** 2026-04-12 (v0.1.25.10 spec-compliance hardening), 2026-04-10 (v0.1.25.9 release), 2026-04-10 (CORS hardening + prod config), 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
+**Server version:** 0.1.25.11 (2026-04-12 patch release — enable fail-hard contract testing by default)
+**Date:** 2026-04-12 (v0.1.25.11 contract-testing default ON), 2026-04-12 (v0.1.25.10 spec-compliance hardening), 2026-04-10 (v0.1.25.9 release), 2026-04-10 (CORS hardening + prod config), 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
 **Spec:** [`cycles-governance-admin-v0.1.25.yaml`](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml) (OpenAPI 3.1.0, v0.1.25.9) in [cycles-protocol](https://github.com/runcycles/cycles-protocol)
 **Server:** Spring Boot 3.5.11 / Java 21 / Redis
+
+### 2026-04-12 — v0.1.25.11 contract-testing default ON
+
+Flip follow-up to v0.1.25.10's contract-testing infrastructure. One-line default change: `ContractValidationConfig.validationEnabled()` now returns `true` when neither system property nor env var is set. Every 2xx response from the 13 admin controllers under `*ControllerTest` is validated against `cycles-governance-admin-v0.1.25.yaml` fetched from `cycles-protocol@main` per build (cached to `target/contract/` with 1-hour TTL).
+
+**Why now.** The pre-existing drift-debt is zero:
+- Server-side: v0.1.25.10 closed the `Permission`/`Capabilities` gaps (runcycles/cycles-server-admin#77).
+- Spec-side: v0.1.25.10 spec added `SignedAmount`, `BalanceListResponse`, strict inline PATCH bodies (runcycles/cycles-protocol#32).
+- Fixtures: tenant_id rename to satisfy spec `minLength:3` (runcycles/cycles-server-admin#78).
+
+With all three merged, the gate-ON run (`mvn test -Dcontract.validation.enabled=true`) against v0.1.25.10 showed 432/432 tests passing. Flipping the default makes that the new baseline — future drift fails the build rather than silently shipping.
+
+**How to disable** (offline/air-gapped dev only):
+- `mvn verify -Dcontract.validation.enabled=false`
+- `CONTRACT_VALIDATION_ENABLED=false mvn verify`
+
+No production code changed. No API surface changed. Build-time only.
+
+**Tests:** 432 passing with gate ON, 432 passing with gate OFF. JaCoCo 95%+ coverage maintained.
+
+**Not yet included (Phase 2 follow-up).** Structural diff — comparing SpringDoc's `/api-docs` output against the pinned spec to catch endpoints that exist in spec but aren't implemented (or vice versa). `openapi-diff-core:2.1.7` is already on the test classpath for when this lands. Per-endpoint runtime validation (this PR) catches shape drift; structural diff catches surface drift. They're complementary.
 
 ### 2026-04-12 — v0.1.25.10 spec-compliance hardening (`Permission` enum + typed `Capabilities`)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Runcycles Admin Server
 
-Administrative API for the Complete Budget Governance System, aligned with [Cycles Protocol v0.1.25.10](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml).
+Administrative API for the Complete Budget Governance System, aligned with [Cycles Protocol v0.1.25.11](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml).
 
 ## Overview
 
@@ -580,6 +580,8 @@ v0.1.25.8 adds dashboard and observability hardening for v0.1.26 readiness: `Eve
 v0.1.25.9 is a patch release with operational hardening only — **no API surface changes**, spec stays at v0.1.25.8. Adds: Micrometer/Prometheus metrics at `/actuator/prometheus` with custom counters (`cycles_admin_events_emitted_total`, `cycles_admin_webhook_dispatched_total`); Kubernetes liveness/readiness probes at `/actuator/health/liveness` and `/actuator/health/readiness` (docker-compose healthchecks switched to liveness); CORS fixes — `X-Cycles-API-Key` and `X-Request-Id` are now allowlisted (both were previously blocked at preflight, breaking browser dashboards using tenant auth) and `X-Request-Id` is exposed for correlation; multi-origin CORS support via comma-separated `DASHBOARD_CORS_ORIGIN` env var.
 
 v0.1.25.10 is a patch release hardening spec compliance for `cycles-governance-admin-v0.1.25` (no API surface changes). (1) **`Permission` enum now modeled** — the 27 spec permission values are a typed Java enum with Jackson `@JsonValue`/`@JsonCreator`; inbound `POST /v1/admin/api-keys` and `PATCH /v1/admin/api-keys/{key_id}` now reject unknown permission strings (e.g. typos like `"budgets:wirte"`) at deserialization with a 400 instead of silently storing them. Wire format unchanged. (2) **`AuthIntrospectResponse.capabilities` structurally typed** — replaced the `Map<String, Boolean>` with a dedicated `Capabilities` class exposing the eight required booleans (`view_overview`, `view_budgets`, `view_events`, `view_webhooks`, `view_audit`, `view_tenants`, `view_api_keys`, `view_policies`) per spec's "all fields always present" contract. JSON shape identical.
+
+v0.1.25.11 turns on **fail-hard contract testing by default** — no API surface changes, build-time only. Every 2xx response from the 13 admin controllers is now validated against the authoritative `cycles-governance-admin-v0.1.25.yaml` spec fetched from `cycles-protocol@main` on each build. Any future drift between server and spec — missing required fields, extra fields violating `additionalProperties: false`, type/enum/min-max mismatches — fails the build. Depends on v0.1.25.10 (server-side `Permission`/`Capabilities` fixes), cycles-protocol spec v0.1.25.10 (spec-side `SignedAmount`, `BalanceListResponse`, strict PATCH bodies), and test fixture rename (tenant_id `minLength:3`). All three landed; the flip is a one-line default change. Disable for offline dev with `-Dcontract.validation.enabled=false` or `CONTRACT_VALIDATION_ENABLED=false`. See [docs/contract-testing.md](docs/contract-testing.md) for the runbook.
 
 ## Documentation
 

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/contract/ContractValidationConfig.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/contract/ContractValidationConfig.java
@@ -17,11 +17,10 @@ import org.springframework.test.web.servlet.ResultMatcher;
  * <p>Import from controller tests via {@code @Import(ContractValidationConfig.class)}
  * alongside the existing {@code MetricsTestConfiguration}.
  *
- * <p><b>Enablement gate:</b> OFF by default. Flip on with the system
- * property {@code -Dcontract.validation.enabled=true} (or env var
- * {@code CONTRACT_VALIDATION_ENABLED=true}). The gate lets the
- * infrastructure land as a dormant capability, and PR-E flips it on once
- * cycles-protocol@main + the admin server are confirmed drift-free.
+ * <p><b>Enablement gate:</b> ON by default as of v0.1.25.11. Disable
+ * with {@code -Dcontract.validation.enabled=false} (or env
+ * {@code CONTRACT_VALIDATION_ENABLED=false}) for offline / air-gapped
+ * dev where the cycles-protocol@main fetch would fail.
  *
  * <p>When the gate is OFF the customizer is a no-op — no spec fetch, no
  * matcher attached — so tests are unaffected by network or cache state.
@@ -32,12 +31,16 @@ import org.springframework.test.web.servlet.ResultMatcher;
 @TestConfiguration
 public class ContractValidationConfig {
 
-    /** Flip this on via -Dcontract.validation.enabled=true or env CONTRACT_VALIDATION_ENABLED=true. */
+    /**
+     * Defaults to true. Disable for offline dev with
+     * -Dcontract.validation.enabled=false or env CONTRACT_VALIDATION_ENABLED=false.
+     */
     public static boolean validationEnabled() {
         String prop = System.getProperty("contract.validation.enabled");
         if (prop != null) return Boolean.parseBoolean(prop);
         String env = System.getenv("CONTRACT_VALIDATION_ENABLED");
-        return env != null && Boolean.parseBoolean(env);
+        if (env != null) return Boolean.parseBoolean(env);
+        return true;
     }
 
     @Bean

--- a/cycles-admin-service/pom.xml
+++ b/cycles-admin-service/pom.xml
@@ -18,7 +18,7 @@
         <module>cycles-admin-service-api</module>
     </modules>
     <properties>
-        <revision>0.1.25.10</revision>
+        <revision>0.1.25.11</revision>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/docker-compose.full-stack.prod.yml
+++ b/docker-compose.full-stack.prod.yml
@@ -13,7 +13,7 @@ services:
       retries: 5
 
   cycles-admin:
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.10
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.11
     restart: unless-stopped
     ports:
       - "7979:7979"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,7 +13,7 @@ services:
       retries: 5
 
   cycles-admin:
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.10
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.11
     restart: unless-stopped
     ports:
       - "7979:7979"

--- a/docs/contract-testing.md
+++ b/docs/contract-testing.md
@@ -14,17 +14,19 @@ Any 2xx response whose body drifts from `cycles-governance-admin-v0.1.25.yaml` o
 
 ## Enablement gate
 
-Disabled by default. Enable via one of:
+**Enabled by default as of v0.1.25.11.** Every controller test that imports `ContractValidationConfig` runs under contract validation unless explicitly disabled.
+
+Disable for offline / air-gapped dev (where the `cycles-protocol@main` fetch would fail):
 
 ```bash
-# System property (preferred in Maven commands)
-mvn verify -Dcontract.validation.enabled=true
+# System property
+mvn verify -Dcontract.validation.enabled=false
 
-# Environment variable (preferred in CI)
-CONTRACT_VALIDATION_ENABLED=true mvn verify
+# Environment variable
+CONTRACT_VALIDATION_ENABLED=false mvn verify
 ```
 
-When the gate is off, `ContractValidationConfig` becomes a no-op: no spec fetch, no matcher attached. Tests run exactly as they did before the infrastructure landed.
+When the gate is off, `ContractValidationConfig` becomes a no-op: no spec fetch, no matcher attached.
 
 ## How to opt a controller test in
 
@@ -87,12 +89,7 @@ Together they cover both "wrong shape" and "wrong surface". Individually each ha
 
 Both are test-scope in `cycles-admin-service-api/pom.xml`.
 
-## Turning it on permanently
+## History
 
-When `cycles-protocol@main` and the admin server are both confirmed drift-free:
-
-1. In `ContractValidationConfig.validationEnabled()`, swap the default from `false` to `true`.
-2. Add a `-Dcontract.validation.enabled=false` escape hatch documentation for anyone needing to bypass locally (e.g. offline).
-3. Bump the server patch version, record in AUDIT.md.
-
-That's PR-E.
+- v0.1.25.10 — infrastructure landed (ContractSpecLoader + ContractValidationConfig), gate default OFF.
+- v0.1.25.11 — gate default flipped ON after confirming zero drift against `cycles-protocol@main` across all 432 tests.


### PR DESCRIPTION
## Summary

One-line flip-on follow-up to v0.1.25.10's contract-testing infrastructure. `ContractValidationConfig.validationEnabled()` now defaults to `true`. Every 2xx response from the 13 admin controllers is validated against the authoritative `cycles-governance-admin-v0.1.25.yaml` fetched from `cycles-protocol@main` on each build.

No API surface changes. No production code changes. Build-time only.

## Why now

Precondition debt-tally at flip time: **zero**.

| Prerequisite | Where | Status |
|---|---|---|
| Server-side `Permission` enum + `Capabilities` class | v0.1.25.10 (#77) | ✅ Merged |
| Spec-side `SignedAmount`, `BalanceListResponse`, strict inline PATCH bodies | cycles-protocol v0.1.25.10 (#32) | ✅ Merged |
| Test fixture `tenant_id` minLength:3 | #78 | ✅ Merged |
| Contract-testing infrastructure | #79 | ✅ Merged |

With all four merged, the gate-ON run against current main shows 432/432 tests passing with every 2xx body validated. Flipping the default makes drift-free the new baseline — any future divergence fails the build rather than silently shipping.

## Escape hatch

Offline / air-gapped dev only (the default spec fetch would fail):

```bash
mvn verify -Dcontract.validation.enabled=false
CONTRACT_VALIDATION_ENABLED=false mvn verify
```

## Changes

- `ContractValidationConfig.validationEnabled()` — default `false` → `true`. Javadoc + comment updated.
- `pom.xml` `<revision>`, both prod docker-compose image tags, README header + new changelog paragraph, AUDIT.md new 2026-04-12 section.
- `docs/contract-testing.md` — reflects default-ON behavior + history section documenting the flip.

## Verification

```
mvn -B verify (default, gate ON):                   432/432 pass, coverage met
mvn -B verify -Dcontract.validation.enabled=false:  432/432 pass
```

`cycles-admin-service-api-0.1.25.11.jar` builds cleanly.

## Test plan

- [x] `mvn verify` — 432/432 with gate ON, validating every 2xx body against cycles-protocol@main
- [x] `mvn verify -Dcontract.validation.enabled=false` — 432/432 with gate OFF (offline dev)
- [x] JaCoCo 95%+ coverage maintained
- [x] Spring Boot fat jar builds at 0.1.25.11
- [ ] CI wiring: confirm the nightly integration run (runcycles/.github) passes with the v0.1.25.11 admin image
- [ ] Verify offline-dev workflow with `-Dcontract.validation.enabled=false` in the release candidate smoke test

## Phase 2 follow-up

Structural diff via `openapi-diff-core:2.1.7` (already on test classpath) — catches spec endpoints that don't exist on the server or vice versa. Runtime validation (this PR) catches shape drift; structural diff catches surface drift. Separate PR when we're ready.