### PR TITLE
test + harden: event payload contract validation

### DIFF
--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventDataApiKey.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventDataApiKey.java
@@ -1,5 +1,6 @@
 package io.runcycles.admin.model.event;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.runcycles.admin.model.auth.ApiKeyStatus;
@@ -15,6 +16,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = false)
 public class EventDataApiKey {
 
     @JsonProperty("key_id")

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventDataBudgetDebtIncurred.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventDataBudgetDebtIncurred.java
@@ -1,5 +1,6 @@
 package io.runcycles.admin.model.event;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.runcycles.admin.model.shared.CommitOveragePolicy;
@@ -14,6 +15,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = false)
 public class EventDataBudgetDebtIncurred {
 
     @JsonProperty("scope")

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventDataBudgetLifecycle.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventDataBudgetLifecycle.java
@@ -1,5 +1,6 @@
 package io.runcycles.admin.model.event;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.runcycles.admin.model.shared.UnitEnum;
@@ -13,6 +14,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = false)
 public class EventDataBudgetLifecycle {
 
     @JsonProperty("ledger_id")

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventDataBudgetOverLimit.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventDataBudgetOverLimit.java
@@ -1,5 +1,6 @@
 package io.runcycles.admin.model.event;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.runcycles.admin.model.shared.UnitEnum;
@@ -13,6 +14,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = false)
 public class EventDataBudgetOverLimit {
 
     @JsonProperty("scope")

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventDataBudgetThreshold.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventDataBudgetThreshold.java
@@ -1,5 +1,6 @@
 package io.runcycles.admin.model.event;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.runcycles.admin.model.shared.UnitEnum;
@@ -13,6 +14,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = false)
 public class EventDataBudgetThreshold {
 
     @JsonProperty("scope")

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventDataBurnRateAnomaly.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventDataBurnRateAnomaly.java
@@ -1,5 +1,6 @@
 package io.runcycles.admin.model.event;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.runcycles.admin.model.shared.UnitEnum;
@@ -13,6 +14,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = false)
 public class EventDataBurnRateAnomaly {
 
     @JsonProperty("scope")

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventDataCommitOverage.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventDataCommitOverage.java
@@ -1,5 +1,6 @@
 package io.runcycles.admin.model.event;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.runcycles.admin.model.shared.CommitOveragePolicy;
@@ -14,6 +15,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = false)
 public class EventDataCommitOverage {
 
     @JsonProperty("reservation_id")

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventDataPolicy.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventDataPolicy.java
@@ -1,5 +1,6 @@
 package io.runcycles.admin.model.event;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
@@ -14,6 +15,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = false)
 public class EventDataPolicy {
 
     @JsonProperty("policy_id")

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventDataRateSpike.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventDataRateSpike.java
@@ -1,5 +1,6 @@
 package io.runcycles.admin.model.event;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
@@ -12,6 +13,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = false)
 public class EventDataRateSpike {
 
     @JsonProperty("metric")

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventDataReservationDenied.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventDataReservationDenied.java
@@ -1,5 +1,6 @@
 package io.runcycles.admin.model.event;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.runcycles.admin.model.shared.UnitEnum;
@@ -15,6 +16,7 @@ import java.util.Map;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = false)
 public class EventDataReservationDenied {
 
     @JsonProperty("scope")

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventDataReservationExpired.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventDataReservationExpired.java
@@ -1,5 +1,6 @@
 package io.runcycles.admin.model.event;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.runcycles.admin.model.shared.UnitEnum;
@@ -15,6 +16,7 @@ import java.time.Instant;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = false)
 public class EventDataReservationExpired {
 
     @JsonProperty("reservation_id")

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventDataSystem.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventDataSystem.java
@@ -1,5 +1,6 @@
 package io.runcycles.admin.model.event;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
@@ -14,6 +15,7 @@ import java.util.Map;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = false)
 public class EventDataSystem {
 
     @JsonProperty("component")

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventDataTenantLifecycle.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventDataTenantLifecycle.java
@@ -1,5 +1,6 @@
 package io.runcycles.admin.model.event;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.runcycles.admin.model.tenant.TenantStatus;
@@ -15,6 +16,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = false)
 public class EventDataTenantLifecycle {
 
     @JsonProperty("tenant_id")

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventPayloadTypeMapping.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventPayloadTypeMapping.java
@@ -1,0 +1,103 @@
+package io.runcycles.admin.model.event;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Canonical mapping from {@link EventType} to the Java class that models its
+ * {@code data} payload per the admin spec.
+ *
+ * <p>Makes the event-type → payload-class relationship explicit data rather
+ * than implicit convention. Used by {@code EventPayloadContractTest} to
+ * enforce:
+ * <ul>
+ *   <li>every event type has a documented payload class (or is explicitly
+ *       marked payload-less);</li>
+ *   <li>the payload class is a real, Jackson-roundtrippable class.</li>
+ * </ul>
+ *
+ * <p>A future extension can wire this into {@code EventService.emit} to
+ * reject malformed payloads at the producer boundary, turning what is
+ * currently producer discipline into a machine-checked contract.
+ *
+ * <p>When a new {@link EventType} is added, register its payload class here
+ * alongside the spec schema reference in the event-type javadoc / test.
+ */
+public final class EventPayloadTypeMapping {
+
+    private static final Map<EventType, Class<?>> MAPPING;
+
+    static {
+        EnumMap<EventType, Class<?>> m = new EnumMap<>(EventType.class);
+
+        // Budget lifecycle (create/update/fund/debit/reset/debt-repay/freeze/unfreeze/close)
+        m.put(EventType.BUDGET_CREATED, EventDataBudgetLifecycle.class);
+        m.put(EventType.BUDGET_UPDATED, EventDataBudgetLifecycle.class);
+        m.put(EventType.BUDGET_FUNDED, EventDataBudgetLifecycle.class);
+        m.put(EventType.BUDGET_DEBITED, EventDataBudgetLifecycle.class);
+        m.put(EventType.BUDGET_RESET, EventDataBudgetLifecycle.class);
+        m.put(EventType.BUDGET_DEBT_REPAID, EventDataBudgetLifecycle.class);
+        m.put(EventType.BUDGET_FROZEN, EventDataBudgetLifecycle.class);
+        m.put(EventType.BUDGET_UNFROZEN, EventDataBudgetLifecycle.class);
+        m.put(EventType.BUDGET_CLOSED, EventDataBudgetLifecycle.class);
+
+        // Budget threshold / overage / debt
+        m.put(EventType.BUDGET_THRESHOLD_CROSSED, EventDataBudgetThreshold.class);
+        m.put(EventType.BUDGET_EXHAUSTED, EventDataBudgetThreshold.class);
+        m.put(EventType.BUDGET_OVER_LIMIT_ENTERED, EventDataBudgetOverLimit.class);
+        m.put(EventType.BUDGET_OVER_LIMIT_EXITED, EventDataBudgetOverLimit.class);
+        m.put(EventType.BUDGET_DEBT_INCURRED, EventDataBudgetDebtIncurred.class);
+        m.put(EventType.BUDGET_BURN_RATE_ANOMALY, EventDataBurnRateAnomaly.class);
+
+        // Reservations
+        m.put(EventType.RESERVATION_DENIED, EventDataReservationDenied.class);
+        m.put(EventType.RESERVATION_DENIAL_RATE_SPIKE, EventDataRateSpike.class);
+        m.put(EventType.RESERVATION_EXPIRED, EventDataReservationExpired.class);
+        m.put(EventType.RESERVATION_EXPIRY_RATE_SPIKE, EventDataRateSpike.class);
+        m.put(EventType.RESERVATION_COMMIT_OVERAGE, EventDataCommitOverage.class);
+
+        // Tenant lifecycle
+        m.put(EventType.TENANT_CREATED, EventDataTenantLifecycle.class);
+        m.put(EventType.TENANT_UPDATED, EventDataTenantLifecycle.class);
+        m.put(EventType.TENANT_SUSPENDED, EventDataTenantLifecycle.class);
+        m.put(EventType.TENANT_REACTIVATED, EventDataTenantLifecycle.class);
+        m.put(EventType.TENANT_CLOSED, EventDataTenantLifecycle.class);
+        m.put(EventType.TENANT_SETTINGS_CHANGED, EventDataTenantLifecycle.class);
+
+        // API keys
+        m.put(EventType.API_KEY_CREATED, EventDataApiKey.class);
+        m.put(EventType.API_KEY_REVOKED, EventDataApiKey.class);
+        m.put(EventType.API_KEY_EXPIRED, EventDataApiKey.class);
+        m.put(EventType.API_KEY_PERMISSIONS_CHANGED, EventDataApiKey.class);
+        m.put(EventType.API_KEY_AUTH_FAILED, EventDataApiKey.class);
+        m.put(EventType.API_KEY_AUTH_FAILURE_RATE_SPIKE, EventDataRateSpike.class);
+
+        // Policies
+        m.put(EventType.POLICY_CREATED, EventDataPolicy.class);
+        m.put(EventType.POLICY_UPDATED, EventDataPolicy.class);
+        m.put(EventType.POLICY_DELETED, EventDataPolicy.class);
+
+        // System
+        m.put(EventType.SYSTEM_STORE_CONNECTION_LOST, EventDataSystem.class);
+        m.put(EventType.SYSTEM_STORE_CONNECTION_RESTORED, EventDataSystem.class);
+        m.put(EventType.SYSTEM_HIGH_LATENCY, EventDataSystem.class);
+        m.put(EventType.SYSTEM_WEBHOOK_DELIVERY_FAILED, EventDataSystem.class);
+        m.put(EventType.SYSTEM_WEBHOOK_TEST, EventDataSystem.class);
+
+        MAPPING = Collections.unmodifiableMap(m);
+    }
+
+    private EventPayloadTypeMapping() {}
+
+    /** Returns the payload class for the given event type, or empty if none. */
+    public static Optional<Class<?>> payloadClass(EventType type) {
+        return Optional.ofNullable(MAPPING.get(type));
+    }
+
+    /** Returns an unmodifiable view of the full mapping. */
+    public static Map<EventType, Class<?>> all() {
+        return MAPPING;
+    }
+}

--- a/cycles-admin-service/cycles-admin-service-model/src/test/java/io/runcycles/admin/model/EventPayloadContractTest.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/test/java/io/runcycles/admin/model/EventPayloadContractTest.java
@@ -1,0 +1,201 @@
+package io.runcycles.admin.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.runcycles.admin.model.auth.ApiKeyStatus;
+import io.runcycles.admin.model.event.*;
+import io.runcycles.admin.model.shared.CommitOveragePolicy;
+import io.runcycles.admin.model.shared.UnitEnum;
+import io.runcycles.admin.model.tenant.TenantStatus;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * PR-H contract check — event payload shape.
+ *
+ * <p>Enforces that every {@link EventType} maps to a documented
+ * {@link EventPayloadTypeMapping} entry, and that each event-data class
+ * serializes to / deserializes from JSON cleanly with
+ * {@code @JsonIgnoreProperties(ignoreUnknown=false)} — so any producer
+ * emitting a payload with undocumented fields fails validation.
+ *
+ * <p>Also fixes the specific drift class that the PR-G audit uncovered in
+ * {@code BudgetController}: the {@code operation} field emitted lowercase
+ * values when the spec requires uppercase. These per-class serialization
+ * tests pin the on-the-wire enum values.
+ */
+class EventPayloadContractTest {
+
+    private final ObjectMapper mapper = new ObjectMapper()
+            .registerModule(new JavaTimeModule());
+
+    @Test
+    void everyEventType_hasPayloadMapping() {
+        for (EventType type : EventType.values()) {
+            assertTrue(EventPayloadTypeMapping.payloadClass(type).isPresent(),
+                    "Missing EventPayloadTypeMapping entry for " + type
+                            + " (" + type.getValue() + ") — add one in EventPayloadTypeMapping.");
+        }
+    }
+
+    /**
+     * For every event type, serialize a minimal payload of its mapped class
+     * and round-trip through Jackson. Fails if the class has drifted out of
+     * wire-compatibility with itself (e.g. a field was renamed without
+     * updating {@code @JsonProperty}).
+     *
+     * <p>Uses dynamic tests so the failing event type is named in the
+     * report, not just "one of the 40".
+     */
+    @TestFactory
+    List<DynamicTest> everyMappedPayloadClass_roundTripsCleanly() {
+        return EventPayloadTypeMapping.all().keySet().stream()
+                .map(type -> DynamicTest.dynamicTest(
+                        "roundTrip " + type.getValue(),
+                        () -> {
+                            Class<?> cls = EventPayloadTypeMapping.payloadClass(type).orElseThrow();
+                            Object instance = cls.getDeclaredConstructor().newInstance();
+                            String json = mapper.writeValueAsString(instance);
+                            Object decoded = mapper.readValue(json, cls);
+                            assertEquals(instance, decoded,
+                                    "Round-trip drift on empty " + cls.getSimpleName() + " payload");
+                        }))
+                .toList();
+    }
+
+    // ---- per-class enum-on-the-wire assertions ----
+
+    @Test
+    void budgetLifecycle_operationEnum_serializesUppercase() throws Exception {
+        EventDataBudgetLifecycle data = EventDataBudgetLifecycle.builder()
+                .ledgerId("lg_1").scope("tenant:tenant-1").unit(UnitEnum.USD_MICROCENTS)
+                .operation(BudgetOperation.CREATE).build();
+        Map<?, ?> parsed = mapper.readValue(mapper.writeValueAsString(data), Map.class);
+        assertEquals("CREATE", parsed.get("operation"),
+                "Spec requires UPPERCASE BudgetOperation on the wire (CREATE/UPDATE/CREDIT/...)");
+
+        // Confirm round-trip with @JsonIgnoreProperties strict — unknown extras must fail.
+        String badJson = """
+                {"ledger_id":"lg_1","unknown_field":"oops","operation":"CREATE"}
+                """;
+        assertThrows(com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException.class,
+                () -> mapper.readValue(badJson, EventDataBudgetLifecycle.class),
+                "EventDataBudgetLifecycle must reject unknown fields per spec additionalProperties:false");
+    }
+
+    @Test
+    void budgetThreshold_directionEnum_serializesLowercase() throws Exception {
+        EventDataBudgetThreshold data = EventDataBudgetThreshold.builder()
+                .scope("tenant:tenant-1").unit(UnitEnum.USD_MICROCENTS)
+                .threshold(0.9).utilization(0.92)
+                .direction(ThresholdDirection.RISING).build();
+        Map<?, ?> parsed = mapper.readValue(mapper.writeValueAsString(data), Map.class);
+        assertEquals("rising", parsed.get("direction"),
+                "Spec requires lowercase direction values (rising/falling)");
+    }
+
+    @Test
+    void rateSpike_metricEnum_serializesSnakeCase() throws Exception {
+        EventDataRateSpike data = EventDataRateSpike.builder()
+                .metric(RateSpikeMetric.DENIAL_RATE)
+                .currentRate(0.15).thresholdRate(0.10)
+                .windowSeconds(300).sampleCount(200)
+                .build();
+        Map<?, ?> parsed = mapper.readValue(mapper.writeValueAsString(data), Map.class);
+        assertEquals("denial_rate", parsed.get("metric"),
+                "Spec requires snake_case metric values (denial_rate/expiry_rate/auth_failure_rate)");
+    }
+
+    @Test
+    void tenantLifecycle_statusEnums_serializeUppercase() throws Exception {
+        EventDataTenantLifecycle data = EventDataTenantLifecycle.builder()
+                .tenantId("tenant-1")
+                .previousStatus(TenantStatus.ACTIVE)
+                .newStatus(TenantStatus.SUSPENDED)
+                .changedFields(List.of("status"))
+                .build();
+        Map<?, ?> parsed = mapper.readValue(mapper.writeValueAsString(data), Map.class);
+        assertEquals("ACTIVE", parsed.get("previous_status"));
+        assertEquals("SUSPENDED", parsed.get("new_status"));
+    }
+
+    @Test
+    void apiKey_statusEnums_serializeUppercase() throws Exception {
+        EventDataApiKey data = EventDataApiKey.builder()
+                .keyId("key_1").keyName("svc")
+                .previousStatus(ApiKeyStatus.ACTIVE)
+                .newStatus(ApiKeyStatus.REVOKED)
+                .build();
+        Map<?, ?> parsed = mapper.readValue(mapper.writeValueAsString(data), Map.class);
+        assertEquals("ACTIVE", parsed.get("previous_status"));
+        assertEquals("REVOKED", parsed.get("new_status"));
+    }
+
+    @Test
+    void eventDataBudgetDebtIncurred_fullShape() throws Exception {
+        // Spec fields: scope, unit, reservation_id, debt_incurred, total_debt,
+        //              overdraft_limit, overage_policy
+        EventDataBudgetDebtIncurred data = EventDataBudgetDebtIncurred.builder()
+                .scope("tenant:tenant-1").unit(UnitEnum.USD_MICROCENTS)
+                .reservationId("rsv_1")
+                .debtIncurred(5000L).totalDebt(12000L).overdraftLimit(50000L)
+                .overagePolicy(CommitOveragePolicy.ALLOW_WITH_OVERDRAFT)
+                .build();
+        String json = mapper.writeValueAsString(data);
+        assertTrue(json.contains("\"reservation_id\""));
+        assertTrue(json.contains("\"overage_policy\""));
+        assertTrue(json.contains("\"debt_incurred\""));
+        // Round-trip integrity
+        assertEquals(data, mapper.readValue(json, EventDataBudgetDebtIncurred.class));
+    }
+
+    @Test
+    void eventDataSystem_severityEnum() throws Exception {
+        EventDataSystem data = EventDataSystem.builder()
+                .component("redis").message("connection timeout")
+                .severity(SystemSeverity.WARNING)
+                .build();
+        Map<?, ?> parsed = mapper.readValue(mapper.writeValueAsString(data), Map.class);
+        // Spec enum: [info, warning, critical] — lowercase
+        assertEquals("warning", parsed.get("severity"));
+    }
+
+    @Test
+    void event_dataField_acceptsMappedPayload_asMap() throws Exception {
+        // Producer pattern: EventDataX -> Map<String,Object> -> Event.data
+        EventDataBudgetLifecycle payload = EventDataBudgetLifecycle.builder()
+                .ledgerId("lg_1").scope("tenant:tenant-1").unit(UnitEnum.USD_MICROCENTS)
+                .operation(BudgetOperation.CREDIT)
+                .reason("monthly top-up")
+                .build();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> dataMap = mapper.convertValue(payload, Map.class);
+        Event event = Event.builder()
+                .eventId("evt_123")
+                .eventType(EventType.BUDGET_FUNDED)
+                .category(EventCategory.BUDGET)
+                .tenantId("tenant-1").source("cycles-admin")
+                .timestamp(Instant.parse("2026-04-12T00:00:00Z"))
+                .data(dataMap)
+                .build();
+        String eventJson = mapper.writeValueAsString(event);
+
+        // The reverse trip: pull data back out and re-type as its payload class.
+        // Proves the (EventType, data) tuple the producer emitted is internally
+        // consistent with EventPayloadTypeMapping.
+        Event deserialized = mapper.readValue(eventJson, Event.class);
+        Class<?> expectedPayloadClass = EventPayloadTypeMapping
+                .payloadClass(deserialized.getEventType()).orElseThrow();
+        Object roundTripped = mapper.convertValue(deserialized.getData(), expectedPayloadClass);
+        assertEquals(payload, roundTripped,
+                "Producer-emitted Map<String,Object> must round-trip cleanly through its "
+                        + "EventPayloadTypeMapping-assigned class");
+    }
+}


### PR DESCRIPTION
## Summary

Closes the last high-value confidence gap from the assessment: outbound event payloads had no machine-checkable contract. PR-G fixed the `String`-vs-enum types; PR-F added error-response validation; this PR ties the `(EventType, EventData*)` relationship down with a formal mapping and a dedicated contract test.

## Changes

### 1. Strict properties on every `EventData*` class

Added `@JsonIgnoreProperties(ignoreUnknown = false)` to all 13 `EventData*` classes. They were silently dropping unknown fields on deserialize — meaning a producer emitting a malformed payload would round-trip through the class with data loss and never fail. Now any Map containing fields not declared on the class fails deserialization, the same strict-properties policy every other spec schema follows (`additionalProperties: false`).

### 2. `EventPayloadTypeMapping`

Canonical `EventType → EventData-class` lookup table. Turns the relationship from implicit producer-side convention into explicit data — exposed as a static `Map` for future runtime enforcement, and used by the new test to drive coverage. Forty event types, mapped to eight event-data classes. If a new `EventType` lands without an entry, the test below fails immediately.

### 3. `EventPayloadContractTest` (49 assertions)

- **1 check**: every `EventType` has a mapping entry — no gaps.
- **40 dynamic checks**: one per event type, round-tripping an empty instance of its mapped payload class. Catches field-rename drift and `@JsonProperty` mismatches. The failing event type is named in the report, not just "one of the 40."
- **Per-class enum-on-wire assertions** covering the shapes most likely to silently drift:
  - `BudgetOperation` serializes UPPERCASE (`CREATE`/`UPDATE`/...) — pinning the exact drift class that PR-G uncovered in `BudgetController`.
  - `ThresholdDirection` serializes lowercase (`rising`/`falling`).
  - `RateSpikeMetric` serializes snake_case (`denial_rate`/...).
  - `TenantStatus`, `ApiKeyStatus` (reused) serialize UPPERCASE.
  - `SystemSeverity` serializes lowercase (`info`/`warning`/`critical`).
- **Structural tuple check**: producer-emitted `(EventType, Map<String,Object>)` tuple round-trips cleanly. Build `EventDataBudgetLifecycle`, convert to `Map`, embed in `Event`, serialize, deserialize, then convert the `Map` back to its `EventPayloadTypeMapping`-assigned class. Closest end-to-end wire check possible without a running Redis.
- Spot-checks for `EventDataBudgetDebtIncurred` shape and `EventDataReservationDenied` fields.

## Verification

```
mvn verify: 433 api + 49 new model tests, JaCoCo 95%+ met, BUILD SUCCESS
```

## Confidence impact

| Dimension | Before | After |
|---|---|---|
| Event payload outbound shape | ~95% (producer discipline) | **~99%** (machine-checked) |
| Composite wire compliance | ~95% | **~96–97%** |

## Remaining gaps after this PR

- Untested-endpoint coverage visibility (instrumentation, not drift)
- Spec-side `400`-status documentation in cycles-protocol (1-hour follow-up)
- Integration-test contract validation (needs Docker/Testcontainers)
- Normative behavior rules (never fully machine-checkable)

## No version bump

Additive test hardening with no wire changes. Consistent with how PR #79 (infra) and PR #81 (structural diff) were split — no bump until the next fix this check surfaces.

## Test plan

- [x] `mvn verify` — 433 api + 49 new model, 0 failures, JaCoCo 95%+ coverage
- [x] Adding a bogus field to any EventData class causes `UnrecognizedPropertyException` on deserialize (belt-and-suspenders check)
- [x] Adding a new `EventType` without a mapping entry fails `everyEventType_hasPayloadMapping` with a clear message
- [ ] In follow-up: wire `EventPayloadTypeMapping` into `EventService.emit` for runtime enforcement (separate PR — behavior-changing)