### PR TITLE
test: DTO constraint contract check + COMPATIBLE drift logging

### DIFF
--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/contract/DtoConstraintContractTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/contract/DtoConstraintContractTest.java
@@ -1,0 +1,134 @@
+package io.runcycles.admin.api.contract;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.runcycles.admin.model.auth.ApiKeyCreateRequest;
+import io.runcycles.admin.model.auth.ApiKeyUpdateRequest;
+import io.runcycles.admin.model.auth.ApiKeyValidationRequest;
+import io.runcycles.admin.model.budget.BudgetCreateRequest;
+import io.runcycles.admin.model.budget.BudgetFundingRequest;
+import io.runcycles.admin.model.budget.BudgetUpdateRequest;
+import io.runcycles.admin.model.policy.PolicyCreateRequest;
+import io.runcycles.admin.model.tenant.TenantCreateRequest;
+import io.runcycles.admin.model.webhook.ReplayRequest;
+import io.runcycles.admin.model.webhook.WebhookCreateRequest;
+import io.runcycles.admin.model.webhook.WebhookSecurityConfig;
+import io.runcycles.admin.model.webhook.WebhookUpdateRequest;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.parser.OpenAPIV3Parser;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Phase-3 contract check — DTO CONSTRAINT DRIFT.
+ *
+ * <p>For every admin request-body DTO used on a {@code @RequestBody}
+ * controller parameter, asserts that each property the spec marks
+ * {@code required} has a corresponding Java field annotated with one of
+ * {@code @NotNull}, {@code @NotBlank}, or {@code @NotEmpty}.
+ *
+ * <p>Catches the class of drift where the spec tightens a field to
+ * {@code required} but the DTO still accepts null — an invalid request
+ * would pass Bean Validation, flow into the controller with a null
+ * field, and either 500 or silently 200 on structurally-invalid input.
+ *
+ * <p>DTO field-to-property mapping follows {@code @JsonProperty}; if
+ * absent, the field name is compared directly.
+ *
+ * <p>Deliberately conservative: checks only {@code required → @NotNull}.
+ * Ranges ({@code maxLength}/{@code pattern}) vary enough between spec
+ * style and Bean Validation that a strict check produces false positives;
+ * runtime {@code @Valid} in prod plus the response-schema validator cover
+ * most of those cases.
+ *
+ * <p>This is the admin-side port of cycles-server's
+ * {@code DtoConstraintContractTest}, reflecting the admin's
+ * {@code @RequestBody} DTOs rather than the runtime-plane reservation DTOs.
+ */
+class DtoConstraintContractTest {
+
+    /** Request DTOs whose spec schema is a NAMED component (not inline under a path's
+     * requestBody). Inline-schema endpoints are omitted because the spec uses them for
+     * partial-update bodies with no {@code required} fields anyway — nothing to check.
+     * Concretely: {@code BudgetUpdateRequest}, {@code ApiKeyUpdateRequest},
+     * {@code ReplayRequest}, {@code TenantUpdateRequest}, {@code PolicyUpdateRequest}
+     * are all inline in the admin spec, so they're excluded from this reflective check. */
+    private static final List<Class<?>> REQUEST_DTOS = List.of(
+            TenantCreateRequest.class,
+            BudgetCreateRequest.class,
+            BudgetFundingRequest.class,
+            PolicyCreateRequest.class,
+            ApiKeyCreateRequest.class,
+            ApiKeyValidationRequest.class,
+            WebhookCreateRequest.class,
+            WebhookUpdateRequest.class,
+            WebhookSecurityConfig.class
+    );
+
+    @Test
+    @EnabledIf(value = "io.runcycles.admin.api.contract.ContractValidationConfig#validationEnabled",
+               disabledReason = "contract.validation.enabled=false — skipping DTO constraint check")
+    void specRequiredFields_haveCorrespondingNotNullOnDto() {
+        OpenAPI spec = new OpenAPIV3Parser().readContents(ContractSpecLoader.loadSpec())
+                .getOpenAPI();
+        Map<String, Schema> schemas = spec.getComponents().getSchemas();
+
+        List<String> violations = new ArrayList<>();
+        for (Class<?> dtoClass : REQUEST_DTOS) {
+            Schema<?> schema = schemas.get(dtoClass.getSimpleName());
+            if (schema == null) {
+                violations.add(dtoClass.getSimpleName() + " — no matching spec schema");
+                continue;
+            }
+            List<String> requiredProps = schema.getRequired();
+            if (requiredProps == null || requiredProps.isEmpty()) continue;
+
+            for (String prop : requiredProps) {
+                Field field = findFieldByJsonName(dtoClass, prop);
+                if (field == null) {
+                    violations.add(dtoClass.getSimpleName() + "." + prop
+                            + " — spec requires this but DTO has no matching field");
+                    continue;
+                }
+                if (!hasNotNullAnnotation(field)) {
+                    violations.add(dtoClass.getSimpleName() + "." + prop
+                            + " (field " + field.getName()
+                            + ") — spec requires this but field lacks @NotNull/@NotBlank/@NotEmpty");
+                }
+            }
+        }
+
+        assertTrue(violations.isEmpty(),
+                "DTO constraint drift vs spec:\n  - " + String.join("\n  - ", violations));
+    }
+
+    private static Field findFieldByJsonName(Class<?> cls, String jsonName) {
+        for (Class<?> c = cls; c != null && c != Object.class; c = c.getSuperclass()) {
+            for (Field f : c.getDeclaredFields()) {
+                JsonProperty jp = f.getAnnotation(JsonProperty.class);
+                String name = (jp != null && !jp.value().isEmpty()) ? jp.value() : f.getName();
+                if (name.equals(jsonName)) return f;
+            }
+        }
+        return null;
+    }
+
+    private static boolean hasNotNullAnnotation(Field field) {
+        for (Annotation a : field.getAnnotations()) {
+            Class<? extends Annotation> t = a.annotationType();
+            if (t == NotNull.class || t == NotBlank.class || t == NotEmpty.class) return true;
+        }
+        return false;
+    }
+}

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/contract/OpenApiContractDiffTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/contract/OpenApiContractDiffTest.java
@@ -86,6 +86,22 @@ class OpenApiContractDiffTest {
         List<ChangedOperation> breakingOps = diff.getChangedOperations().stream()
                 .filter(op -> op.isCoreChanged() == DiffResult.INCOMPATIBLE)
                 .collect(Collectors.toList());
+        List<ChangedOperation> compatibleOps = diff.getChangedOperations().stream()
+                .filter(op -> op.isCoreChanged() == DiffResult.COMPATIBLE)
+                .collect(Collectors.toList());
+
+        // Observability-only: log COMPATIBLE-level drift (non-breaking). These are
+        // additions the server made that the spec hasn't absorbed yet — usually new
+        // optional fields, new response codes, or SpringDoc rendering differences.
+        // We don't fail the build on them; the runtime validator catches any actual
+        // shape issues. Printing them gives reviewers visibility without noise.
+        if (!compatibleOps.isEmpty()) {
+            System.out.printf("%n[structural diff] %d non-breaking (COMPATIBLE) drift items — " +
+                            "spec trailing server. No action required unless they indicate " +
+                            "missing spec updates:%n", compatibleOps.size());
+            compatibleOps.forEach(op ->
+                    System.out.println("  [compat] " + op.getHttpMethod() + " " + op.getPathUrl()));
+        }
 
         assertAll("structural diff between spec (cycles-protocol@main) and server /api-docs",
                 () -> assertTrue(missing.isEmpty(),


### PR DESCRIPTION
## Summary

Two additive hardening items ported from cycles-server's contract test suite (per parity review). No wire changes, no version bump.

## #6 — `DtoConstraintContractTest` (new)

Reflects over every admin `@RequestBody` DTO used by the 13 controllers. For each DTO whose spec schema is a named component, asserts that every property the spec marks `required` has a matching Java field annotated `@NotNull` / `@NotBlank` / `@NotEmpty`.

Catches the drift class where spec tightens a field but the DTO still accepts null — the request would pass Bean Validation (because the DTO has no `@NotNull`), flow into the controller with a null field, and either 500 or silently 200 on structurally-invalid input.

**Covered** (9 DTOs, all named in spec): `TenantCreateRequest`, `BudgetCreateRequest`, `BudgetFundingRequest`, `PolicyCreateRequest`, `ApiKeyCreateRequest`, `ApiKeyValidationRequest`, `WebhookCreateRequest`, `WebhookUpdateRequest`, `WebhookSecurityConfig`.

**Excluded** (inline-schema PATCH bodies have no `required: [...]` anyway): `TenantUpdateRequest`, `PolicyUpdateRequest`, `BudgetUpdateRequest`, `ApiKeyUpdateRequest`, `ReplayRequest`.

Deliberately conservative: checks `required → @NotNull` only. Ranges (`maxLength`/`pattern`) vary enough between spec style and Bean Validation that a strict check produces false positives; the runtime response-schema validator catches the real issues.

**Verification:** 0 drift on current main.

## #4 — COMPATIBLE-level drift logging in `OpenApiContractDiffTest`

Previously the test filtered `diff.getChangedOperations()` to `INCOMPATIBLE` only. Now it additionally **logs** COMPATIBLE (non-breaking) drift — doesn't fail, just prints. Gives reviewers visibility into "spec trailing server" cases without swamping the build with SpringDoc rendering noise that would trigger if we asserted.

Example output when drift exists:
```
[structural diff] 2 non-breaking (COMPATIBLE) drift items — spec trailing server. No action required unless they indicate missing spec updates:
  [compat] POST /v1/admin/budgets
  [compat] GET  /v1/admin/budgets/lookup
```

## Gap #2 deferred

Dropping the `validation.response.status.unknown → IGNORE` from `ContractValidationConfig` is blocked on runcycles/cycles-protocol#35 merging. That spec PR adds 404 on `PATCH /v1/admin/tenants/{tenant_id}` + 409 on `POST /v1/admin/policies` + `DELETE /v1/admin/api-keys/{key_id}` — the three cases that currently trigger the IGNORE. Once cycles-protocol#35 lands and the spec cache expires, the IGNORE drop is a one-line follow-up PR.

## Verification

```
mvn verify: 440/440 tests, JaCoCo 95%+, BUILD SUCCESS
Spec coverage: 43/43 (unchanged)
Structural diff: 0 missing, 0 extra, 0 breaking
DtoConstraintContractTest: 0 required-field drift
```

## Test plan

- [x] `mvn verify` — 440 tests pass (up from 439 — +1 for DtoConstraintContractTest)
- [x] DTO test catches drift: verified by manually removing `@NotBlank` from `TenantCreateRequest.tenantId` — test fails with clear message
- [x] COMPATIBLE logging produces output without failing the build
- [ ] Follow-up PR drops `status.unknown` IGNORE after cycles-protocol#35 merges