### PR TITLE
test: drop status.unknown IGNORE — strict response-status validation

### DIFF
--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/contract/ContractValidationConfig.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/contract/ContractValidationConfig.java
@@ -75,14 +75,13 @@ public class ContractValidationConfig {
                 .withLevel("validation.request.body.schema.enum", ValidationReport.Level.IGNORE)
                 .withLevel("validation.request.body.schema.pattern", ValidationReport.Level.IGNORE)
                 .withLevel("validation.request.body.schema.additionalProperties", ValidationReport.Level.IGNORE)
-                // Response-status coverage in cycles-protocol@main is incomplete: 400
-                // was added in v0.1.25.11 (cycles-protocol#33) but 404 is still
-                // undocumented on several PATCH/GET-by-id endpoints that correctly
-                // emit it for missing resources. Keep the IGNORE until a cycles-protocol
-                // follow-up adds 404 entries; the error BODIES are still validated on
-                // documented status codes.
-                .withLevel("validation.response.status.unknown", ValidationReport.Level.IGNORE)
                 .build();
+        // Response-status coverage is now complete on the admin surface as of
+        // cycles-protocol v0.1.25.12 (PR #35): 400 on all 43 operations (#33),
+        // plus 404 on PATCH tenants/{id}, and 409 on POST policies + DELETE
+        // api-keys/{id}. Every status the server can emit is documented, so the
+        // validator rejects any undocumented status with full strictness —
+        // no escape hatch.
         OpenApiInteractionValidator validator = OpenApiInteractionValidator
                 .createForInlineApiSpecification(ContractSpecLoader.loadSpec())
                 .withLevelResolver(levels)


### PR DESCRIPTION
## Summary

The last `LevelResolver` IGNORE in `ContractValidationConfig` is gone. Now that cycles-protocol v0.1.25.12 (runcycles/cycles-protocol#35) documented the final three missing status codes — 404 on \`PATCH /v1/admin/tenants/{id}\`, 409 on \`POST /v1/admin/policies\`, and 409 on \`DELETE /v1/admin/api-keys/{id}\` — every HTTP status the server emits is in the spec's responses map. The validator can now reject any undocumented-status response with full strictness.

## Diff

```java
 .withLevel("validation.request.body.schema.additionalProperties", ValidationReport.Level.IGNORE)
-// Response-status coverage in cycles-protocol@main is incomplete: 400
-// was added in v0.1.25.11 ... keep the IGNORE until a follow-up
-.withLevel("validation.response.status.unknown", ValidationReport.Level.IGNORE)
 .build();
+// Response-status coverage is now complete on the admin surface as of
+// cycles-protocol v0.1.25.12 (PR #35). Every status the server can
+// emit is documented — no escape hatch.
```

## Closes gap #2

From the cycles-server-parity review: "Drop \`withLevel(\"validation.response.status.unknown\", IGNORE)\` from admin's ContractValidationConfig." Originally claimed as a one-liner; actually required documenting 404/409 in cycles-protocol first (which #35 did). Now it's a one-liner for real.

## Verification

```
mvn verify: 440/440 tests, JaCoCo 95%+, BUILD SUCCESS
  Fresh spec pulled from cycles-protocol@main (v0.1.25.12)
  Spec coverage: 43/43 unchanged
  Response-status validation: strict — any undocumented status fails the build
```

## No version bump

Test-only hardening, zero wire changes. The server behavior hasn't changed; only the validator's tolerance has tightened.

## Wraps the parity push

| Gap | State |
|---|---|
| 1. RestTemplate interceptor | Deliberately skipped (scope) |
| 2. Drop status.unknown IGNORE | ✅ this PR |
| 3. Non-happy-path state tests | N/A (admin has no reservation state machine) |
| 4. COMPATIBLE drift logging | ✅ #87 |
| 5. CI integration-tests job | Deliberately skipped (coupled to #1) |
| 6. DtoConstraintContractTest | ✅ #87 |
| 7. SHA vs main tracking | Tradeoff, no action |
| 8. Shared validator | Downstream of #1 |

3 real gaps addressed; 3 deliberate scope/design decisions; 2 non-gaps. Admin contract testing is now at parity for the items that were actually applicable to its scope.

## Test plan

- [x] \`mvn verify\` — 440/440 pass with fresh spec from cycles-protocol@main
- [x] Response-status validation strict: confirmed no undocumented-status responses on any of the 13 controllers
- [x] DTO constraint test continues passing (from #87)
- [x] Structural diff continues passing (from #81)