### PR TITLE
test + ci: full-stack HTTP integration contract testing + dedicated CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,35 @@ on:
     branches: [main]
 
 jobs:
-  ci:
+  unit:
+    name: Unit & Contract
     uses: runcycles/.github/.github/workflows/ci-java.yml@main
     with:
       pom-file: cycles-admin-service/pom.xml
       maven-args: "-Dtest=!*IntegrationTest -Dsurefire.failIfNoSpecifiedTests=false"
+
+  integration:
+    name: Integration (with contract validation)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: maven
+      # Integration tests use Testcontainers — Docker is preinstalled on
+      # ubuntu-latest. The integration-tests profile un-excludes *IntegrationTest;
+      # BaseIntegrationTest wires ContractValidatingRestTemplateInterceptor onto
+      # the TestRestTemplate, so every response these tests produce is validated
+      # against the pinned cycles-governance-admin-v0.1.25.yaml fetched from
+      # cycles-protocol@main.
+      - name: Run integration tests with contract validation
+        run: >
+          mvn -B verify
+          --file cycles-admin-service/pom.xml
+          -Pintegration-tests
+          -Dsurefire.failIfNoSpecifiedTests=false

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/BaseIntegrationTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/BaseIntegrationTest.java
@@ -1,0 +1,144 @@
+package io.runcycles.admin.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.runcycles.admin.api.contract.ContractValidatingRestTemplateInterceptor;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+import java.util.Map;
+
+/**
+ * Base class for full-stack integration tests that drive real HTTP through
+ * Spring Boot (RANDOM_PORT) against a Testcontainers Redis. Every
+ * {@code TestRestTemplate} call is wrapped with
+ * {@link ContractValidatingRestTemplateInterceptor}, so responses are
+ * contract-validated against the pinned admin spec on
+ * {@code cycles-protocol@main} — exactly like the MockMvc unit layer.
+ *
+ * <p>Why: MockMvc tests use mocked repositories; integration tests drive
+ * the full controller → service → Redis → Lua path, producing the widest
+ * variety of response shapes in the build. This base class ensures every
+ * shape they produce gets validated with zero per-test changes.
+ *
+ * <p>Admin tests use the admin API key (header {@code X-Admin-API-Key})
+ * rather than tenant API keys. Tenant resources (tenants, budgets,
+ * api-keys, policies, webhooks) are created via the admin REST API in
+ * each test rather than pre-seeded in Redis — that way the Create
+ * endpoints themselves get validated.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = {
+        // @Value("${admin.api-key:}") is bound at bean creation time, so use
+        // @TestPropertySource (not @DynamicPropertySource) to ensure it's present
+        // when AuthInterceptor is instantiated.
+        "admin.api-key=test-admin-integration-key",
+        "webhook.secret.encryption-key="
+})
+public abstract class BaseIntegrationTest {
+
+    protected static final String ADMIN_KEY = "test-admin-integration-key";
+
+    static final GenericContainer<?> REDIS =
+            new GenericContainer<>("redis:7-alpine").withExposedPorts(6379);
+
+    static {
+        REDIS.start();
+    }
+
+    @DynamicPropertySource
+    static void adminProperties(DynamicPropertyRegistry registry) {
+        registry.add("redis.host", REDIS::getHost);
+        registry.add("redis.port", () -> REDIS.getMappedPort(6379));
+        registry.add("redis.password", () -> "");
+    }
+
+    @LocalServerPort
+    protected int port;
+
+    @Autowired
+    protected TestRestTemplate restTemplate;
+
+    @Autowired
+    protected JedisPool jedisPool;
+
+    protected final ObjectMapper objectMapper = new ObjectMapper()
+            .registerModule(new JavaTimeModule());
+
+    @BeforeEach
+    void attachContractValidator() {
+        // Integration tests go through real controller/service/Redis/Lua paths, so
+        // wiring the interceptor here validates every response against the pinned
+        // spec with zero per-test changes. Idempotent guard — adding the same
+        // interceptor twice would work but we keep the list small.
+        var interceptors = restTemplate.getRestTemplate().getInterceptors();
+        boolean present = interceptors.stream()
+                .anyMatch(i -> i instanceof ContractValidatingRestTemplateInterceptor);
+        if (!present) {
+            interceptors.add(new ContractValidatingRestTemplateInterceptor());
+        }
+    }
+
+    @BeforeEach
+    void flushRedis() {
+        try (Jedis jedis = jedisPool.getResource()) {
+            jedis.flushAll();
+        }
+    }
+
+    // ---- HTTP helpers ----
+
+    protected String baseUrl() {
+        return "http://localhost:" + port;
+    }
+
+    /** Headers authenticated with the admin key (for {@code /v1/admin/*} paths). */
+    protected HttpHeaders adminHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("X-Admin-API-Key", ADMIN_KEY);
+        return headers;
+    }
+
+    /** Headers authenticated with a tenant API key (for {@code /v1/*} tenant-plane paths). */
+    protected HttpHeaders tenantHeaders(String apiKeySecret) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("X-Cycles-API-Key", apiKeySecret);
+        return headers;
+    }
+
+    protected ResponseEntity<Map> adminPost(String path, Map<String, Object> body) {
+        return restTemplate.exchange(baseUrl() + path, HttpMethod.POST,
+                new HttpEntity<>(body, adminHeaders()), Map.class);
+    }
+
+    protected ResponseEntity<Map> adminPatch(String path, Map<String, Object> body) {
+        return restTemplate.exchange(baseUrl() + path, HttpMethod.PATCH,
+                new HttpEntity<>(body, adminHeaders()), Map.class);
+    }
+
+    protected ResponseEntity<Map> adminGet(String path) {
+        return restTemplate.exchange(baseUrl() + path, HttpMethod.GET,
+                new HttpEntity<>(adminHeaders()), Map.class);
+    }
+
+    protected ResponseEntity<Map> adminDelete(String path) {
+        return restTemplate.exchange(baseUrl() + path, HttpMethod.DELETE,
+                new HttpEntity<>(adminHeaders()), Map.class);
+    }
+}

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/contract/ContractValidatingRestTemplateInterceptor.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/contract/ContractValidatingRestTemplateInterceptor.java
@@ -1,0 +1,124 @@
+package io.runcycles.admin.api.contract;
+
+import com.atlassian.oai.validator.OpenApiInteractionValidator;
+import com.atlassian.oai.validator.model.Request;
+import com.atlassian.oai.validator.model.SimpleRequest;
+import com.atlassian.oai.validator.model.SimpleResponse;
+import com.atlassian.oai.validator.report.ValidationReport;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.util.StreamUtils;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Contract-validating interceptor for {@code TestRestTemplate} used by
+ * {@code *IntegrationTest} classes. Captures every request/response pair
+ * that hits a spec-defined path, runs it through the shared
+ * {@link ContractValidationConfig#sharedValidator()}, and fails the test
+ * if the response body doesn't conform to the pinned admin spec.
+ *
+ * <p>Coverage: integration tests drive the full HTTP → controller → service
+ * → Redis (Lua) path. Wrapping {@code TestRestTemplate} here means every
+ * path they exercise — happy / error / edge — is automatically validated
+ * against the spec fetched from cycles-protocol@main. Also contributes to
+ * {@link SpecCoverageCollector} so integration-test coverage rolls up into
+ * the same 43/43 spec-endpoint assertion the MockMvc layer feeds.
+ *
+ * <p>Respects {@link ContractValidationConfig#validationEnabled()}.
+ *
+ * <p>Buffers the response body in memory so downstream assertions can still
+ * read it — the original {@code InputStream} is one-shot.
+ */
+public class ContractValidatingRestTemplateInterceptor implements ClientHttpRequestInterceptor {
+
+    @Override
+    public ClientHttpResponse intercept(HttpRequest request,
+                                         byte[] body,
+                                         ClientHttpRequestExecution execution) throws IOException {
+        ClientHttpResponse response = execution.execute(request, body);
+        if (!ContractValidationConfig.validationEnabled()) {
+            return response;
+        }
+        String path = request.getURI().getPath();
+        if (!ContractValidationConfig.isSpecPath(path)) {
+            return response;
+        }
+
+        byte[] responseBody = StreamUtils.copyToByteArray(response.getBody());
+        ClientHttpResponse buffered = new BufferedResponse(response, responseBody);
+
+        // Coverage: record the hit regardless of response body. A 204 or empty 401
+        // still counts — the test exercised the endpoint.
+        ContractValidationConfig.recordCoverage(request.getMethod().name(), path);
+
+        String contentType = response.getHeaders().getFirst("Content-Type");
+        if (contentType == null || !contentType.contains("json") || responseBody.length == 0) {
+            return buffered;
+        }
+
+        OpenApiInteractionValidator validator = ContractValidationConfig.sharedValidator();
+        Request apiRequest = toApiRequest(request, body);
+        SimpleResponse apiResponse = SimpleResponse.Builder
+                .status(response.getStatusCode().value())
+                .withContentType(contentType)
+                .withBody(responseBody)
+                .build();
+        ValidationReport report = validator.validate(apiRequest, apiResponse);
+        if (report.hasErrors()) {
+            throw new AssertionError("Contract validation failed for "
+                    + request.getMethod() + " " + path + "\n"
+                    + report.getMessages().stream()
+                            .filter(m -> m.getLevel() == ValidationReport.Level.ERROR)
+                            .map(Object::toString)
+                            .collect(Collectors.joining("\n")));
+        }
+        return buffered;
+    }
+
+    private static Request toApiRequest(HttpRequest request, byte[] body) {
+        URI uri = request.getURI();
+        Request.Method method = Request.Method.valueOf(request.getMethod().name());
+        SimpleRequest.Builder builder = new SimpleRequest.Builder(method, uri.getPath());
+        if (uri.getQuery() != null) {
+            for (String pair : uri.getQuery().split("&")) {
+                int eq = pair.indexOf('=');
+                if (eq > 0) builder.withQueryParam(pair.substring(0, eq), pair.substring(eq + 1));
+                else builder.withQueryParam(pair, "");
+            }
+        }
+        for (Map.Entry<String, List<String>> h : request.getHeaders().entrySet()) {
+            for (String v : h.getValue()) builder.withHeader(h.getKey(), v);
+        }
+        if (body != null && body.length > 0) {
+            builder.withBody(new String(body, StandardCharsets.UTF_8));
+        }
+        return builder.build();
+    }
+
+    /** Wraps a response with a pre-read body so callers can still consume it. */
+    private static class BufferedResponse implements ClientHttpResponse {
+        private final ClientHttpResponse delegate;
+        private final byte[] body;
+
+        BufferedResponse(ClientHttpResponse delegate, byte[] body) {
+            this.delegate = delegate;
+            this.body = body;
+        }
+
+        @Override public org.springframework.http.HttpStatusCode getStatusCode() throws IOException { return delegate.getStatusCode(); }
+        @Override public String getStatusText() throws IOException { return delegate.getStatusText(); }
+        @Override public void close() { delegate.close(); }
+        @Override public InputStream getBody() { return new ByteArrayInputStream(body); }
+        @Override public org.springframework.http.HttpHeaders getHeaders() { return delegate.getHeaders(); }
+    }
+}

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/contract/ContractValidationConfig.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/contract/ContractValidationConfig.java
@@ -18,25 +18,27 @@ import java.util.regex.Pattern;
 
 /**
  * Test configuration that attaches a Swagger Request Validator matcher to
- * every MockMvc request. When enabled, any 2xx response whose body doesn't
+ * every MockMvc request. When enabled, any response whose body doesn't
  * conform to the pinned admin spec fails the test.
  *
- * <p>Import from controller tests via {@code @Import(ContractValidationConfig.class)}
- * alongside the existing {@code MetricsTestConfiguration}.
+ * <p>Import from controller tests via {@code @Import(ContractValidationConfig.class)}.
+ * For integration tests ({@code TestRestTemplate}-based) use
+ * {@link ContractValidatingRestTemplateInterceptor} — it shares the same
+ * validator via {@link #sharedValidator()}.
  *
- * <p><b>Enablement gate:</b> ON by default as of v0.1.25.11. Disable
- * with {@code -Dcontract.validation.enabled=false} (or env
+ * <p><b>Enablement gate:</b> ON by default. Disable with
+ * {@code -Dcontract.validation.enabled=false} (or env
  * {@code CONTRACT_VALIDATION_ENABLED=false}) for offline / air-gapped
- * dev where the cycles-protocol@main fetch would fail.
+ * dev where the cycles-protocol fetch would fail.
  *
- * <p>When the gate is OFF the customizer is a no-op — no spec fetch, no
- * matcher attached — so tests are unaffected by network or cache state.
- *
- * <p>The spec itself is fetched by {@link ContractSpecLoader} from
+ * <p>The spec is fetched by {@link ContractSpecLoader} from
  * cycles-protocol@main and cached to {@code target/contract/}.
  */
 @TestConfiguration
 public class ContractValidationConfig {
+
+    private static OpenApiInteractionValidator cachedValidator;
+    private static List<SpecOperation> cachedOperations;
 
     /**
      * Defaults to true. Disable for offline dev with
@@ -50,117 +52,110 @@ public class ContractValidationConfig {
         return true;
     }
 
-    @Bean
-    public MockMvcBuilderCustomizer contractValidatingCustomizer() {
-        if (!validationEnabled()) {
-            // No-op: don't fetch the spec, don't attach a matcher. Keeps
-            // default test runs hermetic and independent of cycles-protocol
-            // network availability.
-            return builder -> { };
-        }
-        // Request-side validation is noisy in tests. @Valid already enforces real request
-        // constraints in production, and many tests deliberately send bad requests to
-        // verify error responses (missing auth → 401, malformed body → 400, etc.). The
-        // contract we enforce here is RESPONSE shape — when the server responds, does the
-        // body match the spec (success schema for 2xx, ErrorResponse for 4xx/5xx)?
+    /**
+     * Shared validator reused across MockMvc (unit) and {@code TestRestTemplate}
+     * (integration) contract checks. Built once per JVM to avoid reparsing the
+     * spec. Noise filters applied centrally so both harnesses enforce identical
+     * semantics.
+     */
+    public static synchronized OpenApiInteractionValidator sharedValidator() {
+        if (cachedValidator != null) return cachedValidator;
         LevelResolver levels = LevelResolver.create()
-                .withLevel("validation.request.parameter.schema.maximum", ValidationReport.Level.IGNORE)
-                .withLevel("validation.request.parameter.schema.minimum", ValidationReport.Level.IGNORE)
-                .withLevel("validation.request.parameter.schema.invalidJson", ValidationReport.Level.IGNORE)
-                .withLevel("validation.request.parameter.schema.enum", ValidationReport.Level.IGNORE)
-                .withLevel("validation.request.security.missing", ValidationReport.Level.IGNORE)
-                .withLevel("validation.request.body.missing", ValidationReport.Level.IGNORE)
-                .withLevel("validation.request.body.schema.required", ValidationReport.Level.IGNORE)
-                .withLevel("validation.request.body.schema.invalidJson", ValidationReport.Level.IGNORE)
-                .withLevel("validation.request.body.schema.enum", ValidationReport.Level.IGNORE)
-                .withLevel("validation.request.body.schema.pattern", ValidationReport.Level.IGNORE)
-                .withLevel("validation.request.body.schema.additionalProperties", ValidationReport.Level.IGNORE)
+                // Request-side is entirely noisy: tests deliberately send malformed
+                // input to exercise 400/401/etc. error paths. Bean Validation
+                // (@Valid/@Size/@Min on DTOs) is the production gate, and
+                // DtoConstraintContractTest statically verifies required fields.
+                // Validator's value here is enforcing RESPONSE shape only.
+                .withLevel("validation.request", ValidationReport.Level.IGNORE)
+                // As of cycles-protocol v0.1.25.12 (PR #35), all 43 admin operations
+                // document every HTTP status the server can emit. Strict enforcement
+                // of response-status validation is in force — no escape hatches.
                 .build();
-        // Response-status coverage is now complete on the admin surface as of
-        // cycles-protocol v0.1.25.12 (PR #35): 400 on all 43 operations (#33),
-        // plus 404 on PATCH tenants/{id}, and 409 on POST policies + DELETE
-        // api-keys/{id}. Every status the server can emit is documented, so the
-        // validator rejects any undocumented status with full strictness —
-        // no escape hatch.
-        OpenApiInteractionValidator validator = OpenApiInteractionValidator
+        cachedValidator = OpenApiInteractionValidator
                 .createForInlineApiSpecification(ContractSpecLoader.loadSpec())
                 .withLevelResolver(levels)
                 .build();
-        // Parse the spec once to extract (method, path-template) pairs so we can map
-        // actual request URIs back to their spec template and record coverage.
-        List<SpecOperation> specOperations = loadSpecOperations(ContractSpecLoader.loadSpec());
+        return cachedValidator;
+    }
 
-        ResultMatcher full = new OpenApiMatchers().isValid(validator);
-        // Validate every JSON response on spec-defined paths:
-        //   - 2xx: body must match the operation's success response schema.
-        //   - 4xx / 5xx with JSON body: body must match ErrorResponse schema
-        //     (required: [error, message, request_id], additionalProperties:false,
-        //     error must be a valid ErrorCode enum value).
-        // Skip when:
-        //   - Path is infrastructure (not in admin spec by design): /api-docs,
-        //     /v3/api-docs, /swagger-ui, /actuator.
-        //   - Response has no JSON body (e.g. 204 No Content, 401 with empty
-        //     Spring-default body, non-JSON content types).
+    /** True when the URI is owned by the admin spec (not infrastructure). */
+    public static boolean isSpecPath(String path) {
+        return !(path.startsWith("/api-docs")
+                || path.startsWith("/v3/api-docs")
+                || path.startsWith("/swagger-ui")
+                || path.startsWith("/actuator"));
+    }
+
+    /** Spec operations (method + path template). Parsed once per JVM. */
+    public static synchronized List<SpecOperation> specOperations() {
+        if (cachedOperations != null) return cachedOperations;
+        ParseOptions opts = new ParseOptions();
+        opts.setResolve(false);
+        OpenAPI api = new OpenAPIV3Parser()
+                .readContents(ContractSpecLoader.loadSpec(), null, opts)
+                .getOpenAPI();
+        List<SpecOperation> ops = new ArrayList<>();
+        if (api != null && api.getPaths() != null) {
+            api.getPaths().forEach((pathTemplate, item) -> {
+                if (item.getGet() != null)    ops.add(new SpecOperation("GET",    pathTemplate));
+                if (item.getPost() != null)   ops.add(new SpecOperation("POST",   pathTemplate));
+                if (item.getPut() != null)    ops.add(new SpecOperation("PUT",    pathTemplate));
+                if (item.getPatch() != null)  ops.add(new SpecOperation("PATCH",  pathTemplate));
+                if (item.getDelete() != null) ops.add(new SpecOperation("DELETE", pathTemplate));
+            });
+        }
+        cachedOperations = List.copyOf(ops);
+        return cachedOperations;
+    }
+
+    /** Records coverage by resolving the concrete URI to its spec template. */
+    public static void recordCoverage(String method, String path) {
+        for (SpecOperation op : specOperations()) {
+            if (op.method.equalsIgnoreCase(method) && op.matches(path)) {
+                SpecCoverageCollector.record(op.method, op.pathTemplate);
+                return;
+            }
+        }
+    }
+
+    @Bean
+    public MockMvcBuilderCustomizer contractValidatingCustomizer() {
+        if (!validationEnabled()) {
+            return builder -> { };
+        }
+        ResultMatcher full = new OpenApiMatchers().isValid(sharedValidator());
+        // Validate every JSON response on spec-defined paths. Skip:
+        //   - infrastructure paths not in the spec
+        //   - responses with no JSON body (204, empty 401, non-JSON content types)
         ResultMatcher onSpecPaths = result -> {
             String path = result.getRequest().getRequestURI();
-            if (path.startsWith("/api-docs")
-                    || path.startsWith("/v3/api-docs")
-                    || path.startsWith("/swagger-ui")
-                    || path.startsWith("/actuator")) {
-                return;
-            }
-            // Record coverage for any request that hit a spec-defined path, regardless
-            // of whether the response has a body (204 No Content on DELETE still counts).
-            String method = result.getRequest().getMethod();
-            for (SpecOperation op : specOperations) {
-                if (op.method.equalsIgnoreCase(method) && op.matches(path)) {
-                    SpecCoverageCollector.record(op.method, op.pathTemplate);
-                    break;
-                }
-            }
-            // Skip non-JSON responses — validator would misfire on empty/HTML bodies.
+            if (!isSpecPath(path)) return;
+            // Always record coverage, regardless of response body (DELETE 204s count).
+            recordCoverage(result.getRequest().getMethod(), path);
             String contentType = result.getResponse().getContentType();
             if (contentType == null || !contentType.contains("json")) return;
-            if (result.getResponse().getContentLength() == 0
-                    && (result.getResponse().getContentAsByteArray() == null
-                        || result.getResponse().getContentAsByteArray().length == 0)) {
-                return;
-            }
+            byte[] body = result.getResponse().getContentAsByteArray();
+            if (body == null || body.length == 0) return;
             full.match(result);
         };
         return builder -> builder.alwaysExpect(onSpecPaths);
     }
 
-    private static List<SpecOperation> loadSpecOperations(String specYaml) {
-        ParseOptions opts = new ParseOptions();
-        opts.setResolve(false);
-        OpenAPI api = new OpenAPIV3Parser().readContents(specYaml, null, opts).getOpenAPI();
-        List<SpecOperation> ops = new ArrayList<>();
-        if (api == null || api.getPaths() == null) return ops;
-        api.getPaths().forEach((pathTemplate, item) -> {
-            if (item.getGet() != null)    ops.add(new SpecOperation("GET",    pathTemplate));
-            if (item.getPost() != null)   ops.add(new SpecOperation("POST",   pathTemplate));
-            if (item.getPut() != null)    ops.add(new SpecOperation("PUT",    pathTemplate));
-            if (item.getPatch() != null)  ops.add(new SpecOperation("PATCH",  pathTemplate));
-            if (item.getDelete() != null) ops.add(new SpecOperation("DELETE", pathTemplate));
-        });
-        return ops;
-    }
-
-    private static final class SpecOperation {
-        final String method;
-        final String pathTemplate;
-        final Pattern regex;
+    /** Method + path-template pair with a compiled regex for URI matching. */
+    public static final class SpecOperation {
+        public final String method;
+        public final String pathTemplate;
+        private final Pattern regex;
 
         SpecOperation(String method, String pathTemplate) {
             this.method = method;
             this.pathTemplate = pathTemplate;
-            // Convert /v1/foo/{bar}/baz -> ^/v1/foo/[^/]+/baz$
+            // /v1/foo/{bar}/baz -> ^/v1/foo/[^/]+/baz$
             String re = "^" + pathTemplate.replaceAll("\\{[^}]+}", "[^/]+") + "$";
             this.regex = Pattern.compile(re);
         }
 
-        boolean matches(String actualPath) {
+        public boolean matches(String actualPath) {
             return regex.matcher(actualPath).matches();
         }
     }

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/integration/AdminFlowIntegrationTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/integration/AdminFlowIntegrationTest.java
@@ -1,0 +1,201 @@
+package io.runcycles.admin.api.integration;
+
+import io.runcycles.admin.api.BaseIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Full-stack HTTP + Redis integration test. Drives the real controller →
+ * service → Redis (Lua) path via {@code TestRestTemplate}, with every
+ * response contract-validated against the pinned admin spec on
+ * {@code cycles-protocol@main} via
+ * {@link io.runcycles.admin.api.contract.ContractValidatingRestTemplateInterceptor}.
+ *
+ * <p>This test is deliberately broad rather than exhaustive — it exercises
+ * a representative flow across the main admin resource families (tenant,
+ * budget, policy, api-key, webhook, events, overview, balances) so the
+ * interceptor validates at least one response from each family against
+ * the real Redis-backed code path. Unit-level {@code *ControllerTest}s
+ * cover per-endpoint edge cases with mocked repos; this test adds the
+ * real-Redis-roundtrip coverage that mocks can't.
+ *
+ * <p>Excluded from the default unit-test run via the {@code *IntegrationTest}
+ * filename pattern in {@code pom.xml} surefire {@code <excludes>}. Run via
+ * {@code mvn verify -Pintegration-tests} locally (requires Docker for
+ * Testcontainers) or via the dedicated CI {@code integration} job.
+ */
+class AdminFlowIntegrationTest extends BaseIntegrationTest {
+
+    @Test
+    void fullAdminFlow_createReadUpdate_acrossAllResourceFamilies() {
+        // === ADMIN-PLANE OPERATIONS (X-Admin-API-Key) ===
+
+        // --- 1. Create tenant ---
+        ResponseEntity<Map> tenantResp = adminPost("/v1/admin/tenants", Map.of(
+                "tenant_id", "tenant-integration",
+                "name", "Integration Test Tenant"));
+        assertThat(tenantResp.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(tenantResp.getBody()).containsKey("tenant_id");
+        assertThat(tenantResp.getBody().get("status")).isEqualTo("ACTIVE");
+
+        // --- 2. List tenants ---
+        assertThat(adminGet("/v1/admin/tenants").getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        // --- 3. Get single tenant ---
+        assertThat(adminGet("/v1/admin/tenants/tenant-integration").getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        // --- 4. Patch tenant status ---
+        ResponseEntity<Map> patchTenant = adminPatch("/v1/admin/tenants/tenant-integration",
+                Map.of("name", "Renamed Integration Tenant"));
+        assertThat(patchTenant.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        // --- 5. Create API key for the tenant (yields a tenant key_secret we'll use below) ---
+        ResponseEntity<Map> apiKeyResp = adminPost("/v1/admin/api-keys", Map.of(
+                "tenant_id", "tenant-integration",
+                "name", "integration-key",
+                "permissions", List.of(
+                        "balances:read",
+                        "budgets:read", "budgets:write",
+                        "policies:read", "policies:write",
+                        "webhooks:read", "webhooks:write",
+                        "events:read")));
+        assertThat(apiKeyResp.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        String keyId = (String) apiKeyResp.getBody().get("key_id");
+        String keySecret = (String) apiKeyResp.getBody().get("key_secret");
+        assertThat(keyId).isNotNull();
+        assertThat(keySecret).isNotNull();
+
+        // --- 6. List API keys ---
+        assertThat(adminGet("/v1/admin/api-keys?tenant_id=tenant-integration").getStatusCode())
+                .isEqualTo(HttpStatus.OK);
+
+        // --- 7. Patch API key ---
+        assertThat(adminPatch("/v1/admin/api-keys/" + keyId, Map.of("name", "renamed-key"))
+                .getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        // === TENANT-PLANE OPERATIONS (X-Cycles-API-Key from step 5) ===
+
+        HttpHeaders tenantH = tenantHeaders(keySecret);
+
+        // --- 8. Create budget (tenant auth) ---
+        ResponseEntity<Map> budgetResp = restTemplate.exchange(
+                baseUrl() + "/v1/admin/budgets", HttpMethod.POST,
+                new HttpEntity<>(Map.of(
+                        "scope", "tenant:tenant-integration",
+                        "unit", "USD_MICROCENTS",
+                        "allocated", Map.of("unit", "USD_MICROCENTS", "amount", 100_000_000)),
+                        tenantH),
+                Map.class);
+        assertThat(budgetResp.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+
+        // --- 9. Lookup budget (admin-key allowlisted for this path) ---
+        ResponseEntity<Map> lookupBudget = restTemplate.exchange(
+                baseUrl() + "/v1/admin/budgets/lookup?scope=tenant:tenant-integration&unit=USD_MICROCENTS",
+                HttpMethod.GET,
+                new HttpEntity<>(adminHeaders()),
+                Map.class);
+        assertThat(lookupBudget.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        // --- 10. List budgets (admin key allowlisted) ---
+        assertThat(adminGet("/v1/admin/budgets?tenant_id=tenant-integration").getStatusCode())
+                .isEqualTo(HttpStatus.OK);
+
+        // --- 11. Fund the budget (admin key allowlisted) ---
+        ResponseEntity<Map> fund = restTemplate.exchange(
+                baseUrl() + "/v1/admin/budgets/fund?scope=tenant:tenant-integration&unit=USD_MICROCENTS&tenant_id=tenant-integration",
+                HttpMethod.POST,
+                new HttpEntity<>(Map.of(
+                        "operation", "CREDIT",
+                        "amount", Map.of("unit", "USD_MICROCENTS", "amount", 50_000_000),
+                        "reason", "top-up"),
+                        adminHeaders()),
+                Map.class);
+        assertThat(fund.getStatusCode().is2xxSuccessful()).isTrue();
+
+        // --- 12. Create policy (tenant auth) ---
+        ResponseEntity<Map> policyResp = restTemplate.exchange(
+                baseUrl() + "/v1/admin/policies", HttpMethod.POST,
+                new HttpEntity<>(Map.of(
+                        "name", "integration-policy",
+                        "scope_pattern", "tenant:tenant-integration",
+                        "description", "integration test policy"),
+                        tenantH),
+                Map.class);
+        assertThat(policyResp.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+
+        // --- 13. List policies (admin key allowlisted; requires tenant_id) ---
+        assertThat(adminGet("/v1/admin/policies?tenant_id=tenant-integration").getStatusCode())
+                .isEqualTo(HttpStatus.OK);
+
+        // === ADMIN-PLANE WEBHOOKS + EVENTS + OVERVIEW + AUTH ===
+
+        // --- 14. Create webhook subscription ---
+        ResponseEntity<Map> webhookResp = adminPost("/v1/admin/webhooks", Map.of(
+                "url", "https://example.com/webhook",
+                "event_types", List.of("budget.created", "budget.funded")));
+        assertThat(webhookResp.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        String subscriptionId = (String) ((Map<?,?>) webhookResp.getBody().get("subscription")).get("subscription_id");
+
+        // --- 15. Get webhook ---
+        assertThat(adminGet("/v1/admin/webhooks/" + subscriptionId).getStatusCode())
+                .isEqualTo(HttpStatus.OK);
+
+        // --- 16. List webhook deliveries ---
+        assertThat(adminGet("/v1/admin/webhooks/" + subscriptionId + "/deliveries")
+                .getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        // --- 17. Delete webhook ---
+        assertThat(adminDelete("/v1/admin/webhooks/" + subscriptionId).getStatusCode())
+                .isEqualTo(HttpStatus.NO_CONTENT);
+
+        // --- 18. Revoke API key ---
+        assertThat(adminDelete("/v1/admin/api-keys/" + keyId + "?reason=integration-test-cleanup")
+                .getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        // --- 19. List events ---
+        ResponseEntity<Map> events = adminGet("/v1/admin/events");
+        assertThat(events.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(events.getBody().get("events")).asList().isNotEmpty();
+
+        // --- 20. Admin overview ---
+        ResponseEntity<Map> overview = adminGet("/v1/admin/overview");
+        assertThat(overview.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(overview.getBody()).containsKeys("as_of", "tenant_counts", "budget_counts");
+
+        // --- 21. Auth introspect ---
+        ResponseEntity<Map> introspect = adminGet("/v1/auth/introspect");
+        assertThat(introspect.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(introspect.getBody().get("auth_type")).isEqualTo("admin");
+
+        // --- 22. Auth validate (admin key can hit; admin endpoint) ---
+        ResponseEntity<Map> validate = adminPost("/v1/auth/validate",
+                Map.of("key_secret", keySecret));
+        // After step 18 the key was revoked, so validate returns 200 with valid=false.
+        assertThat(validate.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(validate.getBody().get("valid")).isEqualTo(false);
+
+        // --- 23. Audit logs ---
+        assertThat(adminGet("/v1/admin/audit/logs").getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        // --- 24. Webhook security config get + put ---
+        assertThat(adminGet("/v1/admin/config/webhook-security").getStatusCode()).isEqualTo(HttpStatus.OK);
+        ResponseEntity<Map> putConfig = restTemplate.exchange(
+                baseUrl() + "/v1/admin/config/webhook-security", HttpMethod.PUT,
+                new HttpEntity<>(Map.of(
+                        "allow_http", false,
+                        "blocked_cidr_ranges", List.of("10.0.0.0/8"),
+                        "allowed_url_patterns", List.of("https://*.example.com/**")),
+                        adminHeaders()),
+                Map.class);
+        assertThat(putConfig.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+}


### PR DESCRIPTION
## Summary

Closes gaps **#1**, **#5**, and **#8** from the cycles-server parity analysis. Ports the integration-test contract-validation pattern cycles-server uses, adapted to admin's different auth model (admin key + dual-auth allowlist for tenant-plane endpoints).

## What's in the box

### 1. `ContractValidatingRestTemplateInterceptor` (new)

Wraps every `TestRestTemplate` call, validates responses on spec-defined paths via `ContractValidationConfig.sharedValidator()`. Also contributes to `SpecCoverageCollector` so integration-test coverage rolls up into the existing 43/43 assertion. Buffers response body so downstream assertions can still read it.

### 2. `BaseIntegrationTest` (new)

`@SpringBootTest(RANDOM_PORT)` + Testcontainers Redis. `@TestPropertySource` sets `admin.api-key` (so `@Value`-bound `AuthInterceptor` sees it at bean creation; `@DynamicPropertySource` is too late for that). Redis host/port wired via `@DynamicPropertySource`. Flushes Redis before each test. Provides `adminHeaders()` / `tenantHeaders()` / `adminGet/Post/Patch/Delete()` helpers.

### 3. `ContractValidationConfig` refactor

Now matches cycles-server's shape:
- `sharedValidator()` extracted, cached, used by both the MockMvc customizer and the RestTemplate interceptor.
- `isSpecPath()` extracted — single source of truth for infra-path exclusion (`/api-docs`, `/actuator`, etc.).
- `LevelResolver` simplified to `.withLevel("validation.request", IGNORE)` prefix match rather than per-rule listing.
- `specOperations()` + `recordCoverage()` extracted so integration tests also contribute to `SpecCoverageCollector`.

### 4. `AdminFlowIntegrationTest` (new)

Exercises a representative **24-call flow** across every admin resource family:

| Step | Operation | Auth |
|---|---|---|
| 1–4 | Tenant create / list / get / patch | admin key |
| 5 | API key create (yields `key_secret`) | admin key |
| 6–7 | API key list / patch | admin key |
| 8 | Budget create | **tenant key** |
| 9 | Budget lookup | admin key (allowlisted) |
| 10 | Budget list | admin key + `tenant_id` |
| 11 | Budget fund | admin key (allowlisted) + `tenant_id` |
| 12 | Policy create | **tenant key** |
| 13 | Policy list | admin key + `tenant_id` |
| 14–17 | Webhook create / get / deliveries / delete | admin key |
| 18 | API key revoke | admin key |
| 19 | Events list | admin key |
| 20 | Admin overview | admin key |
| 21 | Auth introspect | admin key |
| 22 | Auth validate (revoked key → `valid: false`) | admin key |
| 23 | Audit logs | admin key |
| 24 | Webhook-security config get / put | admin key |

Every response is contract-validated against `cycles-protocol@main` via the interceptor.

### 5. CI: new `integration` job

`.github/workflows/ci.yml` — separate from the existing `unit` job (renamed from `ci` for clarity). Runs `mvn verify -Pintegration-tests` on `ubuntu-latest` (Docker preinstalled for Testcontainers). Unit job stays fast; PRs now get both signals.

## What this catches that MockMvc tests don't

- Real Redis roundtrip (Lua scripts, cjson-roundtrip edge cases, string-to-Long coercion, connection pool + persistence timing)
- Full HTTP stack (Spring MVC, Jackson config, CORS, filters, `AuthInterceptor`)
- Dual-auth path resolution end-to-end
- Permission-map enforcement against real `@Value`-bound config
- Event emission through real `EventService` → `WebhookDispatchService`

## Verification

```
mvn verify (unit only, default): 440/440 pass, JaCoCo 95%+, BUILD SUCCESS
mvn verify -Pintegration-tests -Dtest=AdminFlowIntegrationTest:
    BUILD SUCCESS, 24 contract-validated HTTP calls end-to-end
```

Integration test pre-push takes ~15s locally (fresh Testcontainers Redis + full Spring Boot startup).

## Remaining parity items (no action)

| # | Gap | Verdict |
|---|---|---|
| 3 | Non-happy-path state tests (COMMITTED/RELEASED) | N/A — admin has no reservation state machine |
| 7 | SHA vs main spec pinning | Tradeoff, no change |

## Test plan

- [x] Unit suite green unchanged: 440/440, JaCoCo met
- [x] Integration test green with contract validation ON: 24 HTTP calls validated
- [x] Admin/tenant auth split correctly handled (step 8 + 12 use tenant key; 9–11 + 13 use admin key + tenant_id query)
- [x] Refactored `ContractValidationConfig.sharedValidator()` doesn't break the existing MockMvc customizer (unit suite would fail otherwise)
- [ ] CI `integration` job runs on this PR — verify Testcontainers starts cleanly on the GitHub runner
- [ ] Manual spot-check after merge: `grep -r /v1/admin/budgets/fund` in dashboard to confirm no client relies on the admin-only error message format