### PR TITLE
fix: v0.1.25.13 — CORS allowedMethods missing PUT (dashboard issue #30)

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,9 +1,29 @@
 # Complete Budget Governance v0.1.25.8 — Admin Server Audit
 
-**Server version:** 0.1.25.12 (2026-04-12 — spec-compliance push: Phase 2 structural diff, error + event payload validation, coverage visibility, runtime observability)
-**Date:** 2026-04-12 (v0.1.25.12 spec-compliance hardening + observability), 2026-04-12 (v0.1.25.11 contract-testing default ON), 2026-04-12 (v0.1.25.10 spec-compliance hardening), 2026-04-10 (v0.1.25.9 release), 2026-04-10 (CORS hardening + prod config), 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
+**Server version:** 0.1.25.13 (2026-04-13 — CORS allowedMethods now includes PUT; was silently breaking dashboard webhook-security save with a 403 + zero app logs)
+**Date:** 2026-04-13 (v0.1.25.13 CORS PUT fix), 2026-04-12 (v0.1.25.12 spec-compliance hardening + observability), 2026-04-12 (v0.1.25.11 contract-testing default ON), 2026-04-12 (v0.1.25.10 spec-compliance hardening), 2026-04-10 (v0.1.25.9 release), 2026-04-10 (CORS hardening + prod config), 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
 **Spec:** [`cycles-governance-admin-v0.1.25.yaml`](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml) (OpenAPI 3.1.0, v0.1.25.11) in [cycles-protocol](https://github.com/runcycles/cycles-protocol)
 **Server:** Spring Boot 3.5.11 / Java 21 / Redis
+
+### 2026-04-13 — v0.1.25.13 CORS allowedMethods missing PUT
+
+**Reported by dashboard issue [runcycles/cycles-dashboard#30](https://github.com/runcycles/cycles-dashboard/issues/30).** When the dashboard called `PUT /v1/admin/config/webhook-security` to save the webhook security config, browsers running the dashboard at a different origin (Vite dev server on `:5173`, or any non-proxied deployment) saw a `403 Forbidden` and the admin server produced **zero application logs**.
+
+**Root cause.** `WebConfig.addCorsMappings` listed `allowedMethods("GET", "POST", "PATCH", "DELETE", "OPTIONS")` — `PUT` was missing. The browser CORS preflight (`OPTIONS` with `Access-Control-Request-Method: PUT`) was rejected by Spring's `CorsFilter` *before* `AuthInterceptor` ran, so:
+
+- Spring returned 403 from the filter, not the controller.
+- `AuthInterceptor.preHandle` was never invoked → no INFO/WARN logs.
+- The `WebhookSecurityConfigController.update` method (which uses `@PutMapping("/webhook-security")`) was never reached.
+
+This is the only spec-defined endpoint using `PUT` in the admin API; every other write op uses POST / PATCH / DELETE, which is why no other operation regressed.
+
+**Fix.** Added `PUT` to `allowedMethods` in `WebConfig.java`. Updated the existing exact-match assertion in `WebConfigTest.addCorsMappings_allowlistsApiKeyAndRequestIdHeaders` to expect the new list, and added `addCorsMappings_includesPutForWebhookSecurityConfigEndpoint` as a regression guard so any future refactor that drops PUT fails the build.
+
+**Spec compliance.** Unchanged. Spec at v0.1.25.12; this is a server-only CORS fix.
+
+**Same-origin deployments are not affected.** The standard production stack proxies `/v1/*` from the dashboard's nginx → admin server, which is same-origin from the browser POV; CORS doesn't apply there. Affected deployments: dashboard dev server (Vite on 5173) hitting admin server directly, or any non-proxied cross-origin layout.
+
+---
 
 ### 2026-04-12 — v0.1.25.12 full-stack spec-compliance hardening
 

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/config/WebConfig.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/config/WebConfig.java
@@ -44,7 +44,13 @@ public class WebConfig implements WebMvcConfigurer {
         LOG.info("CORS configured for origins: {}", String.join(", ", origins));
         registry.addMapping("/v1/**")
             .allowedOrigins(origins)
-            .allowedMethods("GET", "POST", "PATCH", "DELETE", "OPTIONS")
+            // PUT must be in this list because PUT /v1/admin/config/webhook-security
+            // is the spec-defined method for updating the webhook security config.
+            // Without PUT here, the browser CORS preflight rejects the request
+            // before it reaches the AuthInterceptor — the user sees a 403 with
+            // zero admin-server logs (the rejection happens in Spring's CorsFilter,
+            // not the application). See dashboard issue #30.
+            .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
             // Both auth headers must be allowlisted or browser preflight rejects them.
             // X-Request-Id lets clients propagate a correlation id through the filter chain.
             .allowedHeaders("X-Admin-API-Key", "X-Cycles-API-Key", "X-Request-Id", "Content-Type")

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/config/WebConfigTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/config/WebConfigTest.java
@@ -62,8 +62,32 @@ class WebConfigTest {
         verify(corsReg).exposedHeaders(exposed.capture());
         assertThat(exposed.getValue()).containsExactly("X-Request-Id");
 
-        verify(corsReg).allowedMethods("GET", "POST", "PATCH", "DELETE", "OPTIONS");
+        // PUT must be present — PUT /v1/admin/config/webhook-security is the
+        // spec-defined method for updating webhook security config. The
+        // previous list omitted PUT and the dashboard's CORS preflight
+        // failed silently in Spring's CorsFilter (dashboard issue #30).
+        verify(corsReg).allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS");
         verify(corsReg).maxAge(3600L);
+    }
+
+    @Test
+    void addCorsMappings_includesPutForWebhookSecurityConfigEndpoint() {
+        // Regression guard for dashboard issue #30: a future refactor that
+        // re-omits PUT would silently break the webhook-security PUT
+        // endpoint with a 403 and no app-level logs. Spec authoritative
+        // method for /v1/admin/config/webhook-security is PUT.
+        WebConfig config = new WebConfig(authInterceptor);
+        ReflectionTestUtils.setField(config, "dashboardOrigin", "https://dash.example.com");
+
+        CorsRegistry corsRegistry = mock(CorsRegistry.class);
+        CorsRegistration corsReg = mock(CorsRegistration.class, RETURNS_SELF);
+        when(corsRegistry.addMapping("/v1/**")).thenReturn(corsReg);
+
+        config.addCorsMappings(corsRegistry);
+
+        ArgumentCaptor<String[]> methods = ArgumentCaptor.forClass(String[].class);
+        verify(corsReg).allowedMethods(methods.capture());
+        assertThat(methods.getValue()).contains("PUT");
     }
 
     @Test

--- a/cycles-admin-service/pom.xml
+++ b/cycles-admin-service/pom.xml
@@ -18,7 +18,7 @@
         <module>cycles-admin-service-api</module>
     </modules>
     <properties>
-        <revision>0.1.25.12</revision>
+        <revision>0.1.25.13</revision>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/docker-compose.full-stack.prod.yml
+++ b/docker-compose.full-stack.prod.yml
@@ -13,7 +13,7 @@ services:
       retries: 5
 
   cycles-admin:
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.12
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.13
     restart: unless-stopped
     ports:
       - "7979:7979"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,7 +13,7 @@ services:
       retries: 5
 
   cycles-admin:
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.12
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.13
     restart: unless-stopped
     ports:
       - "7979:7979"


### PR DESCRIPTION
## Summary
Reported by [runcycles/cycles-dashboard#30](https://github.com/runcycles/cycles-dashboard/issues/30): `PUT /v1/admin/config/webhook-security` returned 403 with **zero admin-server logs**.

## Root cause
`WebConfig.addCorsMappings` listed `allowedMethods("GET", "POST", "PATCH", "DELETE", "OPTIONS")` — **`PUT` was missing**. The browser CORS preflight (`OPTIONS` with `Access-Control-Request-Method: PUT`) was rejected by Spring's `CorsFilter` *before* `AuthInterceptor` ran:
- Spring returned 403 from the filter, not the controller.
- `AuthInterceptor.preHandle` was never invoked → no INFO/WARN logs.
- `WebhookSecurityConfigController.update` (uses `@PutMapping`) was never reached.

`webhook-security` is the **only** spec endpoint that uses PUT — every other write op uses POST/PATCH/DELETE — which is why no other operation regressed.

## Fix
- `WebConfig.java` — added `PUT` to `allowedMethods`.
- `WebConfigTest.java` — updated the existing exact-match assertion to expect the new list; added `addCorsMappings_includesPutForWebhookSecurityConfigEndpoint` as a regression guard so any future refactor that drops PUT fails the build.

## Spec compliance
Unchanged. Spec at v0.1.25.12; this is a server-only CORS fix.

## Same-origin deployments not affected
The standard production stack proxies `/v1/*` from the dashboard's nginx → admin server (same-origin from browser POV; CORS doesn't apply). Affected: dashboard dev server (Vite on `:5173`) hitting admin server directly, or any non-proxied cross-origin layout.

## Test plan
- [x] `mvn -pl cycles-admin-service-api test` — **441/441 pass** (was 440; +1 PUT regression guard)
- [x] WebConfigTest specifically — 5/5 pass
- [ ] Manual: deploy `0.1.25.13` image, point Vite dev dashboard at it, save Webhook Security Config → 200 + server logs visible