### PR TITLE
feat: v0.1.25.14 — admin-on-behalf-of dual-auth on createBudget, createPolicy, updatePolicy

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,9 +1,44 @@
 # Complete Budget Governance v0.1.25.8 — Admin Server Audit
 
-**Server version:** 0.1.25.13 (2026-04-13 — CORS allowedMethods now includes PUT; was silently breaking dashboard webhook-security save with a 403 + zero app logs)
-**Date:** 2026-04-13 (v0.1.25.13 CORS PUT fix), 2026-04-12 (v0.1.25.12 spec-compliance hardening + observability), 2026-04-12 (v0.1.25.11 contract-testing default ON), 2026-04-12 (v0.1.25.10 spec-compliance hardening), 2026-04-10 (v0.1.25.9 release), 2026-04-10 (CORS hardening + prod config), 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
+**Server version:** 0.1.25.14 (2026-04-13 — admin-on-behalf-of dual-auth on createBudget, createPolicy, updatePolicy per spec v0.1.25.13; closes "no Create Budget UI" dashboard gap)
+**Date:** 2026-04-13 (v0.1.25.14 admin-on-behalf-of dual-auth), 2026-04-13 (v0.1.25.13 CORS PUT fix), 2026-04-12 (v0.1.25.12 spec-compliance hardening + observability), 2026-04-12 (v0.1.25.11 contract-testing default ON), 2026-04-12 (v0.1.25.10 spec-compliance hardening), 2026-04-10 (v0.1.25.9 release), 2026-04-10 (CORS hardening + prod config), 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
 **Spec:** [`cycles-governance-admin-v0.1.25.yaml`](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml) (OpenAPI 3.1.0, v0.1.25.11) in [cycles-protocol](https://github.com/runcycles/cycles-protocol)
 **Server:** Spring Boot 3.5.11 / Java 21 / Redis
+
+### 2026-04-13 — v0.1.25.14 admin-on-behalf-of dual-auth on createBudget / createPolicy / updatePolicy
+
+Implements server side of [cycles-protocol PR #36](https://github.com/runcycles/cycles-protocol/pull/36) (spec v0.1.25.13). Closes a long-standing dashboard gap: admin operators previously could not create budgets or policies because those endpoints accepted **only** `ApiKeyAuth` (X-Cycles-API-Key), and the dashboard authenticates exclusively with `X-Admin-API-Key`. Tenant management worked end-to-end; budget/policy management was list/freeze/fund-only.
+
+**Auth changes** (`AuthInterceptor.java`):
+- Three new entries in `ADMIN_ALLOWED_ENDPOINTS` exact-match allowlist:
+  - `POST:/v1/admin/budgets` (createBudget)
+  - `POST:/v1/admin/policies` (createPolicy)
+- New `ADMIN_ALLOWED_PREFIXES` set with `PATCH:/v1/admin/policies/` to handle PATCH `/v1/admin/policies/{policy_id}` — exact match doesn't help when the path contains a resource id. The prefix matcher requires a non-empty resource id after the prefix to avoid accidentally matching the bare path.
+
+**Controller changes** (`BudgetController.create`, `PolicyController.create`, `PolicyController.update`):
+- Branch on auth context. ApiKeyAuth → `tenantId` from `authenticated_tenant_id` request attribute (existing). AdminKeyAuth → `tenantId` from request body's new `tenant_id` field (createBudget / createPolicy) or from the policy's stored owner (updatePolicy — `policy_id` already pins it).
+- Strict bidirectional validation: admin caller MUST send `tenant_id`; tenant caller MUST NOT send `tenant_id`. Either violation returns 400 INVALID_REQUEST with a clear message. Prevents tenants from spoofing creates as another tenant.
+- Audit log records `actor_type=admin_on_behalf_of` (new metadata key) for admin-driven calls; `api_key` for tenant self-service. Lets security review filter without joining to the keys table.
+- Event emission tags `Actor.type` with the new `ADMIN_ON_BEHALF_OF` enum value (was always `API_KEY`).
+
+**Schema changes**:
+- `BudgetCreateRequest` and `PolicyCreateRequest` gain optional `tenant_id` field. Required-when-admin / forbidden-when-tenant validation lives in the controller; bean validation can't express the conditional contract without a custom validator.
+
+**Model changes**:
+- `ActorType` enum gains `ADMIN_ON_BEHALF_OF` value (Jackson `@JsonValue` = `"admin_on_behalf_of"`).
+
+**Tests** (+13):
+- `AuthInterceptorTest`: 3 new dual-auth admit tests (POST budgets, POST policies, PATCH policy by id), 1 prefix-bare-rejection test, 1 trailing-slash normalization test. Existing `preHandle_postBudgets_withAdminKey_rejected` test inverted to `_accepted` (intentional behavior change).
+- `BudgetControllerTest`: admin-with-tenant-id-201, admin-missing-tenant-id-400, api-key-with-tenant-id-400, api-key-with-blank-tenant-id-400.
+- `PolicyControllerTest`: same 3 createPolicy cases + 2 updatePolicy cases (admin returns 200 with subject tenant from policy, api-key returns 200 with self-tenant). Both update tests verify audit `actor_type` discriminator.
+
+**Spec compliance.** Aligned with cycles-protocol v0.1.25.13. No wire-format changes for existing tenant-key callers (purely additive `tenant_id` schema field).
+
+**Backward compatibility.** Pre-existing test `preHandle_postBudgets_withAdminKey_rejected` was changed to `_accepted` — that's an intentional behavior change matching the spec, not a regression.
+
+**Tests.** **454/454 pass** (was 441; +13). Coverage check (JaCoCo) passes — all new branches covered.
+
+---
 
 ### 2026-04-13 — v0.1.25.13 CORS allowedMethods missing PUT
 

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -27,7 +27,12 @@ Implements server side of [cycles-protocol PR #36](https://github.com/runcycles/
 **Model changes**:
 - `ActorType` enum gains `ADMIN_ON_BEHALF_OF` value (Jackson `@JsonValue` = `"admin_on_behalf_of"`).
 
-**Tests** (+13):
+**Pre-merge review hardening** (post code review):
+- Defense-in-depth path-traversal guard in `AuthInterceptor.preHandle`. Tomcat's connector already rejects `..` segments by default, but if a future deployment relaxes that or the server sits behind a proxy that forwards the raw URI, the new prefix matcher could in principle let `PATCH /v1/admin/policies/../tenants/t_1` past the dual-auth allowlist and let Spring's dispatcher route it to a different endpoint with admin auth already approved. Now: short-circuit any request whose servlet path contains `/../`, `/./`, or ends in `/..` with 400 INVALID_REQUEST. Also switched the dual-auth match input from `getRequestURI()` to `getServletPath()` so the interceptor sees the same normalized path Spring's dispatcher uses for routing.
+- Replaced hardcoded `"admin_on_behalf_of"` / `"api_key"` strings in audit metadata with `ActorType.ADMIN_ON_BEHALF_OF.getValue()` / `ActorType.API_KEY.getValue()` — an enum rename can no longer silently drift the wire format.
+- Explicit JSON-null `tenant_id` test on both `BudgetController` and `PolicyController` (separate from JSON-missing and JSON-empty-string).
+
+**Tests** (+18):
 - `AuthInterceptorTest`: 3 new dual-auth admit tests (POST budgets, POST policies, PATCH policy by id), 1 prefix-bare-rejection test, 1 trailing-slash normalization test. Existing `preHandle_postBudgets_withAdminKey_rejected` test inverted to `_accepted` (intentional behavior change).
 - `BudgetControllerTest`: admin-with-tenant-id-201, admin-missing-tenant-id-400, api-key-with-tenant-id-400, api-key-with-blank-tenant-id-400.
 - `PolicyControllerTest`: same 3 createPolicy cases + 2 updatePolicy cases (admin returns 200 with subject tenant from policy, api-key returns 200 with self-tenant). Both update tests verify audit `actor_type` discriminator.
@@ -36,7 +41,7 @@ Implements server side of [cycles-protocol PR #36](https://github.com/runcycles/
 
 **Backward compatibility.** Pre-existing test `preHandle_postBudgets_withAdminKey_rejected` was changed to `_accepted` — that's an intentional behavior change matching the spec, not a regression.
 
-**Tests.** **454/454 pass** (was 441; +13). Coverage check (JaCoCo) passes — all new branches covered.
+**Tests.** **459/459 pass** (was 441; +18). Coverage check (JaCoCo) passes — all new branches covered.
 
 ---
 

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/config/AuthInterceptor.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/config/AuthInterceptor.java
@@ -102,7 +102,29 @@ public class AuthInterceptor implements HandlerInterceptor {
             // Check dual-auth allowlist: some ApiKeyAuth endpoints also accept AdminKeyAuth.
             // Two layers — exact match for fixed paths (e.g. POST /v1/admin/budgets/fund),
             // and prefix match for paths with a resource id (e.g. PATCH /v1/admin/policies/{id}).
-            String normalizedPath = path.endsWith("/") ? path.substring(0, path.length() - 1) : path;
+            //
+            // Defense in depth: reject any request whose path contains traversal
+            // segments before the dual-auth match. Tomcat's connector already
+            // rejects "../" requests by default (RFC 3986 strict mode), but if
+            // a future deployment relaxes that or sits behind a proxy that
+            // forwards the raw URI, we don't want a request like
+            // "PATCH /v1/admin/policies/../api-keys/k_1" to pass the interceptor's
+            // prefix matcher and then get re-routed by Spring's dispatcher to a
+            // different endpoint (auth-context confusion). Spring uses the
+            // servlet path for dispatch; we now match against that same value
+            // and additionally short-circuit on any traversal segment.
+            String dispatchPath = request.getServletPath();
+            if (dispatchPath != null && (dispatchPath.contains("/../") ||
+                    dispatchPath.contains("/./") || dispatchPath.endsWith("/.."))) {
+                writeError(request, response, 400,
+                    io.runcycles.admin.model.shared.ErrorCode.INVALID_REQUEST,
+                    "Path traversal segments not allowed");
+                return false;
+            }
+            // Use the dispatch path (Spring-normalized) for matching so the
+            // interceptor and the dispatcher always see the same URL.
+            String matchPath = (dispatchPath != null && !dispatchPath.isEmpty()) ? dispatchPath : path;
+            String normalizedPath = matchPath.endsWith("/") ? matchPath.substring(0, matchPath.length() - 1) : matchPath;
             String lookupKey = method + ":" + normalizedPath;
             if (hasAdminKeyHeader(request) && (
                     ADMIN_ALLOWED_ENDPOINTS.contains(lookupKey) ||

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/config/AuthInterceptor.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/config/AuthInterceptor.java
@@ -36,7 +36,24 @@ public class AuthInterceptor implements HandlerInterceptor {
         "GET:/v1/admin/budgets",
         "GET:/v1/admin/budgets/lookup",
         "GET:/v1/admin/policies",
-        "POST:/v1/admin/budgets/fund"
+        "POST:/v1/admin/budgets/fund",
+        // v0.1.25.14: dual-auth on create writes added per spec v0.1.25.13.
+        // Admin operators can now provision budgets and policies on behalf
+        // of tenants. Body MUST include tenant_id when admin-key —
+        // controllers enforce + audit-log records actor_type=
+        // ADMIN_ON_BEHALF_OF for these calls.
+        "POST:/v1/admin/budgets",
+        "POST:/v1/admin/policies"
+    );
+
+    // Method:path-prefix entries for dual-auth where the path includes a
+    // resource id (e.g. PATCH /v1/admin/policies/{policy_id}). Exact-match
+    // lookup in ADMIN_ALLOWED_ENDPOINTS doesn't help here because every
+    // request has a different concrete id. policy_id pins the owning
+    // tenant in the persistence layer, so no tenant_id body field is
+    // needed for admin-on-behalf-of updates. (v0.1.25.14, spec v0.1.25.13.)
+    private static final Set<String> ADMIN_ALLOWED_PREFIXES = Set.of(
+        "PATCH:/v1/admin/policies/"
     );
 
     // Endpoint path+method → required permission per admin governance spec
@@ -82,10 +99,14 @@ public class AuthInterceptor implements HandlerInterceptor {
         if (requiresAdminKey(method, path)) {
             return validateAdminKey(request, response);
         } else if (requiresApiKey(path)) {
-            // Check dual-auth allowlist: some ApiKeyAuth endpoints also accept AdminKeyAuth for reads
+            // Check dual-auth allowlist: some ApiKeyAuth endpoints also accept AdminKeyAuth.
+            // Two layers — exact match for fixed paths (e.g. POST /v1/admin/budgets/fund),
+            // and prefix match for paths with a resource id (e.g. PATCH /v1/admin/policies/{id}).
             String normalizedPath = path.endsWith("/") ? path.substring(0, path.length() - 1) : path;
             String lookupKey = method + ":" + normalizedPath;
-            if (ADMIN_ALLOWED_ENDPOINTS.contains(lookupKey) && hasAdminKeyHeader(request)) {
+            if (hasAdminKeyHeader(request) && (
+                    ADMIN_ALLOWED_ENDPOINTS.contains(lookupKey) ||
+                    matchesAdminPrefix(method, normalizedPath))) {
                 return validateAdminKey(request, response);
             }
             return validateApiKey(request, response);
@@ -120,6 +141,21 @@ public class AuthInterceptor implements HandlerInterceptor {
         if ("POST".equals(method) && (path.startsWith("/v1/admin/budgets/freeze") ||
                                        path.startsWith("/v1/admin/budgets/unfreeze"))) {
             return true;
+        }
+        return false;
+    }
+
+    private boolean matchesAdminPrefix(String method, String normalizedPath) {
+        // Entry format: "PATCH:/v1/admin/policies/" (trailing slash).
+        // Request must start with the entry AND have a non-empty suffix
+        // after it — that suffix is the resource id. Bare-prefix requests
+        // (no id) wouldn't be valid REST anyway, but the length check
+        // guards against accidentally matching them.
+        String reqKey = method + ":" + normalizedPath;
+        for (String entry : ADMIN_ALLOWED_PREFIXES) {
+            if (reqKey.startsWith(entry) && reqKey.length() > entry.length()) {
+                return true;
+            }
         }
         return false;
     }

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/BudgetController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/BudgetController.java
@@ -59,7 +59,11 @@ public class BudgetController {
                 "allocated", request.getAllocated().getAmount(),
                 // Surfaces the auth path used so audit reviewers can
                 // distinguish admin-on-behalf-of from tenant self-service.
-                "actor_type", isAdminAuth ? "admin_on_behalf_of" : "api_key"))
+                // Source the wire format from the enum's @JsonValue rather
+                // than a hardcoded string so an enum rename doesn't drift the
+                // audit-log format silently. The wire string is "admin_on_behalf_of"
+                // / "api_key" — same as ActorType.getValue().
+                "actor_type", (isAdminAuth ? ActorType.ADMIN_ON_BEHALF_OF : ActorType.API_KEY).getValue()))
             .build());
         try {
             ActorType actorType = isAdminAuth ? ActorType.ADMIN_ON_BEHALF_OF : ActorType.API_KEY;

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/BudgetController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/BudgetController.java
@@ -30,7 +30,24 @@ public class BudgetController {
     public ResponseEntity<BudgetLedger> create(@Valid @RequestBody BudgetCreateRequest request, HttpServletRequest httpRequest) {
         validateCreateUnits(request);
         ScopeFilterUtil.enforceScopeFilter(httpRequest, request.getScope());
-        String tenantId = (String) httpRequest.getAttribute("authenticated_tenant_id");
+        // v0.1.25.14 dual-auth (spec v0.1.25.13). For ApiKeyAuth the tenant
+        // is implicit from the authenticated key; for AdminKeyAuth it must
+        // come from the request body. Enforce the conditional contract:
+        // tenant_id present iff admin-auth.
+        String authTenantId = (String) httpRequest.getAttribute("authenticated_tenant_id");
+        boolean isAdminAuth = authTenantId == null;
+        if (isAdminAuth) {
+            if (request.getTenantId() == null || request.getTenantId().isBlank()) {
+                throw new GovernanceException(
+                    io.runcycles.admin.model.shared.ErrorCode.INVALID_REQUEST,
+                    "tenant_id is required in the request body when using admin key authentication", 400);
+            }
+        } else if (request.getTenantId() != null) {
+            throw new GovernanceException(
+                io.runcycles.admin.model.shared.ErrorCode.INVALID_REQUEST,
+                "tenant_id MUST NOT be set when using API key authentication (tenant is inferred from the key)", 400);
+        }
+        String tenantId = isAdminAuth ? request.getTenantId() : authTenantId;
         BudgetLedger ledger = repository.create(tenantId, request);
         auditRepository.log(buildAuditEntry(httpRequest)
             .tenantId(tenantId)
@@ -39,11 +56,15 @@ public class BudgetController {
             .operation("createBudget")
             .status(201)
             .metadata(Map.of("scope", request.getScope(), "unit", request.getUnit().name(),
-                "allocated", request.getAllocated().getAmount()))
+                "allocated", request.getAllocated().getAmount(),
+                // Surfaces the auth path used so audit reviewers can
+                // distinguish admin-on-behalf-of from tenant self-service.
+                "actor_type", isAdminAuth ? "admin_on_behalf_of" : "api_key"))
             .build());
         try {
+            ActorType actorType = isAdminAuth ? ActorType.ADMIN_ON_BEHALF_OF : ActorType.API_KEY;
             eventService.emit(EventType.BUDGET_CREATED, tenantId, request.getScope(), "cycles-admin",
-                Actor.builder().type(ActorType.API_KEY)
+                Actor.builder().type(actorType)
                     .keyId((String) httpRequest.getAttribute("authenticated_key_id")).build(),
                 objectMapper.convertValue(EventDataBudgetLifecycle.builder()
                     .ledgerId(ledger.getLedgerId()).scope(request.getScope())

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/PolicyController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/PolicyController.java
@@ -59,7 +59,9 @@ public class PolicyController {
             .operation("createPolicy")
             .status(201)
             .metadata(Map.of("name", request.getName(), "scope_pattern", request.getScopePattern(),
-                "actor_type", isAdminAuth ? "admin_on_behalf_of" : "api_key"))
+                // Sourced from ActorType.@JsonValue so an enum rename can't
+                // silently drift the audit-log format.
+                "actor_type", (isAdminAuth ? ActorType.ADMIN_ON_BEHALF_OF : ActorType.API_KEY).getValue()))
             .build());
         try {
             ActorType actorType = isAdminAuth ? ActorType.ADMIN_ON_BEHALF_OF : ActorType.API_KEY;
@@ -166,7 +168,7 @@ public class PolicyController {
     private Map<String, Object> buildUpdatePolicyMetaWithActor(String scopePattern, PolicyUpdateRequest request, boolean isAdminAuth) {
         Map<String, Object> meta = buildUpdatePolicyMeta(scopePattern, request);
         if (meta == null) meta = new java.util.LinkedHashMap<>();
-        meta.put("actor_type", isAdminAuth ? "admin_on_behalf_of" : "api_key");
+        meta.put("actor_type", (isAdminAuth ? ActorType.ADMIN_ON_BEHALF_OF : ActorType.API_KEY).getValue());
         return meta;
     }
 

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/PolicyController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/PolicyController.java
@@ -1,4 +1,5 @@
 package io.runcycles.admin.api.controller;
+import io.runcycles.admin.data.exception.GovernanceException;
 import io.runcycles.admin.data.repository.AuditRepository;
 import io.runcycles.admin.data.repository.PolicyRepository;
 import io.runcycles.admin.model.audit.AuditLogEntry;
@@ -33,7 +34,23 @@ public class PolicyController {
     @PostMapping @Operation(operationId = "createPolicy")
     public ResponseEntity<Policy> create(@Valid @RequestBody PolicyCreateRequest request, HttpServletRequest httpRequest) {
         ScopeFilterUtil.enforceScopeFilter(httpRequest, request.getScopePattern());
-        String tenantId = (String) httpRequest.getAttribute("authenticated_tenant_id");
+        // v0.1.25.14 dual-auth (spec v0.1.25.13). Same shape as
+        // BudgetController.create — admin caller MUST send tenant_id in body,
+        // tenant caller MUST NOT.
+        String authTenantId = (String) httpRequest.getAttribute("authenticated_tenant_id");
+        boolean isAdminAuth = authTenantId == null;
+        if (isAdminAuth) {
+            if (request.getTenantId() == null || request.getTenantId().isBlank()) {
+                throw new GovernanceException(
+                    io.runcycles.admin.model.shared.ErrorCode.INVALID_REQUEST,
+                    "tenant_id is required in the request body when using admin key authentication", 400);
+            }
+        } else if (request.getTenantId() != null) {
+            throw new GovernanceException(
+                io.runcycles.admin.model.shared.ErrorCode.INVALID_REQUEST,
+                "tenant_id MUST NOT be set when using API key authentication (tenant is inferred from the key)", 400);
+        }
+        String tenantId = isAdminAuth ? request.getTenantId() : authTenantId;
         Policy policy = repository.create(tenantId, request);
         auditRepository.log(buildAuditEntry(httpRequest)
             .tenantId(tenantId)
@@ -41,11 +58,13 @@ public class PolicyController {
             .resourceType("policy").resourceId(policy.getPolicyId())
             .operation("createPolicy")
             .status(201)
-            .metadata(Map.of("name", request.getName(), "scope_pattern", request.getScopePattern()))
+            .metadata(Map.of("name", request.getName(), "scope_pattern", request.getScopePattern(),
+                "actor_type", isAdminAuth ? "admin_on_behalf_of" : "api_key"))
             .build());
         try {
+            ActorType actorType = isAdminAuth ? ActorType.ADMIN_ON_BEHALF_OF : ActorType.API_KEY;
             eventService.emit(EventType.POLICY_CREATED, tenantId, request.getScopePattern(), "cycles-admin",
-                Actor.builder().type(ActorType.API_KEY)
+                Actor.builder().type(actorType)
                     .keyId((String) httpRequest.getAttribute("authenticated_key_id")).build(),
                 objectMapper.convertValue(EventDataPolicy.builder()
                     .policyId(policy.getPolicyId()).name(request.getName())
@@ -60,19 +79,30 @@ public class PolicyController {
     public ResponseEntity<Policy> update(@PathVariable("policy_id") String policyId, @Valid @RequestBody PolicyUpdateRequest request, HttpServletRequest httpRequest) {
         String scopePattern = repository.getScopePattern(policyId);
         ScopeFilterUtil.enforceScopeFilter(httpRequest, scopePattern);
-        String tenantId = (String) httpRequest.getAttribute("authenticated_tenant_id");
-        Policy policy = repository.update(tenantId, policyId, request);
+        // v0.1.25.14 dual-auth: admin caller passes null tenantId to the
+        // repository (the Lua script skips ownership check); tenant caller
+        // passes their authenticated tenant id (Lua enforces ownership).
+        // No body change needed because policy_id pins the owning tenant —
+        // the persisted record's tenant_id is trusted as the audit subject.
+        String authTenantId = (String) httpRequest.getAttribute("authenticated_tenant_id");
+        boolean isAdminAuth = authTenantId == null;
+        Policy policy = repository.update(authTenantId, policyId, request);
+        // For audit / event the subject tenant is the policy's stored owner,
+        // not the (possibly null) caller — keeps history attributable to the
+        // tenant whose policy was modified.
+        String subjectTenantId = isAdminAuth ? policy.getTenantId() : authTenantId;
         auditRepository.log(buildAuditEntry(httpRequest)
-            .tenantId(tenantId)
+            .tenantId(subjectTenantId)
             .keyId((String) httpRequest.getAttribute("authenticated_key_id"))
             .resourceType("policy").resourceId(policyId)
             .operation("updatePolicy")
             .status(200)
-            .metadata(buildUpdatePolicyMeta(scopePattern, request))
+            .metadata(buildUpdatePolicyMetaWithActor(scopePattern, request, isAdminAuth))
             .build());
         try {
-            eventService.emit(EventType.POLICY_UPDATED, tenantId, scopePattern, "cycles-admin",
-                Actor.builder().type(ActorType.API_KEY)
+            ActorType actorType = isAdminAuth ? ActorType.ADMIN_ON_BEHALF_OF : ActorType.API_KEY;
+            eventService.emit(EventType.POLICY_UPDATED, subjectTenantId, scopePattern, "cycles-admin",
+                Actor.builder().type(actorType)
                     .keyId((String) httpRequest.getAttribute("authenticated_key_id")).build(),
                 objectMapper.convertValue(EventDataPolicy.builder()
                     .policyId(policyId).scopePattern(scopePattern).build(), Map.class),
@@ -127,6 +157,17 @@ public class PolicyController {
         if (request.getCaps() != null) meta.put("caps_updated", true);
         if (request.getCommitOveragePolicy() != null) meta.put("commit_overage_policy", request.getCommitOveragePolicy().name());
         return meta.isEmpty() ? null : meta;
+    }
+
+    // v0.1.25.14: same fields as buildUpdatePolicyMeta but always emits the
+    // actor_type discriminator so audit reviewers can filter
+    // admin-on-behalf-of vs tenant self-service updates without joining to
+    // the keys table.
+    private Map<String, Object> buildUpdatePolicyMetaWithActor(String scopePattern, PolicyUpdateRequest request, boolean isAdminAuth) {
+        Map<String, Object> meta = buildUpdatePolicyMeta(scopePattern, request);
+        if (meta == null) meta = new java.util.LinkedHashMap<>();
+        meta.put("actor_type", isAdminAuth ? "admin_on_behalf_of" : "api_key");
+        return meta;
     }
 
     private AuditLogEntry.AuditLogEntryBuilder buildAuditEntry(HttpServletRequest request) {

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/config/AuthInterceptorTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/config/AuthInterceptorTest.java
@@ -578,17 +578,68 @@ class AuthInterceptorTest {
         assertThat(request.getAttribute("authenticated_tenant_id")).isNull();
     }
 
-    // --- Dual-auth: write escalation prevention ---
+    // --- Dual-auth: admin-on-behalf-of writes (v0.1.25.14, spec v0.1.25.13) ---
 
     @Test
-    void preHandle_postBudgets_withAdminKey_rejected() throws Exception {
+    void preHandle_postBudgets_withAdminKey_accepted() throws Exception {
+        // POST /v1/admin/budgets is now in the dual-auth allowlist
+        // (v0.1.25.14, spec v0.1.25.13). Admin operators can create
+        // budgets on behalf of tenants — controller enforces tenant_id
+        // in body separately.
         request.setMethod("POST");
         request.setRequestURI("/v1/admin/budgets");
         request.addHeader("X-Admin-API-Key", "admin-secret-key");
-        // POST /v1/admin/budgets is NOT in the allowlist — should require ApiKeyAuth
 
+        assertThat(interceptor.preHandle(request, response, new Object())).isTrue();
+    }
+
+    @Test
+    void preHandle_postPolicies_withAdminKey_accepted() throws Exception {
+        // POST /v1/admin/policies dual-auth (v0.1.25.14).
+        request.setMethod("POST");
+        request.setRequestURI("/v1/admin/policies");
+        request.addHeader("X-Admin-API-Key", "admin-secret-key");
+
+        assertThat(interceptor.preHandle(request, response, new Object())).isTrue();
+    }
+
+    @Test
+    void preHandle_patchPolicyById_withAdminKey_accepted() throws Exception {
+        // PATCH /v1/admin/policies/{policy_id} dual-auth via prefix matching
+        // (v0.1.25.14). Exact match doesn't help here because every request
+        // has a different concrete policy id.
+        request.setMethod("PATCH");
+        request.setRequestURI("/v1/admin/policies/pol_abc123");
+        request.addHeader("X-Admin-API-Key", "admin-secret-key");
+
+        assertThat(interceptor.preHandle(request, response, new Object())).isTrue();
+    }
+
+    @Test
+    void preHandle_patchPoliciesBarePrefix_withAdminKey_rejected() throws Exception {
+        // The prefix matcher requires a non-empty resource id after the prefix.
+        // PATCH /v1/admin/policies (no id) should NOT be accepted via the
+        // prefix entry — would be a malformed request anyway, but the guard
+        // matters for correctness.
+        request.setMethod("PATCH");
+        request.setRequestURI("/v1/admin/policies");
+        request.addHeader("X-Admin-API-Key", "admin-secret-key");
+
+        // Falls through to validateApiKey since not in exact allowlist and
+        // doesn't match the prefix-with-suffix rule. With admin-only header
+        // and no api key header, rejected with 401.
         assertThat(interceptor.preHandle(request, response, new Object())).isFalse();
         assertThat(response.getStatus()).isEqualTo(401);
+    }
+
+    @Test
+    void preHandle_patchPolicyById_withAdminKey_trailingSlashNormalized() throws Exception {
+        // Trailing slash on the request path is normalized; should still match.
+        request.setMethod("PATCH");
+        request.setRequestURI("/v1/admin/policies/pol_xyz/");
+        request.addHeader("X-Admin-API-Key", "admin-secret-key");
+
+        assertThat(interceptor.preHandle(request, response, new Object())).isTrue();
     }
 
     @Test

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/config/AuthInterceptorTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/config/AuthInterceptorTest.java
@@ -588,6 +588,7 @@ class AuthInterceptorTest {
         // in body separately.
         request.setMethod("POST");
         request.setRequestURI("/v1/admin/budgets");
+        request.setServletPath("/v1/admin/budgets");
         request.addHeader("X-Admin-API-Key", "admin-secret-key");
 
         assertThat(interceptor.preHandle(request, response, new Object())).isTrue();
@@ -598,6 +599,7 @@ class AuthInterceptorTest {
         // POST /v1/admin/policies dual-auth (v0.1.25.14).
         request.setMethod("POST");
         request.setRequestURI("/v1/admin/policies");
+        request.setServletPath("/v1/admin/policies");
         request.addHeader("X-Admin-API-Key", "admin-secret-key");
 
         assertThat(interceptor.preHandle(request, response, new Object())).isTrue();
@@ -610,6 +612,7 @@ class AuthInterceptorTest {
         // has a different concrete policy id.
         request.setMethod("PATCH");
         request.setRequestURI("/v1/admin/policies/pol_abc123");
+        request.setServletPath("/v1/admin/policies/pol_abc123");
         request.addHeader("X-Admin-API-Key", "admin-secret-key");
 
         assertThat(interceptor.preHandle(request, response, new Object())).isTrue();
@@ -623,6 +626,7 @@ class AuthInterceptorTest {
         // matters for correctness.
         request.setMethod("PATCH");
         request.setRequestURI("/v1/admin/policies");
+        request.setServletPath("/v1/admin/policies");
         request.addHeader("X-Admin-API-Key", "admin-secret-key");
 
         // Falls through to validateApiKey since not in exact allowlist and
@@ -637,9 +641,53 @@ class AuthInterceptorTest {
         // Trailing slash on the request path is normalized; should still match.
         request.setMethod("PATCH");
         request.setRequestURI("/v1/admin/policies/pol_xyz/");
+        request.setServletPath("/v1/admin/policies/pol_xyz/");
         request.addHeader("X-Admin-API-Key", "admin-secret-key");
 
         assertThat(interceptor.preHandle(request, response, new Object())).isTrue();
+    }
+
+    // Defense-in-depth: even though Tomcat's connector rejects "../" by
+    // default, the interceptor short-circuits any request whose path
+    // contains a traversal segment before applying the dual-auth allowlist.
+    // Without this guard, a request like
+    //   PATCH /v1/admin/policies/../tenants/t_1
+    // could (in a hypothetical relaxed-Tomcat or behind-a-rewriting-proxy
+    // deployment) pass the prefix matcher and then be re-routed by Spring's
+    // dispatcher to a different endpoint with admin auth already approved
+    // (auth-context confusion).
+    @Test
+    void preHandle_pathContainsDotDot_returns400() throws Exception {
+        request.setMethod("PATCH");
+        request.setRequestURI("/v1/admin/policies/..%2Ftenants/t_1");
+        request.setServletPath("/v1/admin/policies/../tenants/t_1");
+        request.addHeader("X-Admin-API-Key", "admin-secret-key");
+
+        assertThat(interceptor.preHandle(request, response, new Object())).isFalse();
+        assertThat(response.getStatus()).isEqualTo(400);
+    }
+
+    @Test
+    void preHandle_pathEndsInDotDot_returns400() throws Exception {
+        request.setMethod("PATCH");
+        request.setRequestURI("/v1/admin/policies/foo/..");
+        request.setServletPath("/v1/admin/policies/foo/..");
+        request.addHeader("X-Admin-API-Key", "admin-secret-key");
+
+        assertThat(interceptor.preHandle(request, response, new Object())).isFalse();
+        assertThat(response.getStatus()).isEqualTo(400);
+    }
+
+    @Test
+    void preHandle_pathContainsDotSegment_returns400() throws Exception {
+        // /./ is also a normalization-ambiguous segment.
+        request.setMethod("PATCH");
+        request.setRequestURI("/v1/admin/policies/./pol_x");
+        request.setServletPath("/v1/admin/policies/./pol_x");
+        request.addHeader("X-Admin-API-Key", "admin-secret-key");
+
+        assertThat(interceptor.preHandle(request, response, new Object())).isFalse();
+        assertThat(response.getStatus()).isEqualTo(400);
     }
 
     @Test

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BudgetControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BudgetControllerTest.java
@@ -1183,6 +1183,22 @@ class BudgetControllerTest {
     }
 
     @Test
+    void createBudget_withAdminKey_andJsonNullTenantId_returns400() throws Exception {
+        // Explicit coverage for {"tenant_id": null} — Jackson deserializes
+        // to Java null which the !=null guard correctly catches as "missing".
+        // Verifies the bidirectional contract handles JSON null distinctly
+        // from JSON-missing (both should fail; both should fail with the
+        // same "tenant_id is required" error).
+        mockMvc.perform(post("/v1/admin/budgets")
+                        .header("X-Admin-API-Key", "test-admin-key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"tenant_id\":null,\"scope\":\"tenant:acme/workspace:prod\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"USD_MICROCENTS\",\"amount\":5000000}}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("INVALID_REQUEST"))
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("tenant_id is required")));
+    }
+
+    @Test
     void createBudget_withApiKey_andBlankTenantIdInBody_returns400() throws Exception {
         // Defensive: a blank tenant_id from a tenant caller is still wrong
         // (signals intent to override, even if empty).

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BudgetControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BudgetControllerTest.java
@@ -1126,4 +1126,72 @@ class BudgetControllerTest {
                 "tenant-1".equals(entry.getTenantId()) &&
                 entry.getStatus() == 200));
     }
+
+    // ========== Admin-on-behalf-of createBudget (v0.1.25.14, spec v0.1.25.13) ==========
+
+    @Test
+    void createBudget_withAdminKey_andTenantIdInBody_returns201() throws Exception {
+        BudgetLedger ledger = BudgetLedger.builder()
+                .ledgerId("led-admin").scope("tenant:acme/workspace:prod").unit(UnitEnum.USD_MICROCENTS)
+                .allocated(new Amount(UnitEnum.USD_MICROCENTS, 5000000L))
+                .remaining(new Amount(UnitEnum.USD_MICROCENTS, 5000000L))
+                .tenantId("tenant-acme")
+                .status(BudgetStatus.ACTIVE).createdAt(Instant.now()).build();
+        // Admin path: controller forwards body's tenant_id to repository.create
+        when(budgetRepository.create(eq("tenant-acme"), any())).thenReturn(ledger);
+
+        mockMvc.perform(post("/v1/admin/budgets")
+                        .header("X-Admin-API-Key", "test-admin-key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"tenant_id\":\"tenant-acme\",\"scope\":\"tenant:acme/workspace:prod\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"USD_MICROCENTS\",\"amount\":5000000}}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.ledger_id").value("led-admin"));
+
+        // Audit entry MUST be tagged actor_type=admin_on_behalf_of so security
+        // review can tell admin-driven creates apart from tenant self-service.
+        verify(auditRepository).log(argThat(entry ->
+                "createBudget".equals(entry.getOperation()) &&
+                "tenant-acme".equals(entry.getTenantId()) &&
+                entry.getMetadata() != null &&
+                "admin_on_behalf_of".equals(entry.getMetadata().get("actor_type"))));
+    }
+
+    @Test
+    void createBudget_withAdminKey_missingTenantIdInBody_returns400() throws Exception {
+        mockMvc.perform(post("/v1/admin/budgets")
+                        .header("X-Admin-API-Key", "test-admin-key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"scope\":\"tenant:acme/workspace:prod\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"USD_MICROCENTS\",\"amount\":5000000}}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("INVALID_REQUEST"))
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("tenant_id is required")));
+    }
+
+    @Test
+    void createBudget_withApiKey_andTenantIdInBody_returns400() throws Exception {
+        // Tenant-key callers MUST NOT send tenant_id (would let a tenant
+        // claim they're someone else). Server rejects.
+        setupApiKeyAuth();
+
+        mockMvc.perform(post("/v1/admin/budgets")
+                        .header("X-Cycles-API-Key", "valid-api-key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"tenant_id\":\"some-other-tenant\",\"scope\":\"tenant:acme/workspace:prod\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"USD_MICROCENTS\",\"amount\":5000000}}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("INVALID_REQUEST"))
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("MUST NOT be set")));
+    }
+
+    @Test
+    void createBudget_withApiKey_andBlankTenantIdInBody_returns400() throws Exception {
+        // Defensive: a blank tenant_id from a tenant caller is still wrong
+        // (signals intent to override, even if empty).
+        setupApiKeyAuth();
+
+        mockMvc.perform(post("/v1/admin/budgets")
+                        .header("X-Cycles-API-Key", "valid-api-key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"tenant_id\":\"\",\"scope\":\"tenant:acme/workspace:prod\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"USD_MICROCENTS\",\"amount\":5000000}}"))
+                .andExpect(status().isBadRequest());
+    }
 }

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/PolicyControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/PolicyControllerTest.java
@@ -36,6 +36,7 @@ class PolicyControllerTest {
     @MockitoBean private AuditRepository auditRepository;
     @MockitoBean private ApiKeyRepository apiKeyRepository;
     @MockitoBean private JedisPool jedisPool;
+    @MockitoBean private io.runcycles.admin.api.service.EventService eventService;
 
     private void setupApiKeyAuth() {
         when(apiKeyRepository.validate("valid-api-key")).thenReturn(
@@ -360,5 +361,99 @@ class PolicyControllerTest {
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .param("has_action_quotas", "not-a-boolean"))
                 .andExpect(status().isOk());
+    }
+
+    // ========== Admin-on-behalf-of createPolicy / updatePolicy (v0.1.25.14, spec v0.1.25.13) ==========
+
+    @Test
+    void createPolicy_withAdminKey_andTenantIdInBody_returns201() throws Exception {
+        Policy policy = Policy.builder()
+                .policyId("pol_admin").scopePattern("tenant:acme/*").name("Admin Policy")
+                .tenantId("tenant-acme")
+                .status(PolicyStatus.ACTIVE).createdAt(Instant.now()).build();
+        when(policyRepository.create(eq("tenant-acme"), any())).thenReturn(policy);
+
+        mockMvc.perform(post("/v1/admin/policies")
+                        .header("X-Admin-API-Key", "test-admin-key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"tenant_id\":\"tenant-acme\",\"name\":\"Admin Policy\",\"scope_pattern\":\"tenant:acme/*\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.policy_id").value("pol_admin"));
+
+        verify(auditRepository).log(argThat(entry ->
+                "createPolicy".equals(entry.getOperation()) &&
+                "tenant-acme".equals(entry.getTenantId()) &&
+                entry.getMetadata() != null &&
+                "admin_on_behalf_of".equals(entry.getMetadata().get("actor_type"))));
+    }
+
+    @Test
+    void createPolicy_withAdminKey_missingTenantIdInBody_returns400() throws Exception {
+        mockMvc.perform(post("/v1/admin/policies")
+                        .header("X-Admin-API-Key", "test-admin-key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"Admin Policy\",\"scope_pattern\":\"tenant:acme/*\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("INVALID_REQUEST"));
+    }
+
+    @Test
+    void createPolicy_withApiKey_andTenantIdInBody_returns400() throws Exception {
+        // Tenant-key callers MUST NOT send tenant_id (spec v0.1.25.13).
+        setupApiKeyAuth();
+
+        mockMvc.perform(post("/v1/admin/policies")
+                        .header("X-Cycles-API-Key", "valid-api-key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"tenant_id\":\"some-other\",\"name\":\"Sneaky\",\"scope_pattern\":\"tenant:other/*\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void updatePolicy_withAdminKey_returns200_andLogsAdminOnBehalfOf() throws Exception {
+        // Admin update: repository.update receives null tenantId (Lua skips
+        // ownership). Audit subject is the policy's stored tenant_id, not
+        // null — verifies the controller substitutes correctly.
+        when(policyRepository.getScopePattern("pol_xyz")).thenReturn("tenant:acme/*");
+        Policy updated = Policy.builder()
+                .policyId("pol_xyz").scopePattern("tenant:acme/*").name("Updated")
+                .tenantId("tenant-acme")
+                .status(PolicyStatus.ACTIVE).createdAt(Instant.now()).build();
+        when(policyRepository.update(isNull(), eq("pol_xyz"), any())).thenReturn(updated);
+
+        mockMvc.perform(patch("/v1/admin/policies/pol_xyz")
+                        .header("X-Admin-API-Key", "test-admin-key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"Updated\"}"))
+                .andExpect(status().isOk());
+
+        verify(auditRepository).log(argThat(entry ->
+                "updatePolicy".equals(entry.getOperation()) &&
+                "tenant-acme".equals(entry.getTenantId()) && // subject from policy, not null caller
+                entry.getMetadata() != null &&
+                "admin_on_behalf_of".equals(entry.getMetadata().get("actor_type"))));
+    }
+
+    @Test
+    void updatePolicy_withApiKey_returns200_andLogsApiKey() throws Exception {
+        setupApiKeyAuth();
+        when(policyRepository.getScopePattern("pol_self")).thenReturn("tenant:tenant-1/*");
+        Policy updated = Policy.builder()
+                .policyId("pol_self").scopePattern("tenant:tenant-1/*").name("Self-update")
+                .tenantId("tenant-1")
+                .status(PolicyStatus.ACTIVE).createdAt(Instant.now()).build();
+        when(policyRepository.update(eq("tenant-1"), eq("pol_self"), any())).thenReturn(updated);
+
+        mockMvc.perform(patch("/v1/admin/policies/pol_self")
+                        .header("X-Cycles-API-Key", "valid-api-key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"Self-update\"}"))
+                .andExpect(status().isOk());
+
+        verify(auditRepository).log(argThat(entry ->
+                "updatePolicy".equals(entry.getOperation()) &&
+                "tenant-1".equals(entry.getTenantId()) &&
+                entry.getMetadata() != null &&
+                "api_key".equals(entry.getMetadata().get("actor_type"))));
     }
 }

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/PolicyControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/PolicyControllerTest.java
@@ -398,6 +398,17 @@ class PolicyControllerTest {
     }
 
     @Test
+    void createPolicy_withAdminKey_andJsonNullTenantId_returns400() throws Exception {
+        // {"tenant_id": null} — Jackson → Java null → caught by !=null guard.
+        mockMvc.perform(post("/v1/admin/policies")
+                        .header("X-Admin-API-Key", "test-admin-key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"tenant_id\":null,\"name\":\"P\",\"scope_pattern\":\"tenant:acme/*\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("INVALID_REQUEST"));
+    }
+
+    @Test
     void createPolicy_withApiKey_andTenantIdInBody_returns400() throws Exception {
         // Tenant-key callers MUST NOT send tenant_id (spec v0.1.25.13).
         setupApiKeyAuth();

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/budget/BudgetCreateRequest.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/budget/BudgetCreateRequest.java
@@ -9,6 +9,12 @@ import java.util.Map;
 @Data @NoArgsConstructor @AllArgsConstructor
 @com.fasterxml.jackson.annotation.JsonIgnoreProperties(ignoreUnknown = false)
 public class BudgetCreateRequest {
+    // Spec v0.1.25.13: tenant_id is REQUIRED when calling with AdminKeyAuth
+    // (admin operator creating a budget on behalf of a tenant) and MUST NOT
+    // be set when calling with ApiKeyAuth (tenant inferred from the key).
+    // Controller validates the conditional requirement at request time —
+    // bean validation can't express it without a custom validator.
+    @JsonProperty("tenant_id") private String tenantId;
     @NotBlank @JsonProperty("scope") private String scope;
     @NotNull @JsonProperty("unit") private UnitEnum unit;
     @NotNull @Valid @JsonProperty("allocated") private Amount allocated;

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/ActorType.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/ActorType.java
@@ -6,6 +6,14 @@ import com.fasterxml.jackson.annotation.JsonValue;
 public enum ActorType {
     ADMIN("admin"),
     API_KEY("api_key"),
+    // v0.1.25.14 (spec v0.1.25.13): admin operator performing a write
+    // (createBudget, createPolicy, updatePolicy) on behalf of a tenant via
+    // the new dual-auth allowance. Distinct from ADMIN (system-level
+    // operations like introspect, audit query) so security review can
+    // tell admin-driven tenant-resource creates apart from tenant
+    // self-service. Audit log records this; events emitted from these
+    // calls also use it in Actor.type.
+    ADMIN_ON_BEHALF_OF("admin_on_behalf_of"),
     SYSTEM("system"),
     SCHEDULER("scheduler");
 

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/policy/PolicyCreateRequest.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/policy/PolicyCreateRequest.java
@@ -10,6 +10,9 @@ import java.time.Instant;
 @Data @NoArgsConstructor @AllArgsConstructor
 @com.fasterxml.jackson.annotation.JsonIgnoreProperties(ignoreUnknown = false)
 public class PolicyCreateRequest {
+    // Spec v0.1.25.13: tenant_id is REQUIRED when calling with AdminKeyAuth,
+    // MUST NOT be set when calling with ApiKeyAuth. Controller validates.
+    @JsonProperty("tenant_id") private String tenantId;
     @NotBlank @Size(max = 256) @JsonProperty("name") private String name;
     @Size(max = 1024) @JsonProperty("description") private String description;
     @NotBlank @JsonProperty("scope_pattern") private String scopePattern;

--- a/cycles-admin-service/pom.xml
+++ b/cycles-admin-service/pom.xml
@@ -18,7 +18,7 @@
         <module>cycles-admin-service-api</module>
     </modules>
     <properties>
-        <revision>0.1.25.13</revision>
+        <revision>0.1.25.14</revision>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/docker-compose.full-stack.prod.yml
+++ b/docker-compose.full-stack.prod.yml
@@ -13,7 +13,7 @@ services:
       retries: 5
 
   cycles-admin:
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.13
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.14
     restart: unless-stopped
     ports:
       - "7979:7979"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,7 +13,7 @@ services:
       retries: 5
 
   cycles-admin:
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.13
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.14
     restart: unless-stopped
     ports:
       - "7979:7979"


### PR DESCRIPTION
## Summary
Server side of [cycles-protocol#36](https://github.com/runcycles/cycles-protocol/pull/36) (spec v0.1.25.13). Closes the long-standing dashboard gap where admin operators couldn't create budgets or policies — those endpoints accepted **only** \`ApiKeyAuth\`, and the dashboard authenticates exclusively with \`X-Admin-API-Key\`.

## Changes

**\`AuthInterceptor.java\`** — three new entries in \`ADMIN_ALLOWED_ENDPOINTS\` (POST budgets, POST policies). New \`ADMIN_ALLOWED_PREFIXES\` set + \`matchesAdminPrefix()\` method to handle PATCH \`/v1/admin/policies/{policy_id}\` (exact match doesn't work when the path contains a resource id). Prefix matcher requires a non-empty suffix so the bare prefix can't accidentally match.

**Controllers** (\`BudgetController.create\`, \`PolicyController.create\` + \`update\`):
- Branch on auth context. Admin path → \`tenant_id\` from request body (create) or policy's stored owner (update). Tenant path → unchanged.
- **Strict bidirectional contract**: admin MUST send \`tenant_id\`; tenant MUST NOT send \`tenant_id\`. Prevents tenants from spoofing creates as another tenant. 400 INVALID_REQUEST on either violation.
- Audit log records \`actor_type=admin_on_behalf_of\` for admin-driven calls; \`api_key\` for tenant self-service. Lets security review filter without joining to the keys table.
- Event emission uses new \`ActorType.ADMIN_ON_BEHALF_OF\`.

**Schema**: \`BudgetCreateRequest\` and \`PolicyCreateRequest\` gain optional \`tenant_id\` field. \`ActorType\` enum gains \`ADMIN_ON_BEHALF_OF\` (Jackson \`@JsonValue\` = \`\"admin_on_behalf_of\"\`).

## Spec compliance
Aligned with cycles-protocol v0.1.25.13. No wire-format changes for existing tenant-key callers.

## Backward compatibility
Pre-existing test \`preHandle_postBudgets_withAdminKey_rejected\` was changed to \`_accepted\` — intentional behavior change matching the spec, not a regression.

## Test plan
- [x] \`mvn -pl cycles-admin-service-api test\` — **454/454 pass** (was 441; +13 new)
  - \`AuthInterceptorTest\`: dual-auth admit (POST budgets, POST policies, PATCH policy by id), prefix-bare-rejection, trailing-slash normalization
  - \`BudgetControllerTest\`: admin-with-tenant-id-201, admin-missing-tenant-id-400, api-key-with-tenant-id-400, api-key-with-blank-tenant-id-400
  - \`PolicyControllerTest\`: same 3 createPolicy cases + 2 updatePolicy cases verifying audit \`actor_type\` discriminator on both paths
- [x] JaCoCo coverage check passes — all new branches covered
- [ ] Manual: dashboard PR #3 builds against 0.1.25.14 image, end-to-end create-budget flow works

## Downstream
- **Step 3 — dashboard PR (cycles-dashboard v0.1.25.20)** — coming next once this merges. Three new API wrappers, Create Budget + Create Policy form dialogs, capability gates.