### PR TITLE
feat: v0.1.25.15 — canonical ScopeValidator

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -33,7 +33,14 @@ Reported during v0.1.25.14 end-to-end testing: user accidentally created a budge
 
 **Backward compatibility.** Pre-existing budgets or policies in Redis with non-canonical scopes keep working (read paths don't re-validate). New creates must use canonical scopes; clients sending non-canonical now get 400 with a clear error message instead of silent success.
 
-**Tests.** **488/488 pass** (was 459; +29). Coverage check passes.
+**Pre-merge review hardening** (post code review of this PR):
+- **Tightened id regex** from `[A-Za-z0-9._-]+` to `[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?` — rejects ids with leading/trailing punctuation (`.acme`, `acme.`, `-foo`) which are surprising in audit output and never intentional. Single-char alphanumeric ids and mid-string punctuation (`a.b_c-d.v2`) still accepted.
+- **Regression lock** in `ScopeValidatorTest` for the claim "`tenant:*/agent:foo` passes validation". It doesn't — the terminal-id-wildcard rule correctly rejects it. Test documents that lock-in.
+- **Documented** via test + comment that `tenant:*` alone is a legal policy pattern at the grammar layer (matches all tenant-rooted scopes), but is blocked by the tenant-cross-check for admin-on-behalf-of creates — preventing system-wide wildcard policies from being attributed to a specific tenant accidentally.
+- **Equality branch** of the duplicate-kind check (`kindIdx <= lastKindIdx`) now has a dedicated mid-list test (`workspace/workspace` at kindIdx=1) in addition to the pre-existing boundary test (`agent/agent` at kindIdx=4).
+- **Forward-guard comment** in `PolicyController.update`: `scope_pattern` is intentionally absent from `PolicyUpdateRequest` (patterns are immutable per spec); if a future change adds it, the comment directs the engineer to add `ScopeValidator.validatePolicyScopePattern` to prevent PATCH from becoming a non-canonical-scope bypass.
+
+**Tests.** **497/497 pass** (was 459; +38). Coverage check passes.
 
 ---
 

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,9 +1,41 @@
 # Complete Budget Governance v0.1.25.8 — Admin Server Audit
 
-**Server version:** 0.1.25.14 (2026-04-13 — admin-on-behalf-of dual-auth on createBudget, createPolicy, updatePolicy per spec v0.1.25.13; closes "no Create Budget UI" dashboard gap)
-**Date:** 2026-04-13 (v0.1.25.14 admin-on-behalf-of dual-auth), 2026-04-13 (v0.1.25.13 CORS PUT fix), 2026-04-12 (v0.1.25.12 spec-compliance hardening + observability), 2026-04-12 (v0.1.25.11 contract-testing default ON), 2026-04-12 (v0.1.25.10 spec-compliance hardening), 2026-04-10 (v0.1.25.9 release), 2026-04-10 (CORS hardening + prod config), 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
+**Server version:** 0.1.25.15 (2026-04-13 — canonical scope validation; rejects non-canonical kinds, missing tenant prefix, reversed ordering)
+**Date:** 2026-04-13 (v0.1.25.15 ScopeValidator), 2026-04-13 (v0.1.25.14 admin-on-behalf-of dual-auth), 2026-04-13 (v0.1.25.13 CORS PUT fix), 2026-04-12 (v0.1.25.12 spec-compliance hardening + observability), 2026-04-12 (v0.1.25.11 contract-testing default ON), 2026-04-12 (v0.1.25.10 spec-compliance hardening), 2026-04-10 (v0.1.25.9 release), 2026-04-10 (CORS hardening + prod config), 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
 **Spec:** [`cycles-governance-admin-v0.1.25.yaml`](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml) (OpenAPI 3.1.0, v0.1.25.11) in [cycles-protocol](https://github.com/runcycles/cycles-protocol)
 **Server:** Spring Boot 3.5.11 / Java 21 / Redis
+
+### 2026-04-13 — v0.1.25.15 canonical scope validation
+
+Reported during v0.1.25.14 end-to-end testing: user accidentally created a budget with scope `tenant:acme/agentic:codex` — "agentic" is a typo for the canonical kind "agent", but the server happily persisted it with 201 Created. Probing revealed the server was doing essentially no scope validation: `workspace:eng` (no tenant prefix) also worked, as did reverse-ordered kinds. Per `cycles-protocol-v0.yaml` SCOPE DERIVATION (NORMATIVE): *"Canonical ordering is: tenant → workspace → app → workflow → agent → toolset."* Non-canonical scopes silently break downstream enforcement (reservations can't match them) and pollute audit trails with identifiers that break tooling built on the canonical taxonomy.
+
+**New `ScopeValidator` utility** in `cycles-admin-service-api/config/`. Called from `BudgetController.create` and `PolicyController.create`/`.update`. Enforces:
+
+| Rule | Reject | Accept |
+|---|---|---|
+| First segment must be `tenant:<id>` | `workspace:eng` | `tenant:acme` |
+| Canonical kind set only | `tenant:acme/florb:blerp`, `tenant:acme/agentic:codex` | `tenant:acme/agent:codex` |
+| Kinds appear in canonical order, no duplicates | `tenant:x/agent:a/workspace:w`, `tenant:x/agent:a/agent:b` | `tenant:x/workspace:w/agent:a` |
+| Each id non-empty, ≤128 chars, matches `[A-Za-z0-9._-]+` | `tenant:acme/agent:` , `tenant:acme/agent:bad id` | `tenant:acme-corp.v2/agent:rev_01` |
+| Cross-field: scope tenant must match request `tenant_id` | body `tenant_id=acme` + scope `tenant:corp/...` | matching |
+
+**Wildcards in policy `scope_pattern`** — bare `*` as terminal segment (`tenant:acme/*` = all descendants) and id-wildcard (`tenant:acme/agent:*`) both allowed, per spec examples. Mid-chain wildcards rejected (unreachable after match). Budget scopes remain concrete — no wildcards.
+
+**Error shape.** All rejections return 400 INVALID_REQUEST via GovernanceException, with a specific message identifying which rule failed on which segment — easier to self-correct than a generic "invalid scope".
+
+**Tests** (+29):
+- `ScopeValidatorTest` — 27 cases covering every rule: bare-tenant accepted, full chain accepted, skipped levels allowed, the exact `agentic:codex` bug the user reported, missing-tenant-prefix, garbage kind, reverse order, duplicate kinds, empty id, disallowed chars, bare-wildcard terminal accepted in patterns, wildcard rejected in budgets, wildcard mid-chain rejected, tenant-cross-check happy + mismatch, `extractTenantId` helper.
+- `BudgetControllerTest` — existing test fixtures updated from non-canonical `org/team1` to canonical `tenant:tenant-1/workspace:team1`. Pre-existing scope-filter-allowed test now uses a coherent tenant (filter aligned with authenticated tenant).
+- `PolicyControllerTest` — existing `org/*` test fixtures updated to `tenant:tenant-1/*`.
+- Admin-on-behalf-of tests updated to use coherent `tenant_id` and scope (the previous placeholder `tenant-acme` / `tenant:acme/...` didn't satisfy cross-field check).
+
+**Spec compliance.** The server now ENFORCES what the spec describes as canonical. No spec change required — this is tightening an existing implicit contract.
+
+**Backward compatibility.** Pre-existing budgets or policies in Redis with non-canonical scopes keep working (read paths don't re-validate). New creates must use canonical scopes; clients sending non-canonical now get 400 with a clear error message instead of silent success.
+
+**Tests.** **488/488 pass** (was 459; +29). Coverage check passes.
+
+---
 
 ### 2026-04-13 — v0.1.25.14 admin-on-behalf-of dual-auth on createBudget / createPolicy / updatePolicy
 

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/config/ScopeValidator.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/config/ScopeValidator.java
@@ -1,0 +1,196 @@
+package io.runcycles.admin.api.config;
+
+import io.runcycles.admin.data.exception.GovernanceException;
+import io.runcycles.admin.model.shared.ErrorCode;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Canonical scope validation per the Cycles Protocol.
+ *
+ * <p>Until v0.1.25.15 the server accepted any string as a budget/policy
+ * scope -- including garbage like {@code workspace:eng} (no tenant prefix)
+ * or {@code tenant:acme/florb:blerp} (nonsense kind). This lets operators
+ * create canonically-invalid ledgers and policies that silently won't
+ * match anything during enforcement, and pollutes the audit trail with
+ * scopes that break downstream tooling.
+ *
+ * <p>Per {@code cycles-protocol-v0.yaml} SCOPE DERIVATION (NORMATIVE):
+ * <blockquote>Canonical ordering is: tenant -> workspace -> app
+ * -> workflow -> agent -> toolset.</blockquote>
+ *
+ * <p>Scope grammar enforced here:
+ * <ul>
+ *   <li>First segment MUST be {@code tenant:<id>}.</li>
+ *   <li>Each subsequent segment MUST be {@code <kind>:<id>} where kind is
+ *       drawn from the canonical set and appears in canonical order
+ *       (strictly increasing index; no backwards or duplicate kinds).</li>
+ *   <li>Each {@code <id>} is non-empty, at most 128 chars, and matches
+ *       {@code [A-Za-z0-9._-]+}. That's broad enough for real-world
+ *       identifiers (uuids, slugs, dotted-version strings) without letting
+ *       URL-unsafe characters through.</li>
+ * </ul>
+ *
+ * <p>Policy {@code scope_pattern} uses the same grammar with one addition:
+ * {@code *} is allowed in place of the id (e.g. {@code tenant:acme/*}) and
+ * also as a trailing catch-all segment (e.g. {@code tenant:acme/agent:*}).
+ * Wildcards on the kind itself (e.g. a wildcard kind segment followed by
+ * an id) are NOT accepted
+ * because they lead to unbounded enforcement scope and weren't in any
+ * existing test fixtures -- the spec examples only wildcard the id.
+ */
+public final class ScopeValidator {
+
+    private ScopeValidator() {}
+
+    // Canonical kinds in priority order. Budget / policy scopes that skip
+    // levels are allowed (tenant:x/agent:a without a workspace), but they
+    // MUST appear in this order.
+    private static final List<String> CANONICAL_KINDS = List.of(
+        "tenant", "workspace", "app", "workflow", "agent", "toolset"
+    );
+
+    private static final Pattern ID_PATTERN = Pattern.compile("[A-Za-z0-9._-]+");
+    private static final int MAX_ID_LEN = 128;
+
+    /**
+     * Validates a concrete scope (no wildcards) used on budgets.
+     *
+     * @throws GovernanceException with 400 INVALID_REQUEST and a specific
+     *     message identifying which segment broke which rule.
+     */
+    public static void validateBudgetScope(String scope) {
+        validate(scope, /*allowWildcards=*/false, "scope");
+    }
+
+    /**
+     * Validates a policy scope pattern; wildcards are allowed in place of
+     * ids per the spec examples ({@code tenant:acme/*},
+     * {@code tenant:acme/agent:*}).
+     */
+    public static void validatePolicyScopePattern(String scopePattern) {
+        validate(scopePattern, /*allowWildcards=*/true, "scope_pattern");
+    }
+
+    /**
+     * Validates that the tenant id encoded in {@code tenant:<id>} matches
+     * the tenant_id the caller supplied separately. Prevents a write that
+     * creates a budget under one tenant but targets the wrong tenant's
+     * scope -- a subtle bug that's easy to miss in manual curl testing.
+     */
+    public static void validateScopeMatchesTenant(String scope, String expectedTenantId) {
+        String actual = extractTenantId(scope);
+        if (actual != null && !actual.equals(expectedTenantId)) {
+            throw new GovernanceException(
+                ErrorCode.INVALID_REQUEST,
+                "Scope tenant '" + actual + "' does not match request tenant_id '" + expectedTenantId + "'",
+                400);
+        }
+    }
+
+    /**
+     * Extracts the tenant id from {@code tenant:<id>[/...]}. Returns null
+     * if the scope doesn't start with {@code tenant:} -- callers should
+     * have already run validate() first to catch that case; this helper
+     * is only for the cross-field check.
+     */
+    public static String extractTenantId(String scope) {
+        if (scope == null || !scope.startsWith("tenant:")) return null;
+        int end = scope.indexOf('/');
+        String rest = (end < 0) ? scope.substring("tenant:".length()) : scope.substring("tenant:".length(), end);
+        return rest.isEmpty() ? null : rest;
+    }
+
+    // ─────────────────────────────────────────────────────────────
+
+    private static void validate(String scope, boolean allowWildcards, String fieldName) {
+        if (scope == null || scope.isBlank()) {
+            throw new GovernanceException(ErrorCode.INVALID_REQUEST,
+                fieldName + " must not be blank", 400);
+        }
+        String[] segments = scope.split("/", -1);
+        if (segments.length == 0) {
+            throw new GovernanceException(ErrorCode.INVALID_REQUEST,
+                fieldName + " must be a non-empty slash-joined scope", 400);
+        }
+        int lastKindIdx = -1;
+        for (int i = 0; i < segments.length; i++) {
+            String segment = segments[i];
+            if (segment.isEmpty()) {
+                throw new GovernanceException(ErrorCode.INVALID_REQUEST,
+                    fieldName + " has an empty segment (leading, trailing, or consecutive '/')", 400);
+            }
+            // Spec shorthand: a bare terminal "*" means "all descendants of
+            // the prior scope" (e.g. "tenant:acme/*" = every scope rooted
+            // at acme). Only valid in policy scope_pattern, never in a
+            // concrete budget scope, and must be terminal.
+            if ("*".equals(segment)) {
+                if (!allowWildcards) {
+                    throw new GovernanceException(ErrorCode.INVALID_REQUEST,
+                        fieldName + " wildcards are not allowed in budget scopes (segment '*')", 400);
+                }
+                if (i != segments.length - 1) {
+                    throw new GovernanceException(ErrorCode.INVALID_REQUEST,
+                        fieldName + " wildcard '*' must be the final segment", 400);
+                }
+                if (i == 0) {
+                    throw new GovernanceException(ErrorCode.INVALID_REQUEST,
+                        fieldName + " must start with 'tenant:<id>' before any wildcard", 400);
+                }
+                // Bare-* terminal is valid; stop here — no kind/id to check.
+                return;
+            }
+            int colon = segment.indexOf(':');
+            if (colon <= 0 || colon == segment.length() - 1) {
+                throw new GovernanceException(ErrorCode.INVALID_REQUEST,
+                    fieldName + " segment '" + segment + "' must be of form '<kind>:<id>'", 400);
+            }
+            String kind = segment.substring(0, colon);
+            String id = segment.substring(colon + 1);
+
+            int kindIdx = CANONICAL_KINDS.indexOf(kind);
+            if (kindIdx < 0) {
+                throw new GovernanceException(ErrorCode.INVALID_REQUEST,
+                    fieldName + " segment '" + segment + "' uses non-canonical kind '" + kind
+                        + "'. Allowed: " + CANONICAL_KINDS, 400);
+            }
+            if (i == 0 && kindIdx != 0) {
+                // First segment MUST be tenant. Not just any canonical kind --
+                // every concrete scope is rooted at a tenant by protocol.
+                throw new GovernanceException(ErrorCode.INVALID_REQUEST,
+                    fieldName + " must start with 'tenant:<id>' (got '" + kind + ":...')", 400);
+            }
+            if (kindIdx <= lastKindIdx) {
+                throw new GovernanceException(ErrorCode.INVALID_REQUEST,
+                    fieldName + " kind '" + kind + "' appears out of canonical order "
+                        + "(canonical order is " + CANONICAL_KINDS + "; same kind may not repeat)", 400);
+            }
+            lastKindIdx = kindIdx;
+
+            // Id validation -- wildcards only where allowed.
+            if ("*".equals(id)) {
+                if (!allowWildcards) {
+                    throw new GovernanceException(ErrorCode.INVALID_REQUEST,
+                        fieldName + " wildcards are not allowed in budget scopes (segment '" + segment + "')", 400);
+                }
+                // Wildcards must be terminal -- anything after a wildcard
+                // would never be reachable during match.
+                if (i != segments.length - 1) {
+                    throw new GovernanceException(ErrorCode.INVALID_REQUEST,
+                        fieldName + " wildcard '*' must be the final segment's id", 400);
+                }
+            } else {
+                if (id.length() > MAX_ID_LEN) {
+                    throw new GovernanceException(ErrorCode.INVALID_REQUEST,
+                        fieldName + " segment '" + segment + "' id exceeds " + MAX_ID_LEN + " characters", 400);
+                }
+                if (!ID_PATTERN.matcher(id).matches()) {
+                    throw new GovernanceException(ErrorCode.INVALID_REQUEST,
+                        fieldName + " segment '" + segment + "' id contains disallowed characters "
+                            + "(allowed: letters, digits, '.', '_', '-')", 400);
+                }
+            }
+        }
+    }
+}

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/config/ScopeValidator.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/config/ScopeValidator.java
@@ -51,7 +51,12 @@ public final class ScopeValidator {
         "tenant", "workspace", "app", "workflow", "agent", "toolset"
     );
 
-    private static final Pattern ID_PATTERN = Pattern.compile("[A-Za-z0-9._-]+");
+    // Ids must start AND end with an alphanumeric. Middle can contain
+    // `.`, `_`, or `-`. Prevents leading/trailing punctuation like
+    // `.acme`, `acme.`, `-foo`, `foo_` which are surprising in audit
+    // output and rarely intentional. Single-char ids like `a` are fine
+    // (the optional middle group handles that).
+    private static final Pattern ID_PATTERN = Pattern.compile("[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?");
     private static final int MAX_ID_LEN = 128;
 
     /**

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/BudgetController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/BudgetController.java
@@ -6,6 +6,7 @@ import io.runcycles.admin.model.audit.AuditLogEntry;
 import io.runcycles.admin.model.budget.*;
 import io.runcycles.admin.model.shared.UnitEnum;
 import io.runcycles.admin.api.config.ScopeFilterUtil;
+import io.runcycles.admin.api.config.ScopeValidator;
 import io.runcycles.admin.api.service.EventService;
 import io.runcycles.admin.model.event.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -29,6 +30,12 @@ public class BudgetController {
     @PostMapping @Operation(operationId = "createBudget")
     public ResponseEntity<BudgetLedger> create(@Valid @RequestBody BudgetCreateRequest request, HttpServletRequest httpRequest) {
         validateCreateUnits(request);
+        // v0.1.25.15: enforce canonical scope grammar (tenant:<id>[/<kind>:<id>]*
+        // with kinds drawn from tenant/workspace/app/workflow/agent/toolset in
+        // order). Prior to this, garbage like "workspace:eng" (no tenant prefix)
+        // or "tenant:acme/florb:blerp" (nonsense kind) was accepted, creating
+        // ledgers that silently fail to match during enforcement.
+        ScopeValidator.validateBudgetScope(request.getScope());
         ScopeFilterUtil.enforceScopeFilter(httpRequest, request.getScope());
         // v0.1.25.14 dual-auth (spec v0.1.25.13). For ApiKeyAuth the tenant
         // is implicit from the authenticated key; for AdminKeyAuth it must
@@ -48,6 +55,10 @@ public class BudgetController {
                 "tenant_id MUST NOT be set when using API key authentication (tenant is inferred from the key)", 400);
         }
         String tenantId = isAdminAuth ? request.getTenantId() : authTenantId;
+        // Cross-check: scope's tenant prefix must match the routing tenant.
+        // Prevents "body says tenant=acme, scope says tenant:corp" from
+        // silently creating a ledger under the wrong tenant.
+        ScopeValidator.validateScopeMatchesTenant(request.getScope(), tenantId);
         BudgetLedger ledger = repository.create(tenantId, request);
         auditRepository.log(buildAuditEntry(httpRequest)
             .tenantId(tenantId)

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/PolicyController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/PolicyController.java
@@ -1,4 +1,5 @@
 package io.runcycles.admin.api.controller;
+import io.runcycles.admin.api.config.ScopeValidator;
 import io.runcycles.admin.data.exception.GovernanceException;
 import io.runcycles.admin.data.repository.AuditRepository;
 import io.runcycles.admin.data.repository.PolicyRepository;
@@ -33,6 +34,9 @@ public class PolicyController {
     @Autowired private ObjectMapper objectMapper;
     @PostMapping @Operation(operationId = "createPolicy")
     public ResponseEntity<Policy> create(@Valid @RequestBody PolicyCreateRequest request, HttpServletRequest httpRequest) {
+        // v0.1.25.15: enforce canonical scope-pattern grammar. Wildcards
+        // allowed in the id slot and only on the final segment.
+        ScopeValidator.validatePolicyScopePattern(request.getScopePattern());
         ScopeFilterUtil.enforceScopeFilter(httpRequest, request.getScopePattern());
         // v0.1.25.14 dual-auth (spec v0.1.25.13). Same shape as
         // BudgetController.create — admin caller MUST send tenant_id in body,
@@ -51,6 +55,7 @@ public class PolicyController {
                 "tenant_id MUST NOT be set when using API key authentication (tenant is inferred from the key)", 400);
         }
         String tenantId = isAdminAuth ? request.getTenantId() : authTenantId;
+        ScopeValidator.validateScopeMatchesTenant(request.getScopePattern(), tenantId);
         Policy policy = repository.create(tenantId, request);
         auditRepository.log(buildAuditEntry(httpRequest)
             .tenantId(tenantId)

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/PolicyController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/PolicyController.java
@@ -82,6 +82,12 @@ public class PolicyController {
         }
         return ResponseEntity.status(201).body(policy);
     }
+    // scope_pattern is intentionally NOT in PolicyUpdateRequest — patterns
+    // are immutable per spec (a new pattern = a new policy). If a future
+    // change adds scope_pattern to PolicyUpdateRequest, also add a
+    // ScopeValidator.validatePolicyScopePattern call below; without it
+    // the same class of non-canonical-kind bugs that motivated v0.1.25.15
+    // would sneak in via PATCH instead of POST.
     @PatchMapping("/{policy_id}") @Operation(operationId = "updatePolicy")
     public ResponseEntity<Policy> update(@PathVariable("policy_id") String policyId, @Valid @RequestBody PolicyUpdateRequest request, HttpServletRequest httpRequest) {
         String scopePattern = repository.getScopePattern(policyId);

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/config/ScopeValidatorTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/config/ScopeValidatorTest.java
@@ -192,4 +192,74 @@ class ScopeValidatorTest {
         assertThat(ScopeValidator.extractTenantId(null)).isNull();
         assertThat(ScopeValidator.extractTenantId("")).isNull();
     }
+
+    // ─── Post-review hardening (v0.1.25.15 pre-merge) ─────────────
+
+    // Regression lock for the reviewer's CRITICAL claim that
+    // "tenant:*/agent:foo would pass validation" — it should NOT.
+    // The terminal-id-wildcard rule rejects id=="*" when it's not
+    // the final segment.
+    @Test void policyPatternTenantIdWildcardWithMoreSegmentsRejected() {
+        assertThatThrownBy(() ->
+            ScopeValidator.validatePolicyScopePattern("tenant:*/agent:foo"))
+            .isInstanceOf(GovernanceException.class)
+            .hasMessageContaining("must be the final segment");
+    }
+
+    // Bare "tenant:*" as a complete policy pattern IS accepted today
+    // (semantically: match all tenant-rooted scopes). Lock in behavior:
+    // the grammar validator accepts it, but the admin-on-behalf-of
+    // tenant-cross-check rejects it at the controller layer because
+    // extractTenantId returns "*" and no tenant_id matches "*". This
+    // prevents admin operators from creating system-wide policies via
+    // /v1/admin/policies (they'd need a future system-policy endpoint).
+    @Test void policyPatternBareTenantWildcardAcceptedByGrammar() {
+        ScopeValidator.validatePolicyScopePattern("tenant:*");
+    }
+    @Test void policyPatternBareTenantWildcardRejectedByTenantCrossCheck() {
+        assertThatThrownBy(() ->
+            ScopeValidator.validateScopeMatchesTenant("tenant:*", "acme"))
+            .isInstanceOf(GovernanceException.class)
+            .hasMessageContaining("does not match request tenant_id");
+    }
+
+    // The `kindIdx <= lastKindIdx` check must catch equality, not just
+    // strict-less-than. Original duplicate test used agent:a/agent:b
+    // (both at kindIdx 4) — this adds a mid-list kind to verify the
+    // branch isn't accidentally strict-less-than somewhere.
+    @Test void duplicateWorkspaceKindRejected() {
+        assertThatThrownBy(() ->
+            ScopeValidator.validateBudgetScope("tenant:acme/workspace:a/workspace:b"))
+            .isInstanceOf(GovernanceException.class)
+            .hasMessageContaining("out of canonical order");
+    }
+
+    // Tightened regex: ids must start and end with alphanumeric.
+    // Prevents leading-dot, trailing-dot, leading-dash, etc. — these
+    // are syntactically noisy and never intentional in practice.
+    @Test void leadingDotInIdRejected() {
+        assertThatThrownBy(() ->
+            ScopeValidator.validateBudgetScope("tenant:.acme"))
+            .isInstanceOf(GovernanceException.class)
+            .hasMessageContaining("disallowed characters");
+    }
+    @Test void trailingDotInIdRejected() {
+        assertThatThrownBy(() ->
+            ScopeValidator.validateBudgetScope("tenant:acme."))
+            .isInstanceOf(GovernanceException.class)
+            .hasMessageContaining("disallowed characters");
+    }
+    @Test void leadingDashInIdRejected() {
+        assertThatThrownBy(() ->
+            ScopeValidator.validateBudgetScope("tenant:-acme"))
+            .isInstanceOf(GovernanceException.class)
+            .hasMessageContaining("disallowed characters");
+    }
+    @Test void singleAlphanumericIdAccepted() {
+        // Regression: the tightened regex must still accept single-char ids.
+        ScopeValidator.validateBudgetScope("tenant:a");
+    }
+    @Test void mixedPunctuationMidIdAccepted() {
+        ScopeValidator.validateBudgetScope("tenant:a.b_c-d.v2");
+    }
 }

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/config/ScopeValidatorTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/config/ScopeValidatorTest.java
@@ -1,0 +1,195 @@
+package io.runcycles.admin.api.config;
+
+import io.runcycles.admin.data.exception.GovernanceException;
+import io.runcycles.admin.model.shared.ErrorCode;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ScopeValidatorTest {
+
+    // ─── Budget scope: happy path ─────────────────────────────────
+
+    @Test void bareTenantAccepted() {
+        ScopeValidator.validateBudgetScope("tenant:acme");
+    }
+
+    @Test void tenantWorkspaceAccepted() {
+        ScopeValidator.validateBudgetScope("tenant:acme/workspace:prod");
+    }
+
+    @Test void fullCanonicalChainAccepted() {
+        ScopeValidator.validateBudgetScope(
+            "tenant:acme/workspace:prod/app:checkout/workflow:order/agent:reviewer/toolset:llm");
+    }
+
+    @Test void skippedLevelsAllowed() {
+        // workspace and app omitted — allowed as long as order is preserved.
+        ScopeValidator.validateBudgetScope("tenant:acme/agent:reviewer");
+    }
+
+    @Test void idsWithDotsDashesUnderscoresAccepted() {
+        ScopeValidator.validateBudgetScope(
+            "tenant:acme-corp.v2/workspace:prod_01/agent:rev-bot.v3");
+    }
+
+    // ─── Budget scope: rejections ─────────────────────────────────
+
+    @Test void missingTenantPrefixRejected() {
+        assertThatThrownBy(() -> ScopeValidator.validateBudgetScope("workspace:eng"))
+            .isInstanceOf(GovernanceException.class)
+            .hasMessageContaining("must start with 'tenant:<id>'");
+    }
+
+    @Test void nonCanonicalKindRejected() {
+        // The exact bug the user reported: "agentic:codex" is a typo for
+        // "agent:codex". Server was silently accepting it pre-v0.1.25.15.
+        assertThatThrownBy(() -> ScopeValidator.validateBudgetScope("tenant:acme/agentic:codex"))
+            .isInstanceOf(GovernanceException.class)
+            .hasMessageContaining("non-canonical kind 'agentic'");
+    }
+
+    @Test void garbageKindRejected() {
+        assertThatThrownBy(() -> ScopeValidator.validateBudgetScope("tenant:acme/florb:blerp"))
+            .isInstanceOf(GovernanceException.class)
+            .hasMessageContaining("non-canonical kind 'florb'");
+    }
+
+    @Test void reverseOrderRejected() {
+        // agent appears before workspace — violates canonical ordering.
+        assertThatThrownBy(() -> ScopeValidator.validateBudgetScope("tenant:acme/agent:a/workspace:w"))
+            .isInstanceOf(GovernanceException.class)
+            .hasMessageContaining("out of canonical order");
+    }
+
+    @Test void duplicateKindRejected() {
+        assertThatThrownBy(() -> ScopeValidator.validateBudgetScope("tenant:acme/agent:a/agent:b"))
+            .isInstanceOf(GovernanceException.class)
+            .hasMessageContaining("out of canonical order");
+    }
+
+    @Test void emptyIdRejected() {
+        assertThatThrownBy(() -> ScopeValidator.validateBudgetScope("tenant:acme/agent:"))
+            .isInstanceOf(GovernanceException.class)
+            .hasMessageContaining("'<kind>:<id>'");
+    }
+
+    @Test void missingColonRejected() {
+        assertThatThrownBy(() -> ScopeValidator.validateBudgetScope("tenant:acme/agent_reviewer"))
+            .isInstanceOf(GovernanceException.class)
+            .hasMessageContaining("'<kind>:<id>'");
+    }
+
+    @Test void consecutiveSlashesRejected() {
+        assertThatThrownBy(() -> ScopeValidator.validateBudgetScope("tenant:acme//agent:a"))
+            .isInstanceOf(GovernanceException.class)
+            .hasMessageContaining("empty segment");
+    }
+
+    @Test void trailingSlashRejected() {
+        assertThatThrownBy(() -> ScopeValidator.validateBudgetScope("tenant:acme/"))
+            .isInstanceOf(GovernanceException.class)
+            .hasMessageContaining("empty segment");
+    }
+
+    @Test void nullRejected() {
+        assertThatThrownBy(() -> ScopeValidator.validateBudgetScope(null))
+            .isInstanceOf(GovernanceException.class)
+            .hasMessageContaining("must not be blank");
+    }
+
+    @Test void blankRejected() {
+        assertThatThrownBy(() -> ScopeValidator.validateBudgetScope("   "))
+            .isInstanceOf(GovernanceException.class)
+            .hasMessageContaining("must not be blank");
+    }
+
+    @Test void disallowedCharactersInIdRejected() {
+        // Space is not in [A-Za-z0-9._-].
+        assertThatThrownBy(() -> ScopeValidator.validateBudgetScope("tenant:acme/agent:bad id"))
+            .isInstanceOf(GovernanceException.class)
+            .hasMessageContaining("disallowed characters");
+    }
+
+    @Test void wildcardsRejectedInBudgetScope() {
+        // Budgets must be concrete; wildcards belong in policy patterns.
+        assertThatThrownBy(() -> ScopeValidator.validateBudgetScope("tenant:acme/*"))
+            .isInstanceOf(GovernanceException.class)
+            .hasMessageContaining("wildcards are not allowed");
+    }
+
+    @Test void allErrorsReturn400() {
+        try {
+            ScopeValidator.validateBudgetScope("workspace:eng");
+        } catch (GovernanceException e) {
+            assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INVALID_REQUEST);
+            assertThat(e.getHttpStatus()).isEqualTo(400);
+        }
+    }
+
+    // ─── Policy scope_pattern: wildcard accepted ──────────────────
+
+    @Test void policyPatternAllDescendantsAccepted() {
+        // The most common policy pattern from spec examples.
+        ScopeValidator.validatePolicyScopePattern("tenant:acme/*");
+    }
+
+    @Test void policyPatternAgentWildcardAccepted() {
+        ScopeValidator.validatePolicyScopePattern("tenant:acme/agent:*");
+    }
+
+    @Test void policyPatternBareTenantAccepted() {
+        ScopeValidator.validatePolicyScopePattern("tenant:acme");
+    }
+
+    @Test void policyPatternMidChainWildcardRejected() {
+        // Wildcard must be terminal — anything after it is unreachable
+        // during the match walk.
+        assertThatThrownBy(() ->
+            ScopeValidator.validatePolicyScopePattern("tenant:acme/*/agent:a"))
+            .isInstanceOf(GovernanceException.class)
+            .hasMessageContaining("final segment");
+    }
+
+    // ─── Cross-field: scope tenant vs request tenant_id ──────────
+
+    @Test void scopeTenantMatchesRequestTenantAccepted() {
+        ScopeValidator.validateScopeMatchesTenant("tenant:acme/workspace:prod", "acme");
+    }
+
+    @Test void scopeTenantMismatchRejected() {
+        // The dashboard's admin-on-behalf-of flow could otherwise send
+        // tenant_id=acme but scope=tenant:corp/... and silently file the
+        // ledger under the wrong tenant from a bookkeeping perspective.
+        assertThatThrownBy(() ->
+            ScopeValidator.validateScopeMatchesTenant("tenant:corp/agent:a", "acme"))
+            .isInstanceOf(GovernanceException.class)
+            .hasMessageContaining("does not match request tenant_id");
+    }
+
+    @Test void nonTenantScopeIsIgnoredByTenantCheck() {
+        // validateScopeMatchesTenant is a cross-field guard; the
+        // well-formedness check (validateBudgetScope) runs first and
+        // would have already failed on a non-tenant-prefix scope. So
+        // the tenant check should silently pass rather than NPE.
+        ScopeValidator.validateScopeMatchesTenant("workspace:eng", "acme");
+    }
+
+    // ─── extractTenantId helper ───────────────────────────────────
+
+    @Test void extractTenantIdFromBareTenant() {
+        assertThat(ScopeValidator.extractTenantId("tenant:acme")).isEqualTo("acme");
+    }
+
+    @Test void extractTenantIdFromChain() {
+        assertThat(ScopeValidator.extractTenantId("tenant:acme-corp/workspace:prod"))
+            .isEqualTo("acme-corp");
+    }
+
+    @Test void extractTenantIdReturnsNullForNonTenant() {
+        assertThat(ScopeValidator.extractTenantId("workspace:eng")).isNull();
+        assertThat(ScopeValidator.extractTenantId(null)).isNull();
+        assertThat(ScopeValidator.extractTenantId("")).isNull();
+    }
+}

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BudgetControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BudgetControllerTest.java
@@ -53,7 +53,7 @@ class BudgetControllerTest {
     void createBudget_returns201() throws Exception {
         setupApiKeyAuth();
         BudgetLedger ledger = BudgetLedger.builder()
-                .ledgerId("led-1").scope("org/team1").unit(UnitEnum.USD_MICROCENTS)
+                .ledgerId("led-1").scope("tenant:tenant-1/workspace:team1").unit(UnitEnum.USD_MICROCENTS)
                 .allocated(new Amount(UnitEnum.USD_MICROCENTS, 1000000L))
                 .remaining(new Amount(UnitEnum.USD_MICROCENTS, 1000000L))
                 .status(BudgetStatus.ACTIVE).createdAt(Instant.now()).build();
@@ -62,22 +62,22 @@ class BudgetControllerTest {
         mockMvc.perform(post("/v1/admin/budgets")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"scope\":\"org/team1\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"USD_MICROCENTS\",\"amount\":1000000}}"))
+                        .content("{\"scope\":\"tenant:tenant-1/workspace:team1\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"USD_MICROCENTS\",\"amount\":1000000}}"))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.ledger_id").value("led-1"))
-                .andExpect(jsonPath("$.scope").value("org/team1"));
+                .andExpect(jsonPath("$.scope").value("tenant:tenant-1/workspace:team1"));
     }
 
     @Test
     void createBudget_duplicate_returns409() throws Exception {
         setupApiKeyAuth();
         when(budgetRepository.create(eq("tenant-1"), any()))
-                .thenThrow(GovernanceException.duplicateResource("Budget", "org/team1"));
+                .thenThrow(GovernanceException.duplicateResource("Budget", "tenant:tenant-1/workspace:team1"));
 
         mockMvc.perform(post("/v1/admin/budgets")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"scope\":\"org/team1\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"USD_MICROCENTS\",\"amount\":1000000}}"))
+                        .content("{\"scope\":\"tenant:tenant-1/workspace:team1\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"USD_MICROCENTS\",\"amount\":1000000}}"))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.error").value("DUPLICATE_RESOURCE"));
     }
@@ -86,7 +86,7 @@ class BudgetControllerTest {
     void createBudget_noApiKey_returns401() throws Exception {
         mockMvc.perform(post("/v1/admin/budgets")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"scope\":\"org/team1\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"USD_MICROCENTS\",\"amount\":1000000}}"))
+                        .content("{\"scope\":\"tenant:tenant-1/workspace:team1\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"USD_MICROCENTS\",\"amount\":1000000}}"))
                 .andExpect(status().isUnauthorized());
     }
 
@@ -94,26 +94,26 @@ class BudgetControllerTest {
     void lookupBudget_returns200() throws Exception {
         setupApiKeyAuth();
         BudgetLedger ledger = BudgetLedger.builder()
-                .ledgerId("led-1").scope("org/team1").unit(UnitEnum.USD_MICROCENTS)
+                .ledgerId("led-1").scope("tenant:tenant-1/workspace:team1").unit(UnitEnum.USD_MICROCENTS)
                 .allocated(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .remaining(new Amount(UnitEnum.USD_MICROCENTS, 800L))
                 .status(BudgetStatus.ACTIVE).createdAt(Instant.now()).build();
-        when(budgetRepository.getByExactScope("org/team1", UnitEnum.USD_MICROCENTS)).thenReturn(ledger);
+        when(budgetRepository.getByExactScope("tenant:tenant-1/workspace:team1", UnitEnum.USD_MICROCENTS)).thenReturn(ledger);
 
         mockMvc.perform(get("/v1/admin/budgets/lookup")
                         .header("X-Cycles-API-Key", "valid-api-key")
-                        .param("scope", "org/team1")
+                        .param("scope", "tenant:tenant-1/workspace:team1")
                         .param("unit", "USD_MICROCENTS"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.ledger_id").value("led-1"))
-                .andExpect(jsonPath("$.scope").value("org/team1"));
+                .andExpect(jsonPath("$.scope").value("tenant:tenant-1/workspace:team1"));
     }
 
     @Test
     void listBudgets_returns200() throws Exception {
         setupApiKeyAuth();
         BudgetLedger ledger = BudgetLedger.builder()
-                .ledgerId("led-1").scope("org/team1").unit(UnitEnum.USD_MICROCENTS)
+                .ledgerId("led-1").scope("tenant:tenant-1/workspace:team1").unit(UnitEnum.USD_MICROCENTS)
                 .allocated(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .remaining(new Amount(UnitEnum.USD_MICROCENTS, 800L))
                 .status(BudgetStatus.ACTIVE).createdAt(Instant.now()).build();
@@ -152,7 +152,7 @@ class BudgetControllerTest {
                         .scopeFilter(List.of("workspace:eng"))
                         .build());
         BudgetLedger ledger = BudgetLedger.builder()
-                .ledgerId("led-1").scope("tenant:acme/workspace:eng").unit(UnitEnum.USD_MICROCENTS)
+                .ledgerId("led-1").scope("tenant:tenant-1/workspace:eng").unit(UnitEnum.USD_MICROCENTS)
                 .allocated(new Amount(UnitEnum.USD_MICROCENTS, 1000000L))
                 .remaining(new Amount(UnitEnum.USD_MICROCENTS, 1000000L))
                 .status(BudgetStatus.ACTIVE).createdAt(Instant.now()).build();
@@ -161,7 +161,7 @@ class BudgetControllerTest {
         mockMvc.perform(post("/v1/admin/budgets")
                         .header("X-Cycles-API-Key", "restricted-key")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"scope\":\"tenant:acme/workspace:eng\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"USD_MICROCENTS\",\"amount\":1000000}}"))
+                        .content("{\"scope\":\"tenant:tenant-1/workspace:eng\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"USD_MICROCENTS\",\"amount\":1000000}}"))
                 .andExpect(status().isCreated());
     }
 
@@ -193,11 +193,11 @@ class BudgetControllerTest {
     @Test
     void fundBudget_frozen_returns409() throws Exception {
         setupApiKeyAuth();
-        when(budgetRepository.fund(eq("tenant-1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any()))
+        when(budgetRepository.fund(eq("tenant-1"), eq("tenant:tenant-1/workspace:tscope"), eq(UnitEnum.USD_MICROCENTS), any()))
                 .thenThrow(GovernanceException.budgetFrozen("scope"));
 
         mockMvc.perform(post("/v1/admin/budgets/fund")
-                        .param("scope", "scope")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -209,11 +209,11 @@ class BudgetControllerTest {
     @Test
     void fundBudget_insufficientFunds_returns409() throws Exception {
         setupApiKeyAuth();
-        when(budgetRepository.fund(eq("tenant-1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any()))
+        when(budgetRepository.fund(eq("tenant-1"), eq("tenant:tenant-1/workspace:tscope"), eq(UnitEnum.USD_MICROCENTS), any()))
                 .thenThrow(GovernanceException.insufficientFunds("scope"));
 
         mockMvc.perform(post("/v1/admin/budgets/fund")
-                        .param("scope", "scope")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -226,7 +226,7 @@ class BudgetControllerTest {
     void createBudget_logsAuditEntry() throws Exception {
         setupApiKeyAuth();
         BudgetLedger ledger = BudgetLedger.builder()
-                .ledgerId("led-1").scope("org/team1").unit(UnitEnum.USD_MICROCENTS)
+                .ledgerId("led-1").scope("tenant:tenant-1/workspace:team1").unit(UnitEnum.USD_MICROCENTS)
                 .allocated(new Amount(UnitEnum.USD_MICROCENTS, 1000000L))
                 .remaining(new Amount(UnitEnum.USD_MICROCENTS, 1000000L))
                 .status(BudgetStatus.ACTIVE).createdAt(Instant.now()).build();
@@ -235,7 +235,7 @@ class BudgetControllerTest {
         mockMvc.perform(post("/v1/admin/budgets")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"scope\":\"org/team1\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"USD_MICROCENTS\",\"amount\":1000000}}"))
+                        .content("{\"scope\":\"tenant:tenant-1/workspace:team1\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"USD_MICROCENTS\",\"amount\":1000000}}"))
                 .andExpect(status().isCreated());
 
         verify(auditRepository).log(argThat(entry ->
@@ -254,10 +254,10 @@ class BudgetControllerTest {
                 .previousRemaining(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .newRemaining(new Amount(UnitEnum.USD_MICROCENTS, 2000L))
                 .timestamp(Instant.now()).build();
-        when(budgetRepository.fund(eq("tenant-1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
+        when(budgetRepository.fund(eq("tenant-1"), eq("tenant:tenant-1/workspace:tscope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
 
         mockMvc.perform(post("/v1/admin/budgets/fund")
-                        .param("scope", "scope")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -324,11 +324,11 @@ class BudgetControllerTest {
     @Test
     void fundBudget_notFound_returns404() throws Exception {
         setupApiKeyAuth();
-        when(budgetRepository.fund(eq("tenant-1"), eq("missing"), eq(UnitEnum.USD_MICROCENTS), any()))
+        when(budgetRepository.fund(eq("tenant-1"), eq("tenant:tenant-1/workspace:missing"), eq(UnitEnum.USD_MICROCENTS), any()))
                 .thenThrow(GovernanceException.budgetNotFound("missing"));
 
         mockMvc.perform(post("/v1/admin/budgets/fund")
-                        .param("scope", "missing")
+                        .param("scope", "tenant:tenant-1/workspace:missing")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -367,7 +367,7 @@ class BudgetControllerTest {
     void createBudget_auditEntry_requestIdIsFallbackUuidWhenAttributeMissing() throws Exception {
         setupApiKeyAuth();
         BudgetLedger ledger = BudgetLedger.builder()
-                .ledgerId("led-1").scope("org/team1").unit(UnitEnum.USD_MICROCENTS)
+                .ledgerId("led-1").scope("tenant:tenant-1/workspace:team1").unit(UnitEnum.USD_MICROCENTS)
                 .allocated(new Amount(UnitEnum.USD_MICROCENTS, 1000000L))
                 .remaining(new Amount(UnitEnum.USD_MICROCENTS, 1000000L))
                 .status(BudgetStatus.ACTIVE).createdAt(Instant.now()).build();
@@ -376,7 +376,7 @@ class BudgetControllerTest {
         mockMvc.perform(post("/v1/admin/budgets")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"scope\":\"org/team1\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"USD_MICROCENTS\",\"amount\":1000000}}"))
+                        .content("{\"scope\":\"tenant:tenant-1/workspace:team1\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"USD_MICROCENTS\",\"amount\":1000000}}"))
                 .andExpect(status().isCreated());
 
         verify(auditRepository).log(argThat(entry ->
@@ -395,10 +395,10 @@ class BudgetControllerTest {
                 .previousRemaining(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .newRemaining(new Amount(UnitEnum.USD_MICROCENTS, 2000L))
                 .timestamp(Instant.now()).build();
-        when(budgetRepository.fund(eq("tenant-1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
+        when(budgetRepository.fund(eq("tenant-1"), eq("tenant:tenant-1/workspace:tscope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
 
         mockMvc.perform(post("/v1/admin/budgets/fund")
-                        .param("scope", "scope")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -421,10 +421,10 @@ class BudgetControllerTest {
                 .previousRemaining(new Amount(UnitEnum.USD_MICROCENTS, 2000L))
                 .newRemaining(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .timestamp(Instant.now()).build();
-        when(budgetRepository.fund(eq("tenant-1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
+        when(budgetRepository.fund(eq("tenant-1"), eq("tenant:tenant-1/workspace:tscope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
 
         mockMvc.perform(post("/v1/admin/budgets/fund")
-                        .param("scope", "scope")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -443,10 +443,10 @@ class BudgetControllerTest {
                 .previousRemaining(new Amount(UnitEnum.USD_MICROCENTS, 1500L))
                 .newRemaining(new Amount(UnitEnum.USD_MICROCENTS, 5000L))
                 .timestamp(Instant.now()).build();
-        when(budgetRepository.fund(eq("tenant-1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
+        when(budgetRepository.fund(eq("tenant-1"), eq("tenant:tenant-1/workspace:tscope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
 
         mockMvc.perform(post("/v1/admin/budgets/fund")
-                        .param("scope", "scope")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -465,10 +465,10 @@ class BudgetControllerTest {
                 .previousRemaining(new Amount(UnitEnum.USD_MICROCENTS, -200L))
                 .newRemaining(new Amount(UnitEnum.USD_MICROCENTS, 300L))
                 .timestamp(Instant.now()).build();
-        when(budgetRepository.fund(eq("tenant-1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
+        when(budgetRepository.fund(eq("tenant-1"), eq("tenant:tenant-1/workspace:tscope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
 
         mockMvc.perform(post("/v1/admin/budgets/fund")
-                        .param("scope", "scope")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -529,11 +529,11 @@ class BudgetControllerTest {
     @Test
     void fundBudget_budgetClosed_returns409() throws Exception {
         setupApiKeyAuth();
-        when(budgetRepository.fund(eq("tenant-1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any()))
-                .thenThrow(GovernanceException.budgetClosed("scope"));
+        when(budgetRepository.fund(eq("tenant-1"), eq("tenant:tenant-1/workspace:tscope"), eq(UnitEnum.USD_MICROCENTS), any()))
+                .thenThrow(GovernanceException.budgetClosed("tenant:tenant-1/workspace:tscope"));
 
         mockMvc.perform(post("/v1/admin/budgets/fund")
-                        .param("scope", "scope")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -552,11 +552,11 @@ class BudgetControllerTest {
                 .previousRemaining(new Amount(UnitEnum.USD_MICROCENTS, 0L))
                 .newRemaining(new Amount(UnitEnum.USD_MICROCENTS, 500000L))
                 .timestamp(Instant.now()).build();
-        when(budgetRepository.fund(eq("tenant-1"), eq("tenant:acme/workspace:prod"), eq(UnitEnum.USD_MICROCENTS), any()))
+        when(budgetRepository.fund(eq("tenant-1"), eq("tenant:tenant-acme/workspace:prod"), eq(UnitEnum.USD_MICROCENTS), any()))
                 .thenReturn(funding);
 
         mockMvc.perform(post("/v1/admin/budgets/fund")
-                        .param("scope", "tenant:acme/workspace:prod")
+                        .param("scope", "tenant:tenant-acme/workspace:prod")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -565,7 +565,7 @@ class BudgetControllerTest {
                 .andExpect(jsonPath("$.operation").value("CREDIT"))
                 .andExpect(jsonPath("$.new_allocated.amount").value(500000));
 
-        verify(budgetRepository).fund(eq("tenant-1"), eq("tenant:acme/workspace:prod"), eq(UnitEnum.USD_MICROCENTS), any());
+        verify(budgetRepository).fund(eq("tenant-1"), eq("tenant:tenant-acme/workspace:prod"), eq(UnitEnum.USD_MICROCENTS), any());
     }
 
     // ========== PATCH /v1/admin/budgets ==========
@@ -593,11 +593,11 @@ class BudgetControllerTest {
 
     @Test
     void updateBudget_notFound_returns404() throws Exception {
-        when(budgetRepository.update(isNull(), eq("missing"), eq(UnitEnum.USD_MICROCENTS), any()))
-                .thenThrow(GovernanceException.budgetNotFound("missing:USD_MICROCENTS"));
+        when(budgetRepository.update(isNull(), eq("tenant:tenant-1/workspace:missing"), eq(UnitEnum.USD_MICROCENTS), any()))
+                .thenThrow(GovernanceException.budgetNotFound("tenant:tenant-1/workspace:missing:USD_MICROCENTS"));
 
         mockMvc.perform(patch("/v1/admin/budgets")
-                        .param("scope", "missing")
+                        .param("scope", "tenant:tenant-1/workspace:missing")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Admin-API-Key", "test-admin-key")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -608,11 +608,11 @@ class BudgetControllerTest {
 
     @Test
     void updateBudget_closed_returns409() throws Exception {
-        when(budgetRepository.update(isNull(), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any()))
-                .thenThrow(GovernanceException.budgetClosed("scope"));
+        when(budgetRepository.update(isNull(), eq("tenant:tenant-1/workspace:tscope"), eq(UnitEnum.USD_MICROCENTS), any()))
+                .thenThrow(GovernanceException.budgetClosed("tenant:tenant-1/workspace:tscope"));
 
         mockMvc.perform(patch("/v1/admin/budgets")
-                        .param("scope", "scope")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Admin-API-Key", "test-admin-key")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -624,15 +624,15 @@ class BudgetControllerTest {
     @Test
     void updateBudget_logsAuditEntry() throws Exception {
         BudgetLedger ledger = BudgetLedger.builder()
-                .ledgerId("led-1").scope("scope").unit(UnitEnum.USD_MICROCENTS)
+                .ledgerId("led-1").scope("tenant:tenant-1/workspace:tscope").unit(UnitEnum.USD_MICROCENTS)
                 .allocated(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .remaining(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .tenantId("tenant-1")
                 .status(BudgetStatus.ACTIVE).createdAt(Instant.now()).build();
-        when(budgetRepository.update(isNull(), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(ledger);
+        when(budgetRepository.update(isNull(), eq("tenant:tenant-1/workspace:tscope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(ledger);
 
         mockMvc.perform(patch("/v1/admin/budgets")
-                        .param("scope", "scope")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Admin-API-Key", "test-admin-key")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -648,7 +648,7 @@ class BudgetControllerTest {
     @Test
     void updateBudget_noAdminKey_returns401() throws Exception {
         mockMvc.perform(patch("/v1/admin/budgets")
-                        .param("scope", "scope")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
                         .param("unit", "USD_MICROCENTS")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"overdraft_limit\":{\"unit\":\"USD_MICROCENTS\",\"amount\":100}}"))
@@ -658,24 +658,24 @@ class BudgetControllerTest {
     @Test
     void updateBudget_workspaceScope_returns200() throws Exception {
         BudgetLedger ledger = BudgetLedger.builder()
-                .ledgerId("led-1").scope("tenant:acme/workspace:prod").unit(UnitEnum.USD_MICROCENTS)
+                .ledgerId("led-1").scope("tenant:tenant-acme/workspace:prod").unit(UnitEnum.USD_MICROCENTS)
                 .allocated(new Amount(UnitEnum.USD_MICROCENTS, 1000000L))
                 .remaining(new Amount(UnitEnum.USD_MICROCENTS, 500000L))
                 .overdraftLimit(new Amount(UnitEnum.USD_MICROCENTS, 50000L))
                 .status(BudgetStatus.ACTIVE).createdAt(Instant.now()).build();
-        when(budgetRepository.update(isNull(), eq("tenant:acme/workspace:prod"), eq(UnitEnum.USD_MICROCENTS), any()))
+        when(budgetRepository.update(isNull(), eq("tenant:tenant-acme/workspace:prod"), eq(UnitEnum.USD_MICROCENTS), any()))
                 .thenReturn(ledger);
 
         mockMvc.perform(patch("/v1/admin/budgets")
-                        .param("scope", "tenant:acme/workspace:prod")
+                        .param("scope", "tenant:tenant-acme/workspace:prod")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Admin-API-Key", "test-admin-key")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"overdraft_limit\":{\"unit\":\"USD_MICROCENTS\",\"amount\":50000}}"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.scope").value("tenant:acme/workspace:prod"));
+                .andExpect(jsonPath("$.scope").value("tenant:tenant-acme/workspace:prod"));
 
-        verify(budgetRepository).update(isNull(), eq("tenant:acme/workspace:prod"), eq(UnitEnum.USD_MICROCENTS), any());
+        verify(budgetRepository).update(isNull(), eq("tenant:tenant-acme/workspace:prod"), eq(UnitEnum.USD_MICROCENTS), any());
     }
 
     // ========== Unit mismatch validation ==========
@@ -687,7 +687,7 @@ class BudgetControllerTest {
         mockMvc.perform(post("/v1/admin/budgets")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"scope\":\"org/team1\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"TOKENS\",\"amount\":1000}}"))
+                        .content("{\"scope\":\"tenant:tenant-1/workspace:team1\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"TOKENS\",\"amount\":1000}}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error").value("UNIT_MISMATCH"));
     }
@@ -697,7 +697,7 @@ class BudgetControllerTest {
         setupApiKeyAuth();
 
         mockMvc.perform(post("/v1/admin/budgets/fund")
-                        .param("scope", "scope")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -709,7 +709,7 @@ class BudgetControllerTest {
     @Test
     void updateBudget_unitMismatch_returns400() throws Exception {
         mockMvc.perform(patch("/v1/admin/budgets")
-                        .param("scope", "scope")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Admin-API-Key", "test-admin-key")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -724,7 +724,7 @@ class BudgetControllerTest {
     void createBudget_emitsEvent() throws Exception {
         setupApiKeyAuth();
         BudgetLedger ledger = BudgetLedger.builder()
-                .ledgerId("led-1").scope("org/team1").unit(UnitEnum.USD_MICROCENTS)
+                .ledgerId("led-1").scope("tenant:tenant-1/workspace:team1").unit(UnitEnum.USD_MICROCENTS)
                 .allocated(new Amount(UnitEnum.USD_MICROCENTS, 1000000L))
                 .remaining(new Amount(UnitEnum.USD_MICROCENTS, 1000000L))
                 .status(BudgetStatus.ACTIVE).createdAt(Instant.now()).build();
@@ -733,30 +733,30 @@ class BudgetControllerTest {
         mockMvc.perform(post("/v1/admin/budgets")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"scope\":\"org/team1\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"USD_MICROCENTS\",\"amount\":1000000}}"))
+                        .content("{\"scope\":\"tenant:tenant-1/workspace:team1\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"USD_MICROCENTS\",\"amount\":1000000}}"))
                 .andExpect(status().isCreated());
 
-        verify(eventService).emit(eq(EventType.BUDGET_CREATED), eq("tenant-1"), eq("org/team1"), any(), any(), any(), any(), any());
+        verify(eventService).emit(eq(EventType.BUDGET_CREATED), eq("tenant-1"), eq("tenant:tenant-1/workspace:team1"), any(), any(), any(), any(), any());
     }
 
     @Test
     void updateBudget_emitsEvent() throws Exception {
         BudgetLedger ledger = BudgetLedger.builder()
-                .ledgerId("led-1").scope("scope").unit(UnitEnum.USD_MICROCENTS)
+                .ledgerId("led-1").scope("tenant:tenant-1/workspace:tscope").unit(UnitEnum.USD_MICROCENTS)
                 .allocated(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .remaining(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .status(BudgetStatus.ACTIVE).createdAt(Instant.now()).build();
-        when(budgetRepository.update(isNull(), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(ledger);
+        when(budgetRepository.update(isNull(), eq("tenant:tenant-1/workspace:tscope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(ledger);
 
         mockMvc.perform(patch("/v1/admin/budgets")
-                        .param("scope", "scope")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Admin-API-Key", "test-admin-key")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"overdraft_limit\":{\"unit\":\"USD_MICROCENTS\",\"amount\":100}}"))
                 .andExpect(status().isOk());
 
-        verify(eventService).emit(eq(EventType.BUDGET_UPDATED), any(), eq("scope"), any(), any(), any(), any(), any());
+        verify(eventService).emit(eq(EventType.BUDGET_UPDATED), any(), eq("tenant:tenant-1/workspace:tscope"), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -769,17 +769,17 @@ class BudgetControllerTest {
                 .previousRemaining(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .newRemaining(new Amount(UnitEnum.USD_MICROCENTS, 2000L))
                 .timestamp(Instant.now()).build();
-        when(budgetRepository.fund(eq("tenant-1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
+        when(budgetRepository.fund(eq("tenant-1"), eq("tenant:tenant-1/workspace:tscope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
 
         mockMvc.perform(post("/v1/admin/budgets/fund")
-                        .param("scope", "scope")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"operation\":\"CREDIT\",\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":1000}}"))
                 .andExpect(status().isOk());
 
-        verify(eventService).emit(eq(EventType.BUDGET_FUNDED), eq("tenant-1"), eq("scope"), any(), any(), any(), any(), any());
+        verify(eventService).emit(eq(EventType.BUDGET_FUNDED), eq("tenant-1"), eq("tenant:tenant-1/workspace:tscope"), any(), any(), any(), any(), any());
     }
 
     // ========== INSUFFICIENT_PERMISSIONS ==========
@@ -795,7 +795,7 @@ class BudgetControllerTest {
         mockMvc.perform(post("/v1/admin/budgets")
                         .header("X-Cycles-API-Key", "readonly-key")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"scope\":\"org/team1\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"USD_MICROCENTS\",\"amount\":1000000}}"))
+                        .content("{\"scope\":\"tenant:tenant-1/workspace:team1\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"USD_MICROCENTS\",\"amount\":1000000}}"))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.error").value("INSUFFICIENT_PERMISSIONS"));
     }
@@ -809,7 +809,7 @@ class BudgetControllerTest {
                         .permissions(List.of("budgets:read")).build());
 
         mockMvc.perform(post("/v1/admin/budgets/fund")
-                        .param("scope", "scope")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Cycles-API-Key", "read-only-key")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -837,13 +837,13 @@ class BudgetControllerTest {
     @Test
     void fundBudget_idempotencyMismatch_returns409() throws Exception {
         setupApiKeyAuth();
-        when(budgetRepository.fund(eq("tenant-1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any()))
+        when(budgetRepository.fund(eq("tenant-1"), eq("tenant:tenant-1/workspace:tscope"), eq(UnitEnum.USD_MICROCENTS), any()))
                 .thenThrow(new GovernanceException(
                         io.runcycles.admin.model.shared.ErrorCode.IDEMPOTENCY_MISMATCH,
                         "Idempotency key already used with different payload", 409));
 
         mockMvc.perform(post("/v1/admin/budgets/fund")
-                        .param("scope", "scope")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -873,15 +873,15 @@ class BudgetControllerTest {
     @Test
     void freezeBudget_returns200() throws Exception {
         BudgetLedger ledger = BudgetLedger.builder()
-                .ledgerId("led-1").scope("org/team1").unit(UnitEnum.USD_MICROCENTS)
+                .ledgerId("led-1").scope("tenant:tenant-1/workspace:team1").unit(UnitEnum.USD_MICROCENTS)
                 .allocated(new Amount(UnitEnum.USD_MICROCENTS, 1000000L))
                 .remaining(new Amount(UnitEnum.USD_MICROCENTS, 500000L))
                 .tenantId("tenant-1")
                 .status(BudgetStatus.FROZEN).createdAt(Instant.now()).build();
-        when(budgetRepository.freeze("org/team1", UnitEnum.USD_MICROCENTS)).thenReturn(ledger);
+        when(budgetRepository.freeze("tenant:tenant-1/workspace:team1", UnitEnum.USD_MICROCENTS)).thenReturn(ledger);
 
         mockMvc.perform(post("/v1/admin/budgets/freeze")
-                        .param("scope", "org/team1")
+                        .param("scope", "tenant:tenant-1/workspace:team1")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Admin-API-Key", "test-admin-key"))
                 .andExpect(status().isOk())
@@ -892,15 +892,15 @@ class BudgetControllerTest {
     @Test
     void freezeBudget_withReason_returns200() throws Exception {
         BudgetLedger ledger = BudgetLedger.builder()
-                .ledgerId("led-1").scope("scope").unit(UnitEnum.USD_MICROCENTS)
+                .ledgerId("led-1").scope("tenant:tenant-1/workspace:tscope").unit(UnitEnum.USD_MICROCENTS)
                 .allocated(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .remaining(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .tenantId("tenant-1")
                 .status(BudgetStatus.FROZEN).createdAt(Instant.now()).build();
-        when(budgetRepository.freeze("scope", UnitEnum.USD_MICROCENTS)).thenReturn(ledger);
+        when(budgetRepository.freeze("tenant:tenant-1/workspace:tscope", UnitEnum.USD_MICROCENTS)).thenReturn(ledger);
 
         mockMvc.perform(post("/v1/admin/budgets/freeze")
-                        .param("scope", "scope")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Admin-API-Key", "test-admin-key")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -911,13 +911,13 @@ class BudgetControllerTest {
 
     @Test
     void freezeBudget_alreadyFrozen_returns409() throws Exception {
-        when(budgetRepository.freeze("scope", UnitEnum.USD_MICROCENTS))
+        when(budgetRepository.freeze("tenant:tenant-1/workspace:tscope", UnitEnum.USD_MICROCENTS))
                 .thenThrow(new GovernanceException(
                         io.runcycles.admin.model.shared.ErrorCode.INVALID_REQUEST,
                         "Budget is already frozen", 409));
 
         mockMvc.perform(post("/v1/admin/budgets/freeze")
-                        .param("scope", "scope")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Admin-API-Key", "test-admin-key"))
                 .andExpect(status().isConflict())
@@ -926,11 +926,11 @@ class BudgetControllerTest {
 
     @Test
     void freezeBudget_closed_returns409() throws Exception {
-        when(budgetRepository.freeze("scope", UnitEnum.USD_MICROCENTS))
-                .thenThrow(GovernanceException.budgetClosed("scope"));
+        when(budgetRepository.freeze("tenant:tenant-1/workspace:tscope", UnitEnum.USD_MICROCENTS))
+                .thenThrow(GovernanceException.budgetClosed("tenant:tenant-1/workspace:tscope"));
 
         mockMvc.perform(post("/v1/admin/budgets/freeze")
-                        .param("scope", "scope")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Admin-API-Key", "test-admin-key"))
                 .andExpect(status().isConflict())
@@ -939,11 +939,11 @@ class BudgetControllerTest {
 
     @Test
     void freezeBudget_notFound_returns404() throws Exception {
-        when(budgetRepository.freeze("missing", UnitEnum.USD_MICROCENTS))
-                .thenThrow(GovernanceException.budgetNotFound("missing:USD_MICROCENTS"));
+        when(budgetRepository.freeze("tenant:tenant-1/workspace:missing", UnitEnum.USD_MICROCENTS))
+                .thenThrow(GovernanceException.budgetNotFound("tenant:tenant-1/workspace:missing:USD_MICROCENTS"));
 
         mockMvc.perform(post("/v1/admin/budgets/freeze")
-                        .param("scope", "missing")
+                        .param("scope", "tenant:tenant-1/workspace:missing")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Admin-API-Key", "test-admin-key"))
                 .andExpect(status().isNotFound())
@@ -953,7 +953,7 @@ class BudgetControllerTest {
     @Test
     void freezeBudget_noAdminKey_returns401() throws Exception {
         mockMvc.perform(post("/v1/admin/budgets/freeze")
-                        .param("scope", "scope")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
                         .param("unit", "USD_MICROCENTS"))
                 .andExpect(status().isUnauthorized());
     }
@@ -961,15 +961,15 @@ class BudgetControllerTest {
     @Test
     void freezeBudget_logsAuditEntry() throws Exception {
         BudgetLedger ledger = BudgetLedger.builder()
-                .ledgerId("led-1").scope("scope").unit(UnitEnum.USD_MICROCENTS)
+                .ledgerId("led-1").scope("tenant:tenant-1/workspace:tscope").unit(UnitEnum.USD_MICROCENTS)
                 .allocated(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .remaining(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .tenantId("tenant-1")
                 .status(BudgetStatus.FROZEN).createdAt(Instant.now()).build();
-        when(budgetRepository.freeze("scope", UnitEnum.USD_MICROCENTS)).thenReturn(ledger);
+        when(budgetRepository.freeze("tenant:tenant-1/workspace:tscope", UnitEnum.USD_MICROCENTS)).thenReturn(ledger);
 
         mockMvc.perform(post("/v1/admin/budgets/freeze")
-                        .param("scope", "scope")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Admin-API-Key", "test-admin-key"))
                 .andExpect(status().isOk());
@@ -983,20 +983,20 @@ class BudgetControllerTest {
     @Test
     void freezeBudget_emitsEvent() throws Exception {
         BudgetLedger ledger = BudgetLedger.builder()
-                .ledgerId("led-1").scope("scope").unit(UnitEnum.USD_MICROCENTS)
+                .ledgerId("led-1").scope("tenant:tenant-1/workspace:tscope").unit(UnitEnum.USD_MICROCENTS)
                 .allocated(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .remaining(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .tenantId("tenant-1")
                 .status(BudgetStatus.FROZEN).createdAt(Instant.now()).build();
-        when(budgetRepository.freeze("scope", UnitEnum.USD_MICROCENTS)).thenReturn(ledger);
+        when(budgetRepository.freeze("tenant:tenant-1/workspace:tscope", UnitEnum.USD_MICROCENTS)).thenReturn(ledger);
 
         mockMvc.perform(post("/v1/admin/budgets/freeze")
-                        .param("scope", "scope")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Admin-API-Key", "test-admin-key"))
                 .andExpect(status().isOk());
 
-        verify(eventService).emit(eq(EventType.BUDGET_FROZEN), eq("tenant-1"), eq("scope"), any(), any(), any(), any(), any());
+        verify(eventService).emit(eq(EventType.BUDGET_FROZEN), eq("tenant-1"), eq("tenant:tenant-1/workspace:tscope"), any(), any(), any(), any(), any());
     }
 
     // ========== POST /v1/admin/budgets/unfreeze ==========
@@ -1004,15 +1004,15 @@ class BudgetControllerTest {
     @Test
     void unfreezeBudget_returns200() throws Exception {
         BudgetLedger ledger = BudgetLedger.builder()
-                .ledgerId("led-1").scope("org/team1").unit(UnitEnum.USD_MICROCENTS)
+                .ledgerId("led-1").scope("tenant:tenant-1/workspace:team1").unit(UnitEnum.USD_MICROCENTS)
                 .allocated(new Amount(UnitEnum.USD_MICROCENTS, 1000000L))
                 .remaining(new Amount(UnitEnum.USD_MICROCENTS, 500000L))
                 .tenantId("tenant-1")
                 .status(BudgetStatus.ACTIVE).createdAt(Instant.now()).build();
-        when(budgetRepository.unfreeze("org/team1", UnitEnum.USD_MICROCENTS)).thenReturn(ledger);
+        when(budgetRepository.unfreeze("tenant:tenant-1/workspace:team1", UnitEnum.USD_MICROCENTS)).thenReturn(ledger);
 
         mockMvc.perform(post("/v1/admin/budgets/unfreeze")
-                        .param("scope", "org/team1")
+                        .param("scope", "tenant:tenant-1/workspace:team1")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Admin-API-Key", "test-admin-key"))
                 .andExpect(status().isOk())
@@ -1021,13 +1021,13 @@ class BudgetControllerTest {
 
     @Test
     void unfreezeBudget_alreadyActive_returns409() throws Exception {
-        when(budgetRepository.unfreeze("scope", UnitEnum.USD_MICROCENTS))
+        when(budgetRepository.unfreeze("tenant:tenant-1/workspace:tscope", UnitEnum.USD_MICROCENTS))
                 .thenThrow(new GovernanceException(
                         io.runcycles.admin.model.shared.ErrorCode.INVALID_REQUEST,
                         "Budget is not frozen", 409));
 
         mockMvc.perform(post("/v1/admin/budgets/unfreeze")
-                        .param("scope", "scope")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Admin-API-Key", "test-admin-key"))
                 .andExpect(status().isConflict());
@@ -1035,11 +1035,11 @@ class BudgetControllerTest {
 
     @Test
     void unfreezeBudget_closed_returns409() throws Exception {
-        when(budgetRepository.unfreeze("scope", UnitEnum.USD_MICROCENTS))
-                .thenThrow(GovernanceException.budgetClosed("scope"));
+        when(budgetRepository.unfreeze("tenant:tenant-1/workspace:tscope", UnitEnum.USD_MICROCENTS))
+                .thenThrow(GovernanceException.budgetClosed("tenant:tenant-1/workspace:tscope"));
 
         mockMvc.perform(post("/v1/admin/budgets/unfreeze")
-                        .param("scope", "scope")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Admin-API-Key", "test-admin-key"))
                 .andExpect(status().isConflict())
@@ -1049,20 +1049,20 @@ class BudgetControllerTest {
     @Test
     void unfreezeBudget_emitsEvent() throws Exception {
         BudgetLedger ledger = BudgetLedger.builder()
-                .ledgerId("led-1").scope("scope").unit(UnitEnum.USD_MICROCENTS)
+                .ledgerId("led-1").scope("tenant:tenant-1/workspace:tscope").unit(UnitEnum.USD_MICROCENTS)
                 .allocated(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .remaining(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .tenantId("tenant-1")
                 .status(BudgetStatus.ACTIVE).createdAt(Instant.now()).build();
-        when(budgetRepository.unfreeze("scope", UnitEnum.USD_MICROCENTS)).thenReturn(ledger);
+        when(budgetRepository.unfreeze("tenant:tenant-1/workspace:tscope", UnitEnum.USD_MICROCENTS)).thenReturn(ledger);
 
         mockMvc.perform(post("/v1/admin/budgets/unfreeze")
-                        .param("scope", "scope")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Admin-API-Key", "test-admin-key"))
                 .andExpect(status().isOk());
 
-        verify(eventService).emit(eq(EventType.BUDGET_UNFROZEN), eq("tenant-1"), eq("scope"), any(), any(), any(), any(), any());
+        verify(eventService).emit(eq(EventType.BUDGET_UNFROZEN), eq("tenant-1"), eq("tenant:tenant-1/workspace:tscope"), any(), any(), any(), any(), any());
     }
 
     // ========== POST /v1/admin/budgets/fund with AdminKeyAuth ==========
@@ -1076,11 +1076,11 @@ class BudgetControllerTest {
                 .previousRemaining(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .newRemaining(new Amount(UnitEnum.USD_MICROCENTS, 2000L))
                 .timestamp(Instant.now()).build();
-        when(budgetRepository.fund(eq("tenant-1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
+        when(budgetRepository.fund(eq("tenant-1"), eq("tenant:tenant-1/workspace:tscope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
 
         mockMvc.perform(post("/v1/admin/budgets/fund")
                         .param("tenant_id", "tenant-1")
-                        .param("scope", "scope")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Admin-API-Key", "test-admin-key")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -1092,7 +1092,7 @@ class BudgetControllerTest {
     @Test
     void fundBudget_withAdminKey_missingTenantId_returns400() throws Exception {
         mockMvc.perform(post("/v1/admin/budgets/fund")
-                        .param("scope", "scope")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Admin-API-Key", "test-admin-key")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -1110,11 +1110,11 @@ class BudgetControllerTest {
                 .previousRemaining(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
                 .newRemaining(new Amount(UnitEnum.USD_MICROCENTS, 2000L))
                 .timestamp(Instant.now()).build();
-        when(budgetRepository.fund(eq("tenant-1"), eq("scope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
+        when(budgetRepository.fund(eq("tenant-1"), eq("tenant:tenant-1/workspace:tscope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
 
         mockMvc.perform(post("/v1/admin/budgets/fund")
                         .param("tenant_id", "tenant-1")
-                        .param("scope", "scope")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
                         .param("unit", "USD_MICROCENTS")
                         .header("X-Admin-API-Key", "test-admin-key")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -1132,7 +1132,7 @@ class BudgetControllerTest {
     @Test
     void createBudget_withAdminKey_andTenantIdInBody_returns201() throws Exception {
         BudgetLedger ledger = BudgetLedger.builder()
-                .ledgerId("led-admin").scope("tenant:acme/workspace:prod").unit(UnitEnum.USD_MICROCENTS)
+                .ledgerId("led-admin").scope("tenant:tenant-acme/workspace:prod").unit(UnitEnum.USD_MICROCENTS)
                 .allocated(new Amount(UnitEnum.USD_MICROCENTS, 5000000L))
                 .remaining(new Amount(UnitEnum.USD_MICROCENTS, 5000000L))
                 .tenantId("tenant-acme")
@@ -1143,7 +1143,7 @@ class BudgetControllerTest {
         mockMvc.perform(post("/v1/admin/budgets")
                         .header("X-Admin-API-Key", "test-admin-key")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"tenant_id\":\"tenant-acme\",\"scope\":\"tenant:acme/workspace:prod\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"USD_MICROCENTS\",\"amount\":5000000}}"))
+                        .content("{\"tenant_id\":\"tenant-acme\",\"scope\":\"tenant:tenant-acme/workspace:prod\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"USD_MICROCENTS\",\"amount\":5000000}}"))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.ledger_id").value("led-admin"));
 
@@ -1161,7 +1161,7 @@ class BudgetControllerTest {
         mockMvc.perform(post("/v1/admin/budgets")
                         .header("X-Admin-API-Key", "test-admin-key")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"scope\":\"tenant:acme/workspace:prod\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"USD_MICROCENTS\",\"amount\":5000000}}"))
+                        .content("{\"scope\":\"tenant:tenant-acme/workspace:prod\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"USD_MICROCENTS\",\"amount\":5000000}}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error").value("INVALID_REQUEST"))
                 .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("tenant_id is required")));
@@ -1176,7 +1176,7 @@ class BudgetControllerTest {
         mockMvc.perform(post("/v1/admin/budgets")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"tenant_id\":\"some-other-tenant\",\"scope\":\"tenant:acme/workspace:prod\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"USD_MICROCENTS\",\"amount\":5000000}}"))
+                        .content("{\"tenant_id\":\"some-other-tenant\",\"scope\":\"tenant:tenant-acme/workspace:prod\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"USD_MICROCENTS\",\"amount\":5000000}}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error").value("INVALID_REQUEST"))
                 .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("MUST NOT be set")));
@@ -1192,7 +1192,7 @@ class BudgetControllerTest {
         mockMvc.perform(post("/v1/admin/budgets")
                         .header("X-Admin-API-Key", "test-admin-key")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"tenant_id\":null,\"scope\":\"tenant:acme/workspace:prod\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"USD_MICROCENTS\",\"amount\":5000000}}"))
+                        .content("{\"tenant_id\":null,\"scope\":\"tenant:tenant-acme/workspace:prod\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"USD_MICROCENTS\",\"amount\":5000000}}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error").value("INVALID_REQUEST"))
                 .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("tenant_id is required")));
@@ -1207,7 +1207,7 @@ class BudgetControllerTest {
         mockMvc.perform(post("/v1/admin/budgets")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"tenant_id\":\"\",\"scope\":\"tenant:acme/workspace:prod\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"USD_MICROCENTS\",\"amount\":5000000}}"))
+                        .content("{\"tenant_id\":\"\",\"scope\":\"tenant:tenant-acme/workspace:prod\",\"unit\":\"USD_MICROCENTS\",\"allocated\":{\"unit\":\"USD_MICROCENTS\",\"amount\":5000000}}"))
                 .andExpect(status().isBadRequest());
     }
 }

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/PolicyControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/PolicyControllerTest.java
@@ -49,17 +49,17 @@ class PolicyControllerTest {
     void createPolicy_returns201() throws Exception {
         setupApiKeyAuth();
         Policy policy = Policy.builder()
-                .policyId("pol_123").scopePattern("org/*").name("Rate Limit")
+                .policyId("pol_123").scopePattern("tenant:tenant-1/*").name("Rate Limit")
                 .status(PolicyStatus.ACTIVE).createdAt(Instant.now()).build();
         when(policyRepository.create(eq("tenant-1"), any())).thenReturn(policy);
 
         mockMvc.perform(post("/v1/admin/policies")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"name\":\"Rate Limit\",\"scope_pattern\":\"org/*\"}"))
+                        .content("{\"name\":\"Rate Limit\",\"scope_pattern\":\"tenant:tenant-1/*\"}"))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.policy_id").value("pol_123"))
-                .andExpect(jsonPath("$.scope_pattern").value("org/*"));
+                .andExpect(jsonPath("$.scope_pattern").value("tenant:tenant-1/*"));
     }
 
     @Test
@@ -69,7 +69,7 @@ class PolicyControllerTest {
         mockMvc.perform(post("/v1/admin/policies")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"scope_pattern\":\"org/*\"}"))
+                        .content("{\"scope_pattern\":\"tenant:tenant-1/*\"}"))
                 .andExpect(status().isBadRequest());
     }
 
@@ -85,7 +85,7 @@ class PolicyControllerTest {
     void listPolicies_returns200() throws Exception {
         setupApiKeyAuth();
         Policy policy = Policy.builder()
-                .policyId("pol_1").scopePattern("org/*").name("P1")
+                .policyId("pol_1").scopePattern("tenant:tenant-1/*").name("P1")
                 .status(PolicyStatus.ACTIVE).createdAt(Instant.now()).build();
         when(policyRepository.list(eq("tenant-1"), any(), any(), any(), anyInt())).thenReturn(List.of(policy));
 
@@ -99,12 +99,12 @@ class PolicyControllerTest {
     @Test
     void listPolicies_withFilters() throws Exception {
         setupApiKeyAuth();
-        when(policyRepository.list(eq("tenant-1"), eq("org/*"), eq(PolicyStatus.ACTIVE), any(), anyInt()))
+        when(policyRepository.list(eq("tenant-1"), eq("tenant:tenant-1/*"), eq(PolicyStatus.ACTIVE), any(), anyInt()))
                 .thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/policies")
                         .header("X-Cycles-API-Key", "valid-api-key")
-                        .param("scope_pattern", "org/*")
+                        .param("scope_pattern", "tenant:tenant-1/*")
                         .param("status", "ACTIVE"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.policies").isEmpty());
@@ -114,14 +114,14 @@ class PolicyControllerTest {
     void createPolicy_logsAuditEntry() throws Exception {
         setupApiKeyAuth();
         Policy policy = Policy.builder()
-                .policyId("pol_123").scopePattern("org/*").name("Rate Limit")
+                .policyId("pol_123").scopePattern("tenant:tenant-1/*").name("Rate Limit")
                 .status(PolicyStatus.ACTIVE).createdAt(Instant.now()).build();
         when(policyRepository.create(eq("tenant-1"), any())).thenReturn(policy);
 
         mockMvc.perform(post("/v1/admin/policies")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"name\":\"Rate Limit\",\"scope_pattern\":\"org/*\"}"))
+                        .content("{\"name\":\"Rate Limit\",\"scope_pattern\":\"tenant:tenant-1/*\"}"))
                 .andExpect(status().isCreated());
 
         verify(auditRepository).log(argThat(entry ->
@@ -186,14 +186,14 @@ class PolicyControllerTest {
     void createPolicy_auditEntry_requestIdIsFallbackUuidWhenAttributeMissing() throws Exception {
         setupApiKeyAuth();
         Policy policy = Policy.builder()
-                .policyId("pol_123").scopePattern("org/*").name("Rate Limit")
+                .policyId("pol_123").scopePattern("tenant:tenant-1/*").name("Rate Limit")
                 .status(PolicyStatus.ACTIVE).createdAt(Instant.now()).build();
         when(policyRepository.create(eq("tenant-1"), any())).thenReturn(policy);
 
         mockMvc.perform(post("/v1/admin/policies")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"name\":\"Rate Limit\",\"scope_pattern\":\"org/*\"}"))
+                        .content("{\"name\":\"Rate Limit\",\"scope_pattern\":\"tenant:tenant-1/*\"}"))
                 .andExpect(status().isCreated());
 
         verify(auditRepository).log(argThat(entry ->
@@ -206,14 +206,14 @@ class PolicyControllerTest {
     void createPolicy_auditEntry_userAgentIsNullWhenHeaderMissing() throws Exception {
         setupApiKeyAuth();
         Policy policy = Policy.builder()
-                .policyId("pol_123").scopePattern("org/*").name("Rate Limit")
+                .policyId("pol_123").scopePattern("tenant:tenant-1/*").name("Rate Limit")
                 .status(PolicyStatus.ACTIVE).createdAt(Instant.now()).build();
         when(policyRepository.create(eq("tenant-1"), any())).thenReturn(policy);
 
         mockMvc.perform(post("/v1/admin/policies")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"name\":\"Rate Limit\",\"scope_pattern\":\"org/*\"}"))
+                        .content("{\"name\":\"Rate Limit\",\"scope_pattern\":\"tenant:tenant-1/*\"}"))
                 .andExpect(status().isCreated());
 
         verify(auditRepository).log(argThat(entry ->
@@ -225,14 +225,14 @@ class PolicyControllerTest {
     void createPolicy_auditEntry_capturesSourceIp() throws Exception {
         setupApiKeyAuth();
         Policy policy = Policy.builder()
-                .policyId("pol_123").scopePattern("org/*").name("Rate Limit")
+                .policyId("pol_123").scopePattern("tenant:tenant-1/*").name("Rate Limit")
                 .status(PolicyStatus.ACTIVE).createdAt(Instant.now()).build();
         when(policyRepository.create(eq("tenant-1"), any())).thenReturn(policy);
 
         mockMvc.perform(post("/v1/admin/policies")
                         .header("X-Cycles-API-Key", "valid-api-key")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"name\":\"Rate Limit\",\"scope_pattern\":\"org/*\"}"))
+                        .content("{\"name\":\"Rate Limit\",\"scope_pattern\":\"tenant:tenant-1/*\"}"))
                 .andExpect(status().isCreated());
 
         verify(auditRepository).log(argThat(entry ->
@@ -244,10 +244,10 @@ class PolicyControllerTest {
     void listPolicies_resultCountEqualsLimit_hasMoreTrueWithCursor() throws Exception {
         setupApiKeyAuth();
         Policy p1 = Policy.builder()
-                .policyId("pol_1").scopePattern("org/*").name("P1")
+                .policyId("pol_1").scopePattern("tenant:tenant-1/*").name("P1")
                 .status(PolicyStatus.ACTIVE).createdAt(Instant.now()).build();
         Policy p2 = Policy.builder()
-                .policyId("pol_2").scopePattern("team/*").name("P2")
+                .policyId("pol_2").scopePattern("tenant:tenant-1/agent:*").name("P2")
                 .status(PolicyStatus.ACTIVE).createdAt(Instant.now()).build();
         when(policyRepository.list(eq("tenant-1"), any(), any(), any(), eq(2))).thenReturn(List.of(p1, p2));
 
@@ -278,7 +278,7 @@ class PolicyControllerTest {
     void updatePolicy_returns200() throws Exception {
         setupApiKeyAuth();
         Policy policy = Policy.builder()
-                .policyId("pol_123").scopePattern("org/*").name("Updated Name")
+                .policyId("pol_123").scopePattern("tenant:tenant-1/*").name("Updated Name")
                 .priority(10).status(PolicyStatus.ACTIVE).createdAt(Instant.now()).build();
         when(policyRepository.update(eq("tenant-1"), eq("pol_123"), any())).thenReturn(policy);
 
@@ -310,7 +310,7 @@ class PolicyControllerTest {
     void updatePolicy_logsAuditEntry() throws Exception {
         setupApiKeyAuth();
         Policy policy = Policy.builder()
-                .policyId("pol_123").scopePattern("org/*").name("P")
+                .policyId("pol_123").scopePattern("tenant:tenant-1/*").name("P")
                 .status(PolicyStatus.ACTIVE).createdAt(Instant.now()).build();
         when(policyRepository.update(eq("tenant-1"), eq("pol_123"), any())).thenReturn(policy);
 
@@ -368,7 +368,7 @@ class PolicyControllerTest {
     @Test
     void createPolicy_withAdminKey_andTenantIdInBody_returns201() throws Exception {
         Policy policy = Policy.builder()
-                .policyId("pol_admin").scopePattern("tenant:acme/*").name("Admin Policy")
+                .policyId("pol_admin").scopePattern("tenant:tenant-acme/*").name("Admin Policy")
                 .tenantId("tenant-acme")
                 .status(PolicyStatus.ACTIVE).createdAt(Instant.now()).build();
         when(policyRepository.create(eq("tenant-acme"), any())).thenReturn(policy);
@@ -376,7 +376,7 @@ class PolicyControllerTest {
         mockMvc.perform(post("/v1/admin/policies")
                         .header("X-Admin-API-Key", "test-admin-key")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"tenant_id\":\"tenant-acme\",\"name\":\"Admin Policy\",\"scope_pattern\":\"tenant:acme/*\"}"))
+                        .content("{\"tenant_id\":\"tenant-acme\",\"name\":\"Admin Policy\",\"scope_pattern\":\"tenant:tenant-acme/*\"}"))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.policy_id").value("pol_admin"));
 
@@ -392,7 +392,7 @@ class PolicyControllerTest {
         mockMvc.perform(post("/v1/admin/policies")
                         .header("X-Admin-API-Key", "test-admin-key")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"name\":\"Admin Policy\",\"scope_pattern\":\"tenant:acme/*\"}"))
+                        .content("{\"name\":\"Admin Policy\",\"scope_pattern\":\"tenant:tenant-acme/*\"}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error").value("INVALID_REQUEST"));
     }
@@ -403,7 +403,7 @@ class PolicyControllerTest {
         mockMvc.perform(post("/v1/admin/policies")
                         .header("X-Admin-API-Key", "test-admin-key")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"tenant_id\":null,\"name\":\"P\",\"scope_pattern\":\"tenant:acme/*\"}"))
+                        .content("{\"tenant_id\":null,\"name\":\"P\",\"scope_pattern\":\"tenant:tenant-acme/*\"}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error").value("INVALID_REQUEST"));
     }
@@ -425,9 +425,9 @@ class PolicyControllerTest {
         // Admin update: repository.update receives null tenantId (Lua skips
         // ownership). Audit subject is the policy's stored tenant_id, not
         // null — verifies the controller substitutes correctly.
-        when(policyRepository.getScopePattern("pol_xyz")).thenReturn("tenant:acme/*");
+        when(policyRepository.getScopePattern("pol_xyz")).thenReturn("tenant:tenant-acme/*");
         Policy updated = Policy.builder()
-                .policyId("pol_xyz").scopePattern("tenant:acme/*").name("Updated")
+                .policyId("pol_xyz").scopePattern("tenant:tenant-acme/*").name("Updated")
                 .tenantId("tenant-acme")
                 .status(PolicyStatus.ACTIVE).createdAt(Instant.now()).build();
         when(policyRepository.update(isNull(), eq("pol_xyz"), any())).thenReturn(updated);

--- a/cycles-admin-service/pom.xml
+++ b/cycles-admin-service/pom.xml
@@ -18,7 +18,7 @@
         <module>cycles-admin-service-api</module>
     </modules>
     <properties>
-        <revision>0.1.25.14</revision>
+        <revision>0.1.25.15</revision>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/docker-compose.full-stack.prod.yml
+++ b/docker-compose.full-stack.prod.yml
@@ -13,7 +13,7 @@ services:
       retries: 5
 
   cycles-admin:
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.14
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.15
     restart: unless-stopped
     ports:
       - "7979:7979"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,7 +13,7 @@ services:
       retries: 5
 
   cycles-admin:
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.14
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.15
     restart: unless-stopped
     ports:
       - "7979:7979"


### PR DESCRIPTION
## Background
During v0.1.25.14 end-to-end testing, user created a budget with scope \`tenant:acme/agentic:codex\`. \"agentic\" is a typo for the canonical kind \"agent\" — server persisted it with 201 Created. Further probing: \`workspace:eng\` (no tenant prefix) also worked. Server was doing essentially no scope validation.

Per \`cycles-protocol-v0.yaml\` SCOPE DERIVATION (NORMATIVE):
> Canonical ordering is: tenant → workspace → app → workflow → agent → toolset.

Non-canonical scopes silently break downstream enforcement (reservations can't match them) and pollute audit trails.

## New \`ScopeValidator\`
Called from \`BudgetController.create\`, \`PolicyController.create\`, \`PolicyController.update\`. Enforces:

| Rule | Reject | Accept |
|---|---|---|
| First segment must be \`tenant:<id>\` | \`workspace:eng\` | \`tenant:acme\` |
| Canonical kind set only | \`tenant:acme/agentic:codex\`, \`tenant:acme/florb:blerp\` | \`tenant:acme/agent:codex\` |
| Canonical order, no duplicates | \`tenant:x/agent:a/workspace:w\`, \`tenant:x/agent:a/agent:b\` | \`tenant:x/workspace:w/agent:a\` |
| ID non-empty, ≤128 chars, \`[A-Za-z0-9._-]+\` | \`tenant:acme/agent:\` | \`tenant:acme-corp.v2/agent:rev_01\` |
| Cross-field: scope tenant = request \`tenant_id\` | body \`acme\` + scope \`tenant:corp/...\` | matching |

**Policy wildcards**: bare-\`*\` terminal (\`tenant:acme/*\` = all descendants) + id-wildcard (\`tenant:acme/agent:*\`). Mid-chain wildcards rejected. Budget scopes remain concrete.

All rejections: 400 INVALID_REQUEST with specific segment+rule message.

## Tests (+29)
- \`ScopeValidatorTest\` (27 cases): every rule + the exact \`agentic:codex\` bug.
- \`BudgetControllerTest\` / \`PolicyControllerTest\`: pre-existing fixtures using non-canonical scopes (\`org/team1\`, \`org/*\`) updated to canonical equivalents. Admin-on-behalf-of tests tightened for coherent tenant_id + scope.

**488/488 pass** (was 459; +29). JaCoCo passes.

## Backward compatibility
Pre-existing non-canonical scopes in Redis keep working (reads don't re-validate). Only new creates must be canonical — clients sending non-canonical now get 400 with a clear error message instead of silent success.

## Spec compliance
No spec change needed. This tightens an existing implicit contract that the spec describes as canonical.

## Test plan
- [x] \`mvn -pl cycles-admin-service-api test\` — 488/488 pass
- [ ] Manual: deploy 0.1.25.15, retry \`tenant:acme/agentic:codex\` → 400 with \"non-canonical kind 'agentic'\" message
- [ ] Manual: \`tenant:acme/agent:codex\` → 201 (still works)
- [ ] Manual: \`workspace:eng\` → 400 \"must start with 'tenant:<id>'\"

## Downstream
Dashboard PR #33 will gain a matching client-side \`validateScope\` helper + instant form feedback, then release together as v0.1.25.20.