### PR TITLE
chore: refresh docker-compose — cross-repo image bumps + dev healthchecks

### DIFF
--- a/docker-compose.full-stack.prod.yml
+++ b/docker-compose.full-stack.prod.yml
@@ -40,7 +40,7 @@ services:
         condition: service_healthy
 
   cycles-server:
-    image: ghcr.io/runcycles/cycles-server:0.1.25.1
+    image: ghcr.io/runcycles/cycles-server:0.1.25.8
     restart: unless-stopped
     ports:
       - "7878:7878"
@@ -60,7 +60,7 @@ services:
         condition: service_healthy
 
   cycles-events:
-    image: ghcr.io/runcycles/cycles-server-events:0.1.25.1
+    image: ghcr.io/runcycles/cycles-server-events:0.1.25.5
     restart: unless-stopped
     ports:
       - "7980:7980"

--- a/docker-compose.full-stack.yml
+++ b/docker-compose.full-stack.yml
@@ -24,6 +24,12 @@ services:
       REDIS_PASSWORD: ""
       ADMIN_API_KEY: ${ADMIN_API_KEY:-admin-bootstrap-key}
       WEBHOOK_SECRET_ENCRYPTION_KEY: ${WEBHOOK_SECRET_ENCRYPTION_KEY:-}
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:7979/actuator/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     depends_on:
       redis:
         condition: service_healthy
@@ -39,6 +45,12 @@ services:
       REDIS_PORT: 6379
       WEBHOOK_SECRET_ENCRYPTION_KEY: ${WEBHOOK_SECRET_ENCRYPTION_KEY:-}
       REDIS_PASSWORD: ""
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:7878/actuator/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     depends_on:
       redis:
         condition: service_healthy
@@ -54,6 +66,12 @@ services:
       REDIS_PORT: 6379
       REDIS_PASSWORD: ""
       WEBHOOK_SECRET_ENCRYPTION_KEY: ${WEBHOOK_SECRET_ENCRYPTION_KEY:-}
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:7980/actuator/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     depends_on:
       redis:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,12 @@ services:
       REDIS_PASSWORD: ""
       ADMIN_API_KEY: ${ADMIN_API_KEY:-admin-bootstrap-key}
       WEBHOOK_SECRET_ENCRYPTION_KEY: ${WEBHOOK_SECRET_ENCRYPTION_KEY:-}
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:7979/actuator/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     depends_on:
       redis:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Companion cleanup to [cycles-server#92](https://github.com/runcycles/cycles-server/pull/92). Brings the cross-repo pins in `docker-compose.full-stack.prod.yml` up to current and adds healthchecks to the two dev compose files for parity with prod. **No application-code changes.**

## Image pin bumps (full-stack.prod.yml only)

| Service | Old | New | Gap |
|---|---|---|---|
| `cycles-server` | `0.1.25.1` | `0.1.25.8` | 7 revisions (reservations dual-auth, event fixes, typed ReasonCode) |
| `cycles-server-events` | `0.1.25.1` | `0.1.25.5` | 4 revisions |

`cycles-admin` pin at `0.1.25.16` is already current (bumped in #93 release-prep).

## Dev-file healthchecks

Adding `/actuator/health` wget-based healthchecks on every JVM service in `docker-compose.yml` and `docker-compose.full-stack.yml`, matching the prod file pattern. 10s interval, 30s `start_period`. Dev files keep `build:` context and permissive defaults — this just makes `depends_on: service_healthy` work locally the same way it does in prod.

## Untouched

- `docker-compose.prod.yml` — already current with all hardening from the v0.1.25.16 release prep.

## Test plan

- [x] `docker compose -f <file> config --quiet` passes for all 4 files
- [ ] CI

## Related

- cycles-server#92 — parallel cleanup for cycles-server's own compose files
- cycles-dashboard — similar PR coming (dashboard + admin pins behind)