### PR TITLE
feat(budget): v0.1.25.18 RESET_SPENT operation (billing-period boundary)

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,9 +1,60 @@
 # Complete Budget Governance v0.1.25.8 — Admin Server Audit
 
-**Server version:** 0.1.25.17 (2026-04-14 — cjson round-trip fix across ApiKey / Policy / Tenant write paths)
-**Date:** 2026-04-14 (v0.1.25.17 cjson round-trip sweep: apikey + policy + tenant), 2026-04-13 (v0.1.25.16 webhooks dual-auth), 2026-04-13 (v0.1.25.15 ScopeValidator), 2026-04-13 (v0.1.25.14 admin-on-behalf-of dual-auth), 2026-04-13 (v0.1.25.13 CORS PUT fix), 2026-04-12 (v0.1.25.12 spec-compliance hardening + observability), 2026-04-12 (v0.1.25.11 contract-testing default ON), 2026-04-12 (v0.1.25.10 spec-compliance hardening), 2026-04-10 (v0.1.25.9 release), 2026-04-10 (CORS hardening + prod config), 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
+**Server version:** 0.1.25.18 (2026-04-15 — RESET_SPENT operation: billing-period boundary)
+**Date:** 2026-04-15 (v0.1.25.18 RESET_SPENT operation), 2026-04-14 (v0.1.25.17 cjson round-trip sweep: apikey + policy + tenant), 2026-04-13 (v0.1.25.16 webhooks dual-auth), 2026-04-13 (v0.1.25.15 ScopeValidator), 2026-04-13 (v0.1.25.14 admin-on-behalf-of dual-auth), 2026-04-13 (v0.1.25.13 CORS PUT fix), 2026-04-12 (v0.1.25.12 spec-compliance hardening + observability), 2026-04-12 (v0.1.25.11 contract-testing default ON), 2026-04-12 (v0.1.25.10 spec-compliance hardening), 2026-04-10 (v0.1.25.9 release), 2026-04-10 (CORS hardening + prod config), 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
 **Spec:** [`cycles-governance-admin-v0.1.25.yaml`](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml) (OpenAPI 3.1.0, v0.1.25.11) in [cycles-protocol](https://github.com/runcycles/cycles-protocol)
 **Server:** Spring Boot 3.5.11 / Java 21 / Redis
+
+### 2026-04-15 — v0.1.25.18 RESET_SPENT operation: billing-period boundary
+
+Closes a long-standing gap between the docs (`how-to/budget-allocation-and-management-in-cycles#resetting-budgets` describes RESET as "for resetting a scope for a new billing period") and the RESET implementation (which only resizes the allocated ceiling and preserves spent — a strict no-op on an exhausted budget when re-RESET to the same allocated). Adds the new `RESET_SPENT` funding operation and its event type, paired with the cycles-protocol#45 spec PR.
+
+**Approach:** add a new operation, don't redefine RESET. Keeps RESET symmetric with CREDIT/DEBIT as a history-preserving ceiling adjustment; RESET_SPENT owns the billing-period semantic. No existing caller sees behaviour drift.
+
+**RESET_SPENT semantics** (Lua, BudgetRepository.java):
+- `allocated` = request `amount`
+- `spent` = optional request `spent` field (defaults to 0 when omitted)
+- `reserved` preserved (active runtime reservations straddle the period and land in the new period's spent when they commit)
+- `debt` preserved (periods don't forgive debt; `REPAY_DEBT` is the channel)
+- `remaining` recomputed from the ledger invariant; allowed to go negative if `(allocated - spent - reserved - debt) < 0` (overdraft semantics)
+- `is_over_limit` recomputed from `debt > overdraft_limit` (logic unchanged, inputs change)
+
+**Optional `spent` parameter** covers four operator needs beyond routine rollovers: migration from another billing system, prorated mid-period signup, credit-back / compensation, state correction. Constrained to `>= 0`. Validated at both the controller (Bean Validation + unit-mismatch check) and Lua layers (defensive `INVALID_REQUEST` on negative; surfaces as 400).
+
+**Spec coordination:** depends on cycles-protocol#45 (spec PR for v0.1.25.17). Admin contract test fetches `cycles-protocol@main`; this PR's contract tests pass against the spec PR branch and will pass against `main` once cycles-protocol#45 merges. Spec-first merge ordering required.
+
+**Idempotency cache versioned to v2.** The fund Lua now caches 9 pipe-delimited fields (was 7) — added `prev_spent` and `new_spent`. The cache key prefix bumped from `idempotency:fund:<key>` to `idempotency:fund:v2:<key>`. Old v1 entries expire naturally within 24h; old and new coexist with zero parse-failure risk during the rolling deploy. Java parser updated to read the v2 format.
+
+**Event emission:** new `BUDGET_RESET_SPENT` event type (`budget.reset_spent`), distinct from `budget.reset`. Event consumers (dashboards, webhook handlers, compliance queries) can route period boundaries separately from resize events. The payload's new `spent_override_provided` boolean flags whether the request explicitly set `spent` (migration / correction needing compliance scrutiny) vs defaulted to 0 (routine rollover).
+
+**Audit metadata enriched** in `BudgetController.buildFundMetadata`: now records `previous_spent`, `new_spent`, and (for RESET_SPENT) `spent_override_provided`. Reviewers see the before/after spent transition and whether the operator deliberately set it without joining to event logs.
+
+**Changes:**
+
+| File | Change |
+|---|---|
+| `cycles-admin-service-model/.../FundingOperation.java` | Add RESET_SPENT enum value + javadoc explaining each operation's role |
+| `cycles-admin-service-model/.../BudgetFundingRequest.java` | Add optional `spent` field (Amount); javadoc clarifies RESET_SPENT-only semantic |
+| `cycles-admin-service-model/.../BudgetFundingResponse.java` | Add nullable `previous_spent` and `new_spent` (additive, `@JsonInclude(NON_NULL)`) |
+| `cycles-admin-service-model/.../event/BudgetOperation.java` | Add RESET_SPENT enum value |
+| `cycles-admin-service-model/.../event/EventType.java` | Add `BUDGET_RESET_SPENT("budget.reset_spent", BUDGET)`; drop stale "(15)" comment |
+| `cycles-admin-service-model/.../event/EventPayloadTypeMapping.java` | Map `BUDGET_RESET_SPENT` → `EventDataBudgetLifecycle.class` |
+| `cycles-admin-service-model/.../event/EventDataBudgetLifecycle.java` | Add `spent` and `reserved` to `BudgetState`; new optional `spent_override_provided` field on the outer payload |
+| `cycles-admin-service-data/.../BudgetRepository.java` | New RESET_SPENT Lua branch with optional ARGV[7] spent override; return array extended 8 → 10 elements (adds prev_spent / new_spent); `INVALID_REQUEST` error path for negative spent; idempotency cache key prefix bumped to `idempotency:fund:v2:`; Java parser reads new fields |
+| `cycles-admin-service-api/.../BudgetController.java` | Validate optional `spent` (operation must be RESET_SPENT, unit must match, value `>= 0`); emit `BUDGET_RESET_SPENT` event with full pre/post BudgetState snapshots and `spent_override_provided` flag; enrich audit metadata with prev/new spent + the override flag |
+| `cycles-admin-service-data/.../BudgetRepositoryTest.java` | +6 new tests: default-clears-spent, with-explicit-override, rejects-negative, allows-negative-remaining, empty-ARGV-default-path, idempotent-hit-parses-v2-cache |
+| `cycles-admin-service-api/.../BudgetControllerTest.java` | +5 new tests: RESET_SPENT default, with override, spent on wrong operation rejected, negative spent rejected, spent unit mismatch rejected |
+| `cycles-admin-service-model/.../EventModelTest.java` | Bump expected event-type count 40 → 41 with explanatory comment |
+
+**Verification:**
+- `mvn verify` passes 518 tests (up from 512), JaCoCo coverage met (≥95%), spec coverage 43/43 endpoints.
+- Run with `-Dcontract.spec.url=https://raw.githubusercontent.com/runcycles/cycles-protocol/spec/budget-reset-spent-v0.1.25.17/cycles-governance-admin-v0.1.25.yaml` while cycles-protocol#45 is in flight; once merged, default contract URL (cycles-protocol@main) will validate cleanly.
+
+**Wire format:** additive. Existing RESET callers are unaffected. New fields are optional / nullable; new enum values follow the spec's existing extensibility policy ("consumers MUST ignore unrecognised enum values").
+
+**Cross-refs:** cycles-protocol#45 (spec PR), upcoming docs PR (split `how-to/budget-allocation-and-management-in-cycles#resetting-budgets` into "Resizing a budget" and "Starting a new billing period").
+
+---
 
 ### 2026-04-14 — v0.1.25.17 cjson round-trip sweep: apikey + policy + tenant
 

--- a/README.md
+++ b/README.md
@@ -374,10 +374,11 @@ Use `POST /v1/admin/budgets/fund?scope={scope}&unit={unit}` with one of:
 
 | Operation | Effect |
 |-----------|--------|
-| `CREDIT` | `allocated += amount`, `remaining += amount` |
-| `DEBIT` | `allocated -= amount`, `remaining -= amount` (fails if remaining would go negative) |
-| `RESET` | `allocated = amount`, `remaining = amount - reserved - spent - debt` |
-| `REPAY_DEBT` | `debt -= amount` (uses remaining if debt < amount) |
+| `CREDIT` | `allocated += amount`, `remaining += amount`. Preserves spent / reserved / debt. |
+| `DEBIT` | `allocated -= amount`, `remaining -= amount` (fails if remaining would go negative). Preserves spent / reserved / debt. |
+| `RESET` | `allocated = amount`, `remaining = amount - reserved - spent - debt`. Preserves spent / reserved / debt. Use for **resizing the ceiling** (plan changes, limit adjustments). NOT for billing-period boundaries — use `RESET_SPENT`. |
+| `RESET_SPENT` (v0.1.25.18+) | `allocated = amount`, `spent = request.spent` (defaults to 0), `remaining = allocated - spent - reserved - debt`. Preserves reserved (active reservations straddle the period) and debt (use `REPAY_DEBT` to clear). Use for **starting a new billing period**, migrations, prorated signups, and consumption corrections. Optional `spent` field (Amount, must be ≥ 0, unit must match) lets the operator set a specific starting consumption — emits `budget.reset_spent` event with `spent_override_provided` flag for audit. |
+| `REPAY_DEBT` | `debt -= amount` (uses remaining if debt < amount). |
 
 All funding operations support `idempotency_key` (prevents double-funding; replayed requests return original response) and an optional `reason` field for the audit trail.
 

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/BudgetController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/BudgetController.java
@@ -172,6 +172,25 @@ public class BudgetController {
         if (request.getAmount().getUnit() != unit) {
             throw GovernanceException.unitMismatch(unit.name(), request.getAmount().getUnit().name());
         }
+        // Validate the optional `spent` field: only meaningful for RESET_SPENT,
+        // must share the same unit as the budget (ledger is single-unit), and
+        // must be non-negative. Supplying `spent` on other operations is a
+        // client bug worth surfacing early rather than silently ignoring.
+        if (request.getSpent() != null) {
+            if (request.getOperation() != FundingOperation.RESET_SPENT) {
+                throw new GovernanceException(
+                    io.runcycles.admin.model.shared.ErrorCode.INVALID_REQUEST,
+                    "`spent` field is only honoured for RESET_SPENT operations", 400);
+            }
+            if (request.getSpent().getUnit() != unit) {
+                throw GovernanceException.unitMismatch(unit.name(), request.getSpent().getUnit().name());
+            }
+            if (request.getSpent().getAmount() < 0) {
+                throw new GovernanceException(
+                    io.runcycles.admin.model.shared.ErrorCode.INVALID_REQUEST,
+                    "`spent` must be >= 0", 400);
+            }
+        }
         String tenantId = (String) httpRequest.getAttribute("authenticated_tenant_id");
         if (tenantId == null) {
             // Admin key auth — tenant_id query param is required for scoping
@@ -190,7 +209,7 @@ public class BudgetController {
             .resourceType("budget").resourceId(scope + ":" + unit.name())
             .operation("fundBudget")
             .status(200)
-            .metadata(buildFundMetadata(scope, unit, request))
+            .metadata(buildFundMetadata(scope, unit, request, response))
             .build());
         try {
             EventType fundEventType;
@@ -198,16 +217,44 @@ public class BudgetController {
                 case CREDIT: fundEventType = EventType.BUDGET_FUNDED; break;
                 case DEBIT: fundEventType = EventType.BUDGET_DEBITED; break;
                 case RESET: fundEventType = EventType.BUDGET_RESET; break;
+                case RESET_SPENT: fundEventType = EventType.BUDGET_RESET_SPENT; break;
                 case REPAY_DEBT: fundEventType = EventType.BUDGET_DEBT_REPAID; break;
                 default: fundEventType = EventType.BUDGET_FUNDED; break;
             }
             ActorType actorType = httpRequest.getAttribute("authenticated_tenant_id") != null ? ActorType.API_KEY : ActorType.ADMIN;
+
+            // Pre/post state snapshots. For RESET_SPENT we populate the new spent
+            // and reserved fields so event consumers can see the transition cleanly.
+            // For other operations we populate what we have; unchanged fields appear
+            // equal on both sides.
+            EventDataBudgetLifecycle.BudgetState previousState = EventDataBudgetLifecycle.BudgetState.builder()
+                .allocated(response.getPreviousAllocated() != null ? response.getPreviousAllocated().getAmount() : null)
+                .remaining(response.getPreviousRemaining() != null ? response.getPreviousRemaining().getAmount() : null)
+                .debt(response.getPreviousDebt() != null ? response.getPreviousDebt().getAmount() : null)
+                .spent(response.getPreviousSpent() != null ? response.getPreviousSpent().getAmount() : null)
+                .build();
+            EventDataBudgetLifecycle.BudgetState newState = EventDataBudgetLifecycle.BudgetState.builder()
+                .allocated(response.getNewAllocated() != null ? response.getNewAllocated().getAmount() : null)
+                .remaining(response.getNewRemaining() != null ? response.getNewRemaining().getAmount() : null)
+                .debt(response.getNewDebt() != null ? response.getNewDebt().getAmount() : null)
+                .spent(response.getNewSpent() != null ? response.getNewSpent().getAmount() : null)
+                .build();
+
+            EventDataBudgetLifecycle.EventDataBudgetLifecycleBuilder payloadBuilder =
+                EventDataBudgetLifecycle.builder()
+                    .scope(scope).unit(unit)
+                    .operation(BudgetOperation.valueOf(request.getOperation().name()))
+                    .previousState(previousState)
+                    .newState(newState)
+                    .reason(request.getReason());
+            if (request.getOperation() == FundingOperation.RESET_SPENT) {
+                payloadBuilder.spentOverrideProvided(request.getSpent() != null);
+            }
+
             eventService.emit(fundEventType, tenantId, scope, "cycles-admin",
                 Actor.builder().type(actorType)
                     .keyId((String) httpRequest.getAttribute("authenticated_key_id")).build(),
-                objectMapper.convertValue(EventDataBudgetLifecycle.builder()
-                    .scope(scope).unit(unit).operation(BudgetOperation.valueOf(request.getOperation().name()))
-                    .reason(request.getReason()).build(), Map.class),
+                objectMapper.convertValue(payloadBuilder.build(), Map.class),
                 null, httpRequest.getAttribute("requestId") != null ? httpRequest.getAttribute("requestId").toString() : null);
         } catch (Exception e) {
             LOG.warn("Failed to emit event: {}", e.getMessage());
@@ -291,7 +338,8 @@ public class BudgetController {
         return meta;
     }
 
-    private Map<String, Object> buildFundMetadata(String scope, UnitEnum unit, BudgetFundingRequest request) {
+    private Map<String, Object> buildFundMetadata(String scope, UnitEnum unit, BudgetFundingRequest request,
+                                                   BudgetFundingResponse response) {
         java.util.LinkedHashMap<String, Object> meta = new java.util.LinkedHashMap<>();
         meta.put("scope", scope);
         meta.put("unit", unit.name());
@@ -299,6 +347,21 @@ public class BudgetController {
         meta.put("amount", request.getAmount().getAmount());
         if (request.getReason() != null) meta.put("reason", request.getReason());
         if (request.getIdempotencyKey() != null) meta.put("idempotency_key", request.getIdempotencyKey());
+        // Spent-change audit trail. Only meaningful for RESET_SPENT today; populated
+        // for all operations since the values are cheap and give reviewers a
+        // before/after snapshot without joining to event logs. For preserve-spent
+        // operations prev and new are equal — a visual no-op.
+        if (response != null && response.getPreviousSpent() != null && response.getNewSpent() != null) {
+            meta.put("previous_spent", response.getPreviousSpent().getAmount());
+            meta.put("new_spent", response.getNewSpent().getAmount());
+        }
+        // Flag whether the caller explicitly supplied `spent` vs relied on the
+        // default — important for RESET_SPENT compliance review because explicit
+        // spent values fall under the "operator adjusted consumption" bucket that
+        // usually requires higher scrutiny than routine rollovers.
+        if (request.getOperation() == FundingOperation.RESET_SPENT) {
+            meta.put("spent_override_provided", request.getSpent() != null);
+        }
         return meta;
     }
 

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BudgetControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BudgetControllerTest.java
@@ -549,6 +549,80 @@ class BudgetControllerTest {
                 .andExpect(status().isBadRequest());
     }
 
+    /**
+     * Audit + event payload enrichment for RESET_SPENT: the audit entry
+     * MUST carry previous_spent / new_spent and the spent_override_provided
+     * flag (true when the request supplied an explicit spent value, false on
+     * default-to-zero). This is what compliance dashboards use to filter
+     * routine rollovers from operator-set consumption adjustments.
+     */
+    @Test
+    void fundBudget_resetSpentExplicit_auditMetadataIncludesSpentOverrideFlag() throws Exception {
+        setupApiKeyAuth();
+        BudgetFundingResponse funding = BudgetFundingResponse.builder()
+                .operation(FundingOperation.RESET_SPENT)
+                .previousAllocated(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
+                .newAllocated(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
+                .previousRemaining(new Amount(UnitEnum.USD_MICROCENTS, 0L))
+                .newRemaining(new Amount(UnitEnum.USD_MICROCENTS, 600L))
+                .previousSpent(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
+                .newSpent(new Amount(UnitEnum.USD_MICROCENTS, 400L))
+                .timestamp(Instant.now()).build();
+        when(budgetRepository.fund(eq("tenant-1"), eq("tenant:tenant-1/workspace:tscope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
+
+        mockMvc.perform(post("/v1/admin/budgets/fund")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
+                        .param("unit", "USD_MICROCENTS")
+                        .header("X-Cycles-API-Key", "valid-api-key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"operation\":\"RESET_SPENT\",\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":1000},\"spent\":{\"unit\":\"USD_MICROCENTS\",\"amount\":400}}"))
+                .andExpect(status().isOk());
+
+        verify(auditRepository).log(argThat(entry ->
+                "fundBudget".equals(entry.getOperation())
+                && entry.getStatus() == 200
+                && entry.getMetadata() != null
+                && "RESET_SPENT".equals(entry.getMetadata().get("funding_operation"))
+                && Long.valueOf(1000L).equals(entry.getMetadata().get("previous_spent"))
+                && Long.valueOf(400L).equals(entry.getMetadata().get("new_spent"))
+                && Boolean.TRUE.equals(entry.getMetadata().get("spent_override_provided"))));
+    }
+
+    /**
+     * Audit metadata for the default-no-override case sets
+     * spent_override_provided=false. This is the routine-rollover signal
+     * that compliance dashboards can rely on to filter out high-frequency,
+     * low-scrutiny billing-period boundaries from the operator-adjustments
+     * stream.
+     */
+    @Test
+    void fundBudget_resetSpentDefault_auditMetadataMarksOverrideFalse() throws Exception {
+        setupApiKeyAuth();
+        BudgetFundingResponse funding = BudgetFundingResponse.builder()
+                .operation(FundingOperation.RESET_SPENT)
+                .previousAllocated(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
+                .newAllocated(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
+                .previousRemaining(new Amount(UnitEnum.USD_MICROCENTS, 0L))
+                .newRemaining(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
+                .previousSpent(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
+                .newSpent(new Amount(UnitEnum.USD_MICROCENTS, 0L))
+                .timestamp(Instant.now()).build();
+        when(budgetRepository.fund(eq("tenant-1"), eq("tenant:tenant-1/workspace:tscope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
+
+        mockMvc.perform(post("/v1/admin/budgets/fund")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
+                        .param("unit", "USD_MICROCENTS")
+                        .header("X-Cycles-API-Key", "valid-api-key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"operation\":\"RESET_SPENT\",\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":1000}}"))
+                .andExpect(status().isOk());
+
+        verify(auditRepository).log(argThat(entry ->
+                entry.getMetadata() != null
+                && "RESET_SPENT".equals(entry.getMetadata().get("funding_operation"))
+                && Boolean.FALSE.equals(entry.getMetadata().get("spent_override_provided"))));
+    }
+
     @Test
     void fundBudget_repayDebtOperation_returns200() throws Exception {
         setupApiKeyAuth();

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BudgetControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BudgetControllerTest.java
@@ -455,6 +455,100 @@ class BudgetControllerTest {
                 .andExpect(jsonPath("$.operation").value("RESET"));
     }
 
+    /** RESET_SPENT default flow (v0.1.25.17+): no `spent` field → period reset to 0. */
+    @Test
+    void fundBudget_resetSpentDefault_returns200() throws Exception {
+        setupApiKeyAuth();
+        BudgetFundingResponse funding = BudgetFundingResponse.builder()
+                .operation(FundingOperation.RESET_SPENT)
+                .previousAllocated(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
+                .newAllocated(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
+                .previousRemaining(new Amount(UnitEnum.USD_MICROCENTS, 0L))
+                .newRemaining(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
+                .previousSpent(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
+                .newSpent(new Amount(UnitEnum.USD_MICROCENTS, 0L))
+                .timestamp(Instant.now()).build();
+        when(budgetRepository.fund(eq("tenant-1"), eq("tenant:tenant-1/workspace:tscope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
+
+        mockMvc.perform(post("/v1/admin/budgets/fund")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
+                        .param("unit", "USD_MICROCENTS")
+                        .header("X-Cycles-API-Key", "valid-api-key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"operation\":\"RESET_SPENT\",\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":1000}}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.operation").value("RESET_SPENT"))
+                .andExpect(jsonPath("$.previous_spent.amount").value(1000))
+                .andExpect(jsonPath("$.new_spent.amount").value(0));
+    }
+
+    /** RESET_SPENT with explicit spent override (migration / proration / compensation). */
+    @Test
+    void fundBudget_resetSpentWithOverride_returns200() throws Exception {
+        setupApiKeyAuth();
+        BudgetFundingResponse funding = BudgetFundingResponse.builder()
+                .operation(FundingOperation.RESET_SPENT)
+                .previousAllocated(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
+                .newAllocated(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
+                .previousRemaining(new Amount(UnitEnum.USD_MICROCENTS, 0L))
+                .newRemaining(new Amount(UnitEnum.USD_MICROCENTS, 600L))
+                .previousSpent(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
+                .newSpent(new Amount(UnitEnum.USD_MICROCENTS, 400L))
+                .timestamp(Instant.now()).build();
+        when(budgetRepository.fund(eq("tenant-1"), eq("tenant:tenant-1/workspace:tscope"), eq(UnitEnum.USD_MICROCENTS), any())).thenReturn(funding);
+
+        mockMvc.perform(post("/v1/admin/budgets/fund")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
+                        .param("unit", "USD_MICROCENTS")
+                        .header("X-Cycles-API-Key", "valid-api-key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"operation\":\"RESET_SPENT\",\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":1000},\"spent\":{\"unit\":\"USD_MICROCENTS\",\"amount\":400}}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.new_spent.amount").value(400));
+    }
+
+    /** Sending `spent` on a non-RESET_SPENT operation surfaces as a 400 — client bug. */
+    @Test
+    void fundBudget_spentFieldOnWrongOperation_returns400() throws Exception {
+        setupApiKeyAuth();
+
+        mockMvc.perform(post("/v1/admin/budgets/fund")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
+                        .param("unit", "USD_MICROCENTS")
+                        .header("X-Cycles-API-Key", "valid-api-key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"operation\":\"CREDIT\",\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":1000},\"spent\":{\"unit\":\"USD_MICROCENTS\",\"amount\":400}}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    /** Negative spent on RESET_SPENT — 400 from the controller-side validation. */
+    @Test
+    void fundBudget_negativeSpent_returns400() throws Exception {
+        setupApiKeyAuth();
+
+        mockMvc.perform(post("/v1/admin/budgets/fund")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
+                        .param("unit", "USD_MICROCENTS")
+                        .header("X-Cycles-API-Key", "valid-api-key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"operation\":\"RESET_SPENT\",\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":1000},\"spent\":{\"unit\":\"USD_MICROCENTS\",\"amount\":-1}}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    /** Mismatched spent unit vs budget unit — 400 unit mismatch. */
+    @Test
+    void fundBudget_spentUnitMismatch_returns400() throws Exception {
+        setupApiKeyAuth();
+
+        mockMvc.perform(post("/v1/admin/budgets/fund")
+                        .param("scope", "tenant:tenant-1/workspace:tscope")
+                        .param("unit", "USD_MICROCENTS")
+                        .header("X-Cycles-API-Key", "valid-api-key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"operation\":\"RESET_SPENT\",\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":1000},\"spent\":{\"unit\":\"TOKENS\",\"amount\":400}}"))
+                .andExpect(status().isBadRequest());
+    }
+
     @Test
     void fundBudget_repayDebtOperation_returns200() throws Exception {
         setupApiKeyAuth();

--- a/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/BudgetRepository.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/BudgetRepository.java
@@ -34,14 +34,23 @@ public class BudgetRepository {
     // Lua script for atomic budget funding with idempotency — prevents race conditions on concurrent updates.
     // KEYS[1] = budget key
     // ARGV[1] = operation, ARGV[2] = amount, ARGV[3] = now, ARGV[4] = tenant_id,
-    // ARGV[5] = idempotency_key (empty = skip), ARGV[6] = payload_hash (empty = skip)
+    // ARGV[5] = idempotency_key (empty = skip), ARGV[6] = payload_hash (empty = skip),
+    // ARGV[7] = spent_override (empty = use default 0 for RESET_SPENT; ignored for
+    //          other operations). Added in v0.1.25.17 with the RESET_SPENT operation.
+    //
+    // Idempotency cache key format is versioned: 'idempotency:fund:v2:<key>'. The v2
+    // bump coincides with the expansion of the cached result from 7 to 9
+    // pipe-delimited fields (adds prev_spent|new_spent). Pre-v2 cache entries expire
+    // naturally within 24h, so old and new coexist without parse-failure risk during
+    // deploy. Readers of the v1 key space are unaffected because we never read from
+    // the old prefix here.
     private static final String FUND_LUA =
         "local key = KEYS[1]\n" +
         // Atomic idempotency check: same (idem_key) seen before → replay or mismatch
         "local idem_key_arg = ARGV[5]\n" +
         "local payload_hash = ARGV[6]\n" +
         "if idem_key_arg ~= '' then\n" +
-        "  local idem_redis = 'idempotency:fund:' .. idem_key_arg\n" +
+        "  local idem_redis = 'idempotency:fund:v2:' .. idem_key_arg\n" +
         "  local cached = redis.call('GET', idem_redis)\n" +
         "  if cached then\n" +
         "    if payload_hash ~= '' then\n" +
@@ -62,6 +71,7 @@ public class BudgetRepository {
         "local op = ARGV[1]\n" +
         "local amount = tonumber(ARGV[2])\n" +
         "local now = ARGV[3]\n" +
+        "local spent_override_arg = ARGV[7]\n" +
         "local allocated = tonumber(redis.call('HGET', key, 'allocated') or '0')\n" +
         "local remaining = tonumber(redis.call('HGET', key, 'remaining') or '0')\n" +
         "local reserved = tonumber(redis.call('HGET', key, 'reserved') or '0')\n" +
@@ -71,6 +81,7 @@ public class BudgetRepository {
         "local prev_allocated = allocated\n" +
         "local prev_remaining = remaining\n" +
         "local prev_debt = debt\n" +
+        "local prev_spent = spent\n" +
         "if op == 'CREDIT' then\n" +
         "  allocated = allocated + amount\n" +
         "  remaining = remaining + amount\n" +
@@ -81,6 +92,23 @@ public class BudgetRepository {
         "elseif op == 'RESET' then\n" +
         "  allocated = amount\n" +
         "  remaining = amount - reserved - spent - debt\n" +
+        "elseif op == 'RESET_SPENT' then\n" +
+        // New billing-period operation added in v0.1.25.17. Sets allocated to the given
+        // amount AND sets spent to the optional ARGV[7] override (defaulting to 0).
+        // Preserves reserved (active reservations straddle the period boundary) and
+        // debt (periods don't forgive debt — REPAY_DEBT is the explicit channel).
+        // Remaining recomputed from the ledger invariant; allowed to go negative when
+        // (allocated - spent - reserved - debt) < 0, matching overdraft semantics.
+        "  allocated = amount\n" +
+        "  if spent_override_arg ~= '' then\n" +
+        "    spent = tonumber(spent_override_arg)\n" +
+        "    if spent == nil or spent < 0 then\n" +
+        "      return {'INVALID_REQUEST', 'spent must be >= 0'}\n" +
+        "    end\n" +
+        "  else\n" +
+        "    spent = 0\n" +
+        "  end\n" +
+        "  remaining = allocated - spent - reserved - debt\n" +
         "elseif op == 'REPAY_DEBT' then\n" +
         "  local repayment = math.min(debt, amount)\n" +
         "  debt = debt - repayment\n" +
@@ -96,10 +124,13 @@ public class BudgetRepository {
         "redis.call('HMSET', key, 'allocated', i(allocated), 'remaining', i(remaining),\n" +
         "  'debt', i(debt), 'reserved', i(reserved), 'spent', i(spent),\n" +
         "  'is_over_limit', is_over, 'updated_at', now)\n" +
-        // Store idempotency result atomically (24h TTL)
+        // Store idempotency result atomically (24h TTL). Cache value is 9
+        // pipe-delimited fields (v2 format): prev_allocated|allocated|prev_remaining|
+        // remaining|prev_debt|debt|is_over|prev_spent|spent. v2 cache key prefix
+        // (above) prevents v1 consumers from parsing this expanded format.
         "if idem_key_arg ~= '' then\n" +
-        "  local idem_redis = 'idempotency:fund:' .. idem_key_arg\n" +
-        "  local result_json = i(prev_allocated) .. '|' .. i(allocated) .. '|' .. i(prev_remaining) .. '|' .. i(remaining) .. '|' .. i(prev_debt) .. '|' .. i(debt) .. '|' .. is_over\n" +
+        "  local idem_redis = 'idempotency:fund:v2:' .. idem_key_arg\n" +
+        "  local result_json = i(prev_allocated) .. '|' .. i(allocated) .. '|' .. i(prev_remaining) .. '|' .. i(remaining) .. '|' .. i(prev_debt) .. '|' .. i(debt) .. '|' .. is_over .. '|' .. i(prev_spent) .. '|' .. i(spent)\n" +
         "  redis.call('SET', idem_redis, result_json)\n" +
         "  redis.call('EXPIRE', idem_redis, 86400)\n" +
         "  if payload_hash ~= '' then\n" +
@@ -108,7 +139,7 @@ public class BudgetRepository {
         "  end\n" +
         "end\n" +
         "return {'OK', i(prev_allocated), i(allocated), i(prev_remaining),\n" +
-        "  i(remaining), i(prev_debt), i(debt), is_over}\n";
+        "  i(remaining), i(prev_debt), i(debt), is_over, i(prev_spent), i(spent)}\n";
 
     // Lua script for atomic budget creation — validates tenant exists and is ACTIVE,
     // prevents TOCTOU race on duplicate check.
@@ -400,12 +431,24 @@ public class BudgetRepository {
                 payloadHash = computePayloadHash(request);
             }
 
+            // Spent override (ARGV[7]) — only meaningful for RESET_SPENT. Empty string
+            // means "use default" (spent = 0 for RESET_SPENT; not used at all for
+            // other operations). Passing the raw string (not the request field's
+            // internal unit) keeps the Lua side unit-agnostic; the controller has
+            // already enforced that request.spent.unit matches request.amount.unit.
+            String spentOverride = "";
+            if (request.getOperation() == FundingOperation.RESET_SPENT
+                && request.getSpent() != null) {
+                spentOverride = String.valueOf(request.getSpent().getAmount());
+            }
+
             // Atomic fund via Lua — idempotency check + read + compute + write + cache in one step
             @SuppressWarnings("unchecked")
             List<String> result = (List<String>) jedis.eval(FUND_LUA,
                 List.of(key),
                 List.of(request.getOperation().name(), String.valueOf(changeAmount), now,
-                         tenantId != null ? tenantId : "", idempotencyKey, payloadHash));
+                         tenantId != null ? tenantId : "", idempotencyKey, payloadHash,
+                         spentOverride));
 
             String status = result.get(0);
             if ("IDEMPOTENCY_MISMATCH".equals(status)) {
@@ -414,7 +457,7 @@ public class BudgetRepository {
                     "Idempotency key reused with different payload", 409);
             }
             if ("IDEMPOTENT_HIT".equals(status)) {
-                // Reconstruct response from cached pipe-delimited values
+                // Reconstruct response from cached pipe-delimited values (v2 format)
                 String cached = result.get(1);
                 return parseCachedFundResponse(cached, unit, request.getOperation());
             }
@@ -435,6 +478,13 @@ public class BudgetRepository {
             if ("BUDGET_CLOSED".equals(status)) {
                 throw GovernanceException.budgetClosed(scope);
             }
+            if ("INVALID_REQUEST".equals(status)) {
+                // Raised today only by RESET_SPENT with negative spent override.
+                String detail = result.size() > 1 ? result.get(1) : "Invalid request";
+                throw new GovernanceException(
+                    io.runcycles.admin.model.shared.ErrorCode.INVALID_REQUEST,
+                    detail, 400);
+            }
 
             long prevAllocated = Long.parseLong(result.get(1));
             long newAllocated = Long.parseLong(result.get(2));
@@ -442,6 +492,9 @@ public class BudgetRepository {
             long newRemainingVal = Long.parseLong(result.get(4));
             long prevDebtVal = Long.parseLong(result.get(5));
             long newDebtVal = Long.parseLong(result.get(6));
+            // indices 7 = is_over (string); 8 = prev_spent; 9 = new_spent (v0.1.25.17+)
+            long prevSpentVal = result.size() > 8 ? Long.parseLong(result.get(8)) : 0L;
+            long newSpentVal  = result.size() > 9 ? Long.parseLong(result.get(9)) : 0L;
 
             BudgetFundingResponse response = BudgetFundingResponse.builder()
                 .operation(request.getOperation())
@@ -451,6 +504,8 @@ public class BudgetRepository {
                 .newRemaining(new Amount(unit, newRemainingVal))
                 .previousDebt(new Amount(unit, prevDebtVal))
                 .newDebt(new Amount(unit, newDebtVal))
+                .previousSpent(new Amount(unit, prevSpentVal))
+                .newSpent(new Amount(unit, newSpentVal))
                 .timestamp(Instant.now())
                 .build();
 
@@ -464,8 +519,13 @@ public class BudgetRepository {
     }
 
     private BudgetFundingResponse parseCachedFundResponse(String cached, UnitEnum unit, FundingOperation operation) {
+        // v2 cache format (spec v0.1.25.17+): 9 pipe-delimited fields
+        //   prev_allocated|allocated|prev_remaining|remaining|prev_debt|debt|is_over|prev_spent|spent
+        // We read by position and tolerate older cache format if somehow a 7-field
+        // entry survived — the v2 prefix on the cache key should make this
+        // impossible in practice, but the defensive null-fill is cheap.
         String[] parts = cached.split("\\|");
-        return BudgetFundingResponse.builder()
+        BudgetFundingResponse.BudgetFundingResponseBuilder b = BudgetFundingResponse.builder()
             .operation(operation)
             .previousAllocated(new Amount(unit, Long.parseLong(parts[0])))
             .newAllocated(new Amount(unit, Long.parseLong(parts[1])))
@@ -473,8 +533,12 @@ public class BudgetRepository {
             .newRemaining(new Amount(unit, Long.parseLong(parts[3])))
             .previousDebt(new Amount(unit, Long.parseLong(parts[4])))
             .newDebt(new Amount(unit, Long.parseLong(parts[5])))
-            .timestamp(Instant.now())
-            .build();
+            .timestamp(Instant.now());
+        if (parts.length >= 9) {
+            b.previousSpent(new Amount(unit, Long.parseLong(parts[7])));
+            b.newSpent(new Amount(unit, Long.parseLong(parts[8])));
+        }
+        return b.build();
     }
 
     private String computePayloadHash(Object request) {

--- a/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/BudgetRepositoryTest.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/BudgetRepositoryTest.java
@@ -356,6 +356,181 @@ class BudgetRepositoryTest {
         assertThat(response.getNewRemaining().getAmount()).isEqualTo(4500L);
     }
 
+    // ---- RESET_SPENT (billing-period boundary) — v0.1.25.17+ ---------------
+
+    /**
+     * Default case: no explicit `spent` → Lua defaults to 0.
+     * Simulates the canonical "new billing period" flow on an exhausted budget.
+     * Lua return array has 10 elements in v0.1.25.17+: adds prev_spent/new_spent.
+     */
+    @Test
+    void fund_resetSpent_defaultClearsSpent() {
+        // Pre-state: allocated=1000, remaining=0, spent=1000 (exhausted). Post:
+        // allocated=1000, remaining=1000, spent=0. Mock echoes back what Lua
+        // would compute.
+        List<String> luaResult = List.of("OK",
+            "1000", "1000",       // prev_allocated, new_allocated
+            "0", "1000",          // prev_remaining, new_remaining
+            "0", "0",             // prev_debt, new_debt
+            "false",              // is_over
+            "1000", "0");         // prev_spent, new_spent
+        when(jedis.eval(anyString(), anyList(), anyList())).thenReturn(luaResult);
+
+        BudgetFundingRequest request = new BudgetFundingRequest();
+        request.setOperation(FundingOperation.RESET_SPENT);
+        request.setAmount(new Amount(UnitEnum.USD_MICROCENTS, 1000L));
+        // No spent field — defaults to 0.
+
+        BudgetFundingResponse response = repository.fund("tenant-1", "scope", UnitEnum.USD_MICROCENTS, request);
+
+        assertThat(response.getOperation()).isEqualTo(FundingOperation.RESET_SPENT);
+        assertThat(response.getPreviousAllocated().getAmount()).isEqualTo(1000L);
+        assertThat(response.getNewAllocated().getAmount()).isEqualTo(1000L);
+        assertThat(response.getPreviousRemaining().getAmount()).isEqualTo(0L);
+        assertThat(response.getNewRemaining().getAmount()).isEqualTo(1000L);
+        assertThat(response.getPreviousSpent()).isNotNull();
+        assertThat(response.getPreviousSpent().getAmount()).isEqualTo(1000L);
+        assertThat(response.getNewSpent()).isNotNull();
+        assertThat(response.getNewSpent().getAmount()).isEqualTo(0L);
+    }
+
+    /**
+     * Explicit spent override: migration / proration / compensation use cases.
+     * Tests that the request's spent field is plumbed through to ARGV[7] and
+     * that the response reflects the explicit value.
+     */
+    @Test
+    void fund_resetSpent_withExplicitSpentOverride() {
+        // Pre: allocated=1000, spent=1000, remaining=0. Request: amount=1000,
+        // spent=400 (migration). Post: allocated=1000, spent=400, remaining=600.
+        List<String> luaResult = List.of("OK",
+            "1000", "1000",
+            "0", "600",
+            "0", "0",
+            "false",
+            "1000", "400");
+        when(jedis.eval(anyString(), anyList(), anyList())).thenReturn(luaResult);
+
+        BudgetFundingRequest request = new BudgetFundingRequest();
+        request.setOperation(FundingOperation.RESET_SPENT);
+        request.setAmount(new Amount(UnitEnum.USD_MICROCENTS, 1000L));
+        request.setSpent(new Amount(UnitEnum.USD_MICROCENTS, 400L));
+
+        BudgetFundingResponse response = repository.fund("tenant-1", "scope", UnitEnum.USD_MICROCENTS, request);
+
+        assertThat(response.getOperation()).isEqualTo(FundingOperation.RESET_SPENT);
+        assertThat(response.getNewSpent().getAmount()).isEqualTo(400L);
+        assertThat(response.getNewRemaining().getAmount()).isEqualTo(600L);
+
+        // Verify the Lua call received the spent override at ARGV[7]. Using
+        // ArgumentCaptor for the ARGV list.
+        org.mockito.ArgumentCaptor<List<String>> argsCap = org.mockito.ArgumentCaptor.forClass(List.class);
+        verify(jedis).eval(anyString(), anyList(), argsCap.capture());
+        List<String> argv = argsCap.getValue();
+        assertThat(argv).hasSize(7);
+        assertThat(argv.get(6)).isEqualTo("400");
+    }
+
+    /**
+     * Negative spent: Lua validates and returns INVALID_REQUEST. Java maps
+     * to GovernanceException with 400. This guards the runtime-side check in
+     * case Bean Validation gets bypassed (e.g., direct controller invocation
+     * in a test harness).
+     */
+    @Test
+    void fund_resetSpent_rejectsNegativeSpent() {
+        List<String> luaResult = List.of("INVALID_REQUEST", "spent must be >= 0");
+        when(jedis.eval(anyString(), anyList(), anyList())).thenReturn(luaResult);
+
+        BudgetFundingRequest request = new BudgetFundingRequest();
+        request.setOperation(FundingOperation.RESET_SPENT);
+        request.setAmount(new Amount(UnitEnum.USD_MICROCENTS, 1000L));
+        request.setSpent(new Amount(UnitEnum.USD_MICROCENTS, -1L));
+
+        assertThatThrownBy(() -> repository.fund("tenant-1", "scope", UnitEnum.USD_MICROCENTS, request))
+            .isInstanceOf(io.runcycles.admin.data.exception.GovernanceException.class)
+            .hasMessageContaining("spent must be >= 0");
+    }
+
+    /**
+     * Overdraft-style negative remaining: if the supplied spent plus reserved
+     * and debt exceed allocated, remaining goes negative. No error — matches
+     * existing overdraft ledger semantics. Caller sees the negative value.
+     */
+    @Test
+    void fund_resetSpent_allowsNegativeRemainingWhenOverflow() {
+        // allocated=100, reserved=50, debt=20, spent=200 → remaining=-170
+        List<String> luaResult = List.of("OK",
+            "1000", "100",
+            "0", "-170",
+            "20", "20",
+            "false",
+            "0", "200");
+        when(jedis.eval(anyString(), anyList(), anyList())).thenReturn(luaResult);
+
+        BudgetFundingRequest request = new BudgetFundingRequest();
+        request.setOperation(FundingOperation.RESET_SPENT);
+        request.setAmount(new Amount(UnitEnum.USD_MICROCENTS, 100L));
+        request.setSpent(new Amount(UnitEnum.USD_MICROCENTS, 200L));
+
+        BudgetFundingResponse response = repository.fund("tenant-1", "scope", UnitEnum.USD_MICROCENTS, request);
+
+        assertThat(response.getNewRemaining().getAmount()).isEqualTo(-170L);
+        assertThat(response.getNewSpent().getAmount()).isEqualTo(200L);
+    }
+
+    /**
+     * Verify ARGV[7] is EMPTY when no spent override is supplied (default-0
+     * path). This is important because the Lua script distinguishes empty
+     * from present — an accidental "0" string from a null-unsafe call site
+     * would silently work on a RESET_SPENT but might leak to other ops.
+     */
+    @Test
+    void fund_resetSpent_emptyArgvForDefaultSpent() {
+        List<String> luaResult = List.of("OK",
+            "1000", "1000",
+            "0", "1000",
+            "0", "0",
+            "false",
+            "1000", "0");
+        when(jedis.eval(anyString(), anyList(), anyList())).thenReturn(luaResult);
+
+        BudgetFundingRequest request = new BudgetFundingRequest();
+        request.setOperation(FundingOperation.RESET_SPENT);
+        request.setAmount(new Amount(UnitEnum.USD_MICROCENTS, 1000L));
+        // spent field intentionally null
+
+        repository.fund("tenant-1", "scope", UnitEnum.USD_MICROCENTS, request);
+
+        org.mockito.ArgumentCaptor<List<String>> argsCap = org.mockito.ArgumentCaptor.forClass(List.class);
+        verify(jedis).eval(anyString(), anyList(), argsCap.capture());
+        assertThat(argsCap.getValue().get(6)).isEqualTo("");
+    }
+
+    /**
+     * Idempotent cache replay against the v2 cache format. The cached string
+     * now carries 9 pipe-delimited fields: ...|is_over|prev_spent|new_spent.
+     * Ensure the parser reads prev_spent and new_spent into the response.
+     */
+    @Test
+    void fund_idempotentHit_parsesV2CacheFormatWithSpent() {
+        // v2 cache format: prev_allocated|allocated|prev_remaining|remaining|
+        //                  prev_debt|debt|is_over|prev_spent|new_spent
+        String cached = "1000|1000|0|1000|0|0|false|1000|0";
+        List<String> luaResult = List.of("IDEMPOTENT_HIT", cached);
+        when(jedis.eval(anyString(), anyList(), anyList())).thenReturn(luaResult);
+
+        BudgetFundingRequest request = new BudgetFundingRequest();
+        request.setOperation(FundingOperation.RESET_SPENT);
+        request.setAmount(new Amount(UnitEnum.USD_MICROCENTS, 1000L));
+        request.setIdempotencyKey("same-key-retry");
+
+        BudgetFundingResponse response = repository.fund("tenant-1", "scope", UnitEnum.USD_MICROCENTS, request);
+
+        assertThat(response.getPreviousSpent().getAmount()).isEqualTo(1000L);
+        assertThat(response.getNewSpent().getAmount()).isEqualTo(0L);
+    }
+
     @Test
     void list_cursorPagination_skipsEntriesBeforeCursor() {
         Set<String> keys = new LinkedHashSet<>(List.of("budget:a:USD_MICROCENTS", "budget:b:USD_MICROCENTS", "budget:c:USD_MICROCENTS"));

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/budget/BudgetFundingRequest.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/budget/BudgetFundingRequest.java
@@ -10,6 +10,15 @@ import java.util.Map;
 public class BudgetFundingRequest {
     @NotNull @JsonProperty("operation") private FundingOperation operation;
     @NotNull @Valid @JsonProperty("amount") private Amount amount;
+
+    /**
+     * Only honoured for {@link FundingOperation#RESET_SPENT}; ignored for other operations.
+     * When omitted on a RESET_SPENT, spent defaults to 0 (fresh period).
+     * When supplied, sets spent to this exact value — must be {@code >= 0}.
+     * The amount unit must match the request's {@link #amount} unit (enforced in the controller).
+     */
+    @Valid @JsonProperty("spent") private Amount spent;
+
     @Size(max = 512) @JsonProperty("reason") private String reason;
     @Size(min = 1, max = 256) @JsonProperty("idempotency_key") private String idempotencyKey;
     @JsonProperty("metadata") private Map<String, Object> metadata;

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/budget/BudgetFundingResponse.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/budget/BudgetFundingResponse.java
@@ -13,5 +13,18 @@ public class BudgetFundingResponse {
     @NotNull @JsonProperty("new_remaining") private Amount newRemaining;
     @JsonInclude(JsonInclude.Include.NON_NULL) @JsonProperty("previous_debt") private Amount previousDebt;
     @JsonInclude(JsonInclude.Include.NON_NULL) @JsonProperty("new_debt") private Amount newDebt;
+
+    /**
+     * Spent before the operation. Present when the operation affects spent
+     * (RESET_SPENT). For preserve-spent operations (CREDIT, DEBIT, RESET,
+     * REPAY_DEBT), {@code previousSpent == newSpent} when both are emitted —
+     * a visual no-op-on-spent confirmation for callers.
+     * Added in spec v0.1.25.17.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL) @JsonProperty("previous_spent") private Amount previousSpent;
+
+    /** Spent after the operation. Added in spec v0.1.25.17. */
+    @JsonInclude(JsonInclude.Include.NON_NULL) @JsonProperty("new_spent") private Amount newSpent;
+
     @JsonInclude(JsonInclude.Include.NON_NULL) @JsonProperty("timestamp") private Instant timestamp;
 }

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/budget/FundingOperation.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/budget/FundingOperation.java
@@ -1,2 +1,18 @@
 package io.runcycles.admin.model.budget;
-public enum FundingOperation { CREDIT, DEBIT, RESET, REPAY_DEBT }
+
+/**
+ * Funding operation kinds for {@link BudgetFundingRequest}, per spec
+ * {@code cycles-governance-admin-v0.1.25.yaml} {@code BudgetFundingRequest.operation} enum.
+ *
+ * <ul>
+ *   <li>{@link #CREDIT}, {@link #DEBIT}: adjust allocated + remaining together.
+ *       Preserve spent/reserved/debt.</li>
+ *   <li>{@link #RESET}: resize the allocated ceiling to an exact amount.
+ *       Preserves spent/reserved/debt. NOT for billing-period boundaries.</li>
+ *   <li>{@link #RESET_SPENT} (v0.1.25.17+): start a new billing period.
+ *       Sets allocated to the amount and sets spent to the optional
+ *       {@code spent} field (defaults to 0). Preserves reserved and debt.</li>
+ *   <li>{@link #REPAY_DEBT}: reduce debt by amount (uses remaining if debt &lt; amount).</li>
+ * </ul>
+ */
+public enum FundingOperation { CREDIT, DEBIT, RESET, REPAY_DEBT, RESET_SPENT }

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/BudgetOperation.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/BudgetOperation.java
@@ -8,6 +8,7 @@ public enum BudgetOperation {
     CREDIT,
     DEBIT,
     RESET,
+    RESET_SPENT,
     REPAY_DEBT,
     STATUS_CHANGE,
     CREATE,

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventDataBudgetLifecycle.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventDataBudgetLifecycle.java
@@ -35,6 +35,16 @@ public class EventDataBudgetLifecycle {
     @JsonProperty("new_state")
     private BudgetState newState;
 
+    /**
+     * Only populated on {@code budget.reset_spent}. True when the request
+     * explicitly supplied a {@code spent} field (migration, proration,
+     * compensation, or correction), false when spent defaulted to 0
+     * (routine period rollover).
+     * Added in spec v0.1.25.17.
+     */
+    @JsonProperty("spent_override_provided")
+    private Boolean spentOverrideProvided;
+
     @JsonProperty("reason")
     private String reason;
 
@@ -53,6 +63,23 @@ public class EventDataBudgetLifecycle {
 
         @JsonProperty("debt")
         private Long debt;
+
+        /**
+         * Spent component of the budget state. Populated on
+         * {@code budget.reset_spent} pre/post snapshots so consumers
+         * can see the transition. Added in spec v0.1.25.17.
+         */
+        @JsonProperty("spent")
+        private Long spent;
+
+        /**
+         * Reserved component of the budget state. Populated on
+         * {@code budget.reset_spent} pre/post snapshots so consumers
+         * can see what carried forward across the period boundary.
+         * Added in spec v0.1.25.17.
+         */
+        @JsonProperty("reserved")
+        private Long reserved;
 
         @JsonProperty("status")
         private String status;

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventPayloadTypeMapping.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventPayloadTypeMapping.java
@@ -38,6 +38,7 @@ public final class EventPayloadTypeMapping {
         m.put(EventType.BUDGET_FUNDED, EventDataBudgetLifecycle.class);
         m.put(EventType.BUDGET_DEBITED, EventDataBudgetLifecycle.class);
         m.put(EventType.BUDGET_RESET, EventDataBudgetLifecycle.class);
+        m.put(EventType.BUDGET_RESET_SPENT, EventDataBudgetLifecycle.class);
         m.put(EventType.BUDGET_DEBT_REPAID, EventDataBudgetLifecycle.class);
         m.put(EventType.BUDGET_FROZEN, EventDataBudgetLifecycle.class);
         m.put(EventType.BUDGET_UNFROZEN, EventDataBudgetLifecycle.class);

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventType.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventType.java
@@ -4,12 +4,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum EventType {
-    // Budget lifecycle (15)
+    // Budget lifecycle
     BUDGET_CREATED("budget.created", EventCategory.BUDGET),
     BUDGET_UPDATED("budget.updated", EventCategory.BUDGET),
     BUDGET_FUNDED("budget.funded", EventCategory.BUDGET),
     BUDGET_DEBITED("budget.debited", EventCategory.BUDGET),
     BUDGET_RESET("budget.reset", EventCategory.BUDGET),
+    BUDGET_RESET_SPENT("budget.reset_spent", EventCategory.BUDGET),
     BUDGET_DEBT_REPAID("budget.debt_repaid", EventCategory.BUDGET),
     BUDGET_FROZEN("budget.frozen", EventCategory.BUDGET),
     BUDGET_UNFROZEN("budget.unfrozen", EventCategory.BUDGET),

--- a/cycles-admin-service/cycles-admin-service-model/src/test/java/io/runcycles/admin/model/EventModelTest.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/test/java/io/runcycles/admin/model/EventModelTest.java
@@ -39,7 +39,11 @@ class EventModelTest {
 
     @Test
     void eventType_allTypesHaveExpectedCount() {
-        assertEquals(40, EventType.values().length);
+        // 41 = original 40 + BUDGET_RESET_SPENT (added in spec v0.1.25.17 alongside
+        // the RESET_SPENT funding operation). When adding new event types, bump
+        // this count and ensure the new type is also registered in
+        // EventPayloadTypeMapping (enforced by EventPayloadContractTest).
+        assertEquals(41, EventType.values().length);
     }
 
     @Test

--- a/cycles-admin-service/pom.xml
+++ b/cycles-admin-service/pom.xml
@@ -18,7 +18,7 @@
         <module>cycles-admin-service-api</module>
     </modules>
     <properties>
-        <revision>0.1.25.17</revision>
+        <revision>0.1.25.18</revision>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/docker-compose.full-stack.prod.yml
+++ b/docker-compose.full-stack.prod.yml
@@ -13,7 +13,7 @@ services:
       retries: 5
 
   cycles-admin:
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.16
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.18
     restart: unless-stopped
     ports:
       - "7979:7979"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,7 +13,7 @@ services:
       retries: 5
 
   cycles-admin:
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.16
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.18
     restart: unless-stopped
     ports:
       - "7979:7979"


### PR DESCRIPTION
## Summary

Closes the long-standing gap between the docs (which describe RESET as *"for resetting a scope for a new billing period"*) and the RESET implementation (which only resizes the allocated ceiling and preserves spent — a strict no-op on an exhausted budget when re-RESET to the same allocated amount). Adds the new **`RESET_SPENT`** funding operation paired with the cycles-protocol#45 spec PR.

**Approach:** add a new operation, don't redefine RESET. Keeps RESET symmetric with CREDIT/DEBIT/REPAY_DEBT as a history-preserving ceiling adjustment; `RESET_SPENT` owns the billing-period semantic. No existing caller sees behaviour drift.

## Coordination

**Depends on `runcycles/cycles-protocol#45`** — the spec PR. Admin contract test fetches `cycles-protocol@main`; this PR's tests pass against the spec PR branch (set `-Dcontract.spec.url=...`) and will pass against `main` once #45 merges. **Spec PR must merge first.**

## Implementation

### Lua (`BudgetRepository.java`)

New branch (RESET branch unchanged):

```lua
elseif op == 'RESET_SPENT' then
  allocated = amount
  if spent_override_arg ~= '' then
    spent = tonumber(spent_override_arg)
    if spent == nil or spent < 0 then
      return {'INVALID_REQUEST', 'spent must be >= 0'}
    end
  else
    spent = 0
  end
  remaining = allocated - spent - reserved - debt
end
```

Lua return array extended 8→10 (adds `prev_spent`, `new_spent`). Idempotency cache key prefix bumped `idempotency:fund:` → `idempotency:fund:v2:` so old/new coexist during deploy and old entries expire naturally in 24h.

### Optional `spent` parameter

Covers four operator needs beyond routine rollovers: migration from another billing system, prorated mid-period signup, credit-back / compensation, state correction. Constrained to `>= 0`. Validated at controller (Bean Validation + unit-mismatch + operation match) AND Lua (defensive `INVALID_REQUEST`).

### New event type: `budget.reset_spent`

Distinct from `budget.reset`. Lets event consumers route period boundaries separately from resize events. Payload's new `spent_override_provided` boolean distinguishes routine rollovers from explicit adjustments needing compliance scrutiny.

### Audit metadata enriched

`previous_spent` / `new_spent` recorded on every fund operation (visual no-op for preserve-spent ops); `spent_override_provided` on RESET_SPENT only.

## Verification

Local — full verify against spec PR branch:

```bash
mvn -B verify -f cycles-admin-service/pom.xml \
  -Dcontract.spec.url='https://raw.githubusercontent.com/runcycles/cycles-protocol/spec/budget-reset-spent-v0.1.25.17/cycles-governance-admin-v0.1.25.yaml'
```

Result: **518 tests pass** (up from 512 — added 11 tests across BudgetRepositoryTest and BudgetControllerTest, plus a count-bump in EventModelTest), JaCoCo coverage met (≥95%), spec coverage 43/43.

Once cycles-protocol#45 merges, default contract URL (cycles-protocol@main) will validate cleanly with no flag override.

## Files changed (16)

| Layer | File | Change |
|---|---|---|
| Model | `FundingOperation.java` | Add RESET_SPENT enum + javadoc |
| Model | `BudgetFundingRequest.java` | Add optional `spent` Amount field |
| Model | `BudgetFundingResponse.java` | Add nullable `previous_spent` / `new_spent` |
| Model | `event/BudgetOperation.java` | Add RESET_SPENT |
| Model | `event/EventType.java` | Add `BUDGET_RESET_SPENT` |
| Model | `event/EventPayloadTypeMapping.java` | Map new event type |
| Model | `event/EventDataBudgetLifecycle.java` | Add `spent`/`reserved` to BudgetState; `spent_override_provided` flag |
| Data | `BudgetRepository.java` | New Lua branch + extended return array + v2 cache prefix + Java parser update |
| API | `BudgetController.java` | Validate optional `spent`; emit BUDGET_RESET_SPENT with full BudgetState pre/post snapshots; enrich audit metadata |
| Tests | `BudgetRepositoryTest.java` | +6 tests covering default, override, negative-spent, overdraft-allowed, ARGV-empty, v2-cache |
| Tests | `BudgetControllerTest.java` | +5 tests covering default, override, wrong-op, negative-spent, unit-mismatch |
| Tests | `EventModelTest.java` | Bump expected event count 40 → 41 |
| Build | `pom.xml` | Version 0.1.25.17 → 0.1.25.18 |
| Ops | `docker-compose.prod.yml` | Pin cycles-server-admin → 0.1.25.18 |
| Ops | `docker-compose.full-stack.prod.yml` | Pin cycles-server-admin → 0.1.25.18 |
| Docs | `AUDIT.md` | Release entry + Date header |

## Backward compatibility

Additive. Existing RESET behaviour unchanged. New fields are nullable / optional; new enum values follow the spec's existing extensibility policy (consumers MUST ignore unrecognised enum values). Existing callers see no difference.

## Test plan

- [x] All 518 tests pass (`mvn verify` against spec PR branch)
- [x] JaCoCo coverage ≥95%
- [x] Spec coverage 43/43
- [x] Backward-compatible: existing RESET tests still pass with no modification
- [ ] CI passes once cycles-protocol#45 merges (then default contract URL validates cleanly)

## Cross-refs

- `runcycles/cycles-protocol#45` — spec PR (must merge first)
- Upcoming docs PR: split `how-to/budget-allocation-and-management-in-cycles#resetting-budgets` into "Resizing a budget" (RESET) + "Starting a new billing period" (RESET_SPENT)