### PR TITLE
feat(auth): v0.1.25.19 /v1/auth/introspect dual-auth + operator docs

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,9 +1,61 @@
 # Complete Budget Governance v0.1.25.8 — Admin Server Audit
 
-**Server version:** 0.1.25.18 (2026-04-15 — RESET_SPENT operation: billing-period boundary)
-**Date:** 2026-04-15 (v0.1.25.18 RESET_SPENT operation), 2026-04-14 (v0.1.25.17 cjson round-trip sweep: apikey + policy + tenant), 2026-04-13 (v0.1.25.16 webhooks dual-auth), 2026-04-13 (v0.1.25.15 ScopeValidator), 2026-04-13 (v0.1.25.14 admin-on-behalf-of dual-auth), 2026-04-13 (v0.1.25.13 CORS PUT fix), 2026-04-12 (v0.1.25.12 spec-compliance hardening + observability), 2026-04-12 (v0.1.25.11 contract-testing default ON), 2026-04-12 (v0.1.25.10 spec-compliance hardening), 2026-04-10 (v0.1.25.9 release), 2026-04-10 (CORS hardening + prod config), 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
-**Spec:** [`cycles-governance-admin-v0.1.25.yaml`](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml) (OpenAPI 3.1.0, v0.1.25.11) in [cycles-protocol](https://github.com/runcycles/cycles-protocol)
+**Server version:** 0.1.25.19 (2026-04-16 — /v1/auth/introspect dual-auth: spec v0.1.25.15)
+**Date:** 2026-04-16 (v0.1.25.19 introspect dual-auth + operator docs), 2026-04-15 (v0.1.25.18 RESET_SPENT operation), 2026-04-14 (v0.1.25.17 cjson round-trip sweep: apikey + policy + tenant), 2026-04-13 (v0.1.25.16 webhooks dual-auth), 2026-04-13 (v0.1.25.15 ScopeValidator), 2026-04-13 (v0.1.25.14 admin-on-behalf-of dual-auth), 2026-04-13 (v0.1.25.13 CORS PUT fix), 2026-04-12 (v0.1.25.12 spec-compliance hardening + observability), 2026-04-12 (v0.1.25.11 contract-testing default ON), 2026-04-12 (v0.1.25.10 spec-compliance hardening), 2026-04-10 (v0.1.25.9 release), 2026-04-10 (CORS hardening + prod config), 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
+**Spec:** [`cycles-governance-admin-v0.1.25.yaml`](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml) (OpenAPI 3.1.0, info.version `0.1.25.16`; content includes RESET_SPENT from spec PR #45 v0.1.25.17) in [cycles-protocol](https://github.com/runcycles/cycles-protocol)
 **Server:** Spring Boot 3.5.11 / Java 21 / Redis
+
+### 2026-04-16 — v0.1.25.19 /v1/auth/introspect dual-auth + operator docs (spec v0.1.25.15)
+
+Closes the one remaining parity gap against the admin spec: `GET /v1/auth/introspect` now accepts both `AdminKeyAuth` (admin-shape) and `ApiKeyAuth` (tenant-shape) per spec v0.1.25.15 (cycles-protocol@101416f, yaml:3066-3198 + 4703-4768). Prior admin releases returned the admin-only stub that the spec's BACKWARD COMPATIBILITY clause (yaml:225-228, 4729-4734) explicitly allows as a forward-compat position — this release closes the gap so tenants can introspect their own API keys through the dashboard.
+
+Also introduces consumer-facing `CHANGELOG.md` and operator-facing `OPERATIONS.md`, mirroring the shape just added to cycles-server (CHANGELOG.md + OPERATIONS.md per cycles-server PR #98). `AUDIT.md` remains the engineering-history log; `CHANGELOG.md` is the summary for downstream consumers pulling the Docker image / JAR.
+
+**Parity audit context.** Full review of cycles-governance-admin-v0.1.25.yaml revisions v0.1.25.11 → v0.1.25.17 found every spec change already covered in prior admin releases (v0.1.25.11–v0.1.25.18) except the introspect dual-auth contract from v0.1.25.15. cycles-server recently mirrored `BUDGET_RESET_SPENT` into its runtime `EventType` vocabulary (cycles-server PR #103); admin has had this enum value since v0.1.25.18 — no action required.
+
+**Auth-shape semantics (NORMATIVE, yaml:3105-3166).**
+
+| Branch | `auth_type` | `permissions` | `tenant_id` | `scope_filter` | Capabilities |
+|---|---|---|---|---|---|
+| AdminKeyAuth (X-Admin-API-Key) | `"admin"` | `["*"]` | **absent** | **absent** | all 15 flags true |
+| ApiKeyAuth (X-Cycles-API-Key) | `"tenant"` | concrete key perms | tenant id (required) | key `scope_filter` if non-empty | derived per table; admin-plane caps forced false |
+
+Admin-plane capabilities (`view_tenants`, `view_api_keys`, `view_audit`, `view_overview`, `manage_tenants`, `manage_api_keys`) are hard-coded to `false` under tenant auth regardless of any `admin:*` permissions on the key (yaml:3138-3147 — prevents accidental admin-UI elevation via legacy admin-permission tenant keys).
+
+**Changes:**
+
+| File | Change |
+|---|---|
+| `cycles-admin-service-api/.../config/AuthInterceptor.java` | `/v1/auth/introspect` removed from `requiresAdminKey()`; added to `ADMIN_ALLOWED_ENDPOINTS` (exact dual-auth match) and `requiresApiKey()` path set. Tenant keys now stamp `authenticated_tenant_id`/`authenticated_permissions`/`authenticated_scope_filter` on the request; admin keys take the admin-only branch (no attributes stamped). |
+| `cycles-admin-service-api/.../controller/AuthController.java` | Rewrote `introspect()` to branch on `authenticated_tenant_id` attribute. New helpers `allCapabilitiesTrue()` (admin-shape) and `deriveTenantCapabilities(List<String>)` (tenant-shape per NORMATIVE table). Obsolete `deriveCapabilities(List<String>)` removed. |
+| `cycles-admin-service-model/.../auth/AuthIntrospectResponse.java` | Added nullable `tenant_id` (`@JsonInclude(NON_NULL)`) and `scope_filter` (`@JsonInclude(NON_EMPTY)`). Per-field include overrides class-level `ALWAYS` so admin-shape stays wire-identical to pre-v0.1.25.19. |
+| `cycles-admin-service-model/.../auth/Capabilities.java` | Added 7 optional boxed-`Boolean` fields (`view_reservations`, `manage_budgets`, `manage_policies`, `manage_webhooks`, `manage_tenants`, `manage_api_keys`, `manage_reservations`) each with `@JsonInclude(NON_NULL)`. Absent by default — legacy consumers see unchanged wire output. |
+| `cycles-admin-service-api/.../controller/AuthControllerTest.java` | +5 tests: admin-shape now asserts all 15 caps true + absence of tenant_id/scope_filter; 4 new tenant-shape tests including NORMATIVE admin-plane forced-false guard and scope_filter omit/include. Existing `introspect_withoutAdminKey_returns401` → `introspect_withoutAnyKey_returns401`. |
+| `cycles-admin-service-api/.../config/AuthInterceptorTest.java` | +3 tests: tenant-key success with attribute stamping, invalid-tenant-key 403, zero-permission minimal-key success (no required permission on introspect). Existing admin-key test updated to assert no tenant-auth attributes. |
+| `cycles-admin-service-model/.../AuthModelTest.java` | +5 serialization tests: admin-shape omits tenant_id+scope_filter; tenant-shape includes both; empty scope_filter omitted; legacy Capabilities shape omits all 7 new manage_* fields; full-caps shape serializes all 15. |
+| `cycles-admin-service-api/.../integration/AdminFlowIntegrationTest.java` | New step 17b tenant-key introspect call (before step 18's key revoke), validated through `ContractValidatingRestTemplateInterceptor` against `cycles-protocol@main` — admin-plane caps asserted false, tenant-plane caps derived from step 5's granted permissions. |
+| `pom.xml` | `revision` 0.1.25.18 → 0.1.25.19. |
+| `README.md` | Spec ref line updated v0.1.25.14 → v0.1.25.15. |
+| `docker-compose.prod.yml` + `docker-compose.full-stack.prod.yml` | Image tag bumped 0.1.25.18 → 0.1.25.19. |
+| `CHANGELOG.md` (new) | Consumer-facing Keep-a-Changelog format, entries v0.1.25.10 → v0.1.25.19. |
+| `OPERATIONS.md` (new) | Operator-facing runbook: metrics inventory, alerts, tuning, incident playbook. |
+
+**Design choices:**
+- **Per-field Jackson include overrides class-level `ALWAYS`.** Chose this over restructuring into two response classes because spec has one schema (`AuthIntrospectResponse`) with optional fields — two-class split would drift from spec. `@JsonInclude(NON_NULL)` on `tenantId` and `@JsonInclude(NON_EMPTY)` on `scopeFilter` preserve wire compatibility with pre-v0.1.25.19 admin-shape responses.
+- **Boxed `Boolean` for the 7 optional caps.** Primitive `boolean` defaults to `false` and would serialize (with `ALWAYS` class-level inclusion), breaking pre-v0.1.25.19 wire compatibility for consumers parsing the admin shape.
+- **NORMATIVE admin-plane forced-false under tenant auth.** Dashboard security boundary. Legacy tenant keys with `admin:read`/`admin:write` still govern per-endpoint access control (unchanged in `AuthInterceptor.hasPermission()`) but MUST NOT lift the dashboard's admin-UI chrome.
+- **No new endpoint; no operationId change.** `introspectAuth` already existed; only its security schemes + response shape expand. `OpenApiContractDiffTest` reports zero INCOMPATIBLE diff.
+
+**Verification:**
+- `mvn verify` passes 528 tests (up from 518), JaCoCo ≥95% on all modules, `SpecCoverageReportTest` 43/43 endpoints.
+- `ContractValidationConfig` validates all introspect responses (admin + tenant shapes) against the pinned spec on `cycles-protocol@main` — zero drift.
+- `OpenApiContractDiffTest` vs live spec: zero INCOMPATIBLE diff; added optional fields on `AuthIntrospectResponse`/`Capabilities` show as COMPATIBLE (additive).
+
+**Wire format:** additive. Pre-v0.1.25.19 admin-shape responses remain byte-identical. New tenant-shape and optional cap fields only materialize when the new code paths / new cap setters fire. Existing admin-key callers see no change.
+
+**Cross-refs:** implements [cycles-protocol#43](https://github.com/runcycles/cycles-protocol/pull/43) spec v0.1.25.15 (tenant-introspect dual-auth).
+
+---
 
 ### 2026-04-15 — v0.1.25.18 RESET_SPENT operation: billing-period boundary
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,219 @@
+# Changelog
+
+All notable changes to `cycles-server-admin` are recorded here. Format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions use
+[Semantic-ish Versioning](https://semver.org/) with a fourth "patch-of-patch"
+segment for same-day follow-ups.
+
+This file is for **downstream consumers** — people pulling the Docker image or
+JAR. For internal engineering history (root cause analyses, rejected
+alternatives, test-strategy decisions) see [`AUDIT.md`](AUDIT.md).
+
+Wire format is considered stable within a minor version (`0.1.x`). Breaking
+changes to request/response bodies or Lua-script semantics would require a
+minor bump. Additive fields (new optional response fields, new enum values,
+new optional request fields) are **not** considered breaking.
+
+## [0.1.25.19] — 2026-04-16
+
+### Added
+
+- `GET /v1/auth/introspect` now accepts both `AdminKeyAuth` (X-Admin-API-Key)
+  and `ApiKeyAuth` (X-Cycles-API-Key) per spec v0.1.25.15. Admin keys
+  continue to return the admin-shape response (`auth_type=admin`,
+  `permissions=["*"]`, all 15 capability flags true, no `tenant_id` /
+  `scope_filter`). Tenant API keys now receive a tenant-shape response
+  (`auth_type=tenant`, concrete permissions, `tenant_id`, optional
+  `scope_filter`) with capabilities derived per the NORMATIVE capability
+  table in the spec. Admin-plane capabilities (`view_tenants`,
+  `view_api_keys`, `view_audit`, `view_overview`, `manage_tenants`,
+  `manage_api_keys`) are forced to `false` under tenant auth regardless
+  of any `admin:*` permissions on the key.
+- `AuthIntrospectResponse` schema: added optional `tenant_id` and
+  `scope_filter` fields (absent under admin auth, present under tenant auth).
+- `Capabilities` schema: added 7 optional boolean fields
+  (`view_reservations`, `manage_budgets`, `manage_policies`,
+  `manage_webhooks`, `manage_tenants`, `manage_api_keys`,
+  `manage_reservations`). Absent by default — legacy admin-shape responses
+  from clients that don't set them stay wire-identical to pre-0.1.25.19.
+- Operator docs: new [`OPERATIONS.md`](OPERATIONS.md) runbook covering
+  metrics inventory, alerts, configuration tuning, and incident playbook.
+- Consumer-facing [`CHANGELOG.md`](CHANGELOG.md) (this file) — summaries for
+  Docker/JAR pullers; `AUDIT.md` remains the engineering-history log.
+
+### Wire format
+
+Additive. Admin-shape introspect responses remain byte-identical to
+0.1.25.18. Tenant-shape responses and optional capability fields only
+materialize under the new code paths. No breaking changes; clients built
+against 0.1.25.18 parse 0.1.25.19 responses correctly.
+
+### Notes for upgraders
+
+- No configuration changes required. Dashboard-grade clients may now call
+  `/v1/auth/introspect` with a tenant API key to render permission-gated UI;
+  clients that only use the admin key see no change.
+- If you're building a multi-role dashboard (admin + tenant), switch on
+  `auth_type` in the response to render the right surface. Treat
+  `tenant_id`/`scope_filter` as optional — absent means the caller is an
+  admin.
+
+## [0.1.25.18] — 2026-04-15
+
+### Added
+
+- `RESET_SPENT` funding operation on `POST /v1/admin/budgets/fund`. Closes
+  the billing-period rollover gap: `RESET` resizes the allocated ceiling but
+  preserves `spent`; `RESET_SPENT` additionally clears (or overrides)
+  `spent` to start a fresh billing period. Optional `spent` request field
+  (defaults to `0`; constrained `>= 0`) covers migration, proration,
+  credit-back, and state-correction use cases.
+- New `budget.reset_spent` event type, distinct from `budget.reset`.
+  `EventPayloadTypeMapping` routes it to `EventDataBudgetLifecycle`.
+- `BudgetFundingResponse` gains nullable `previous_spent` + `new_spent`
+  fields (present on `RESET_SPENT`, absent on other operations).
+- `EventDataBudgetLifecycle`: added `spent` and `reserved` to `BudgetState`;
+  new optional `spent_override_provided` flag on the outer payload.
+
+### Fixed
+
+- Negative `spent` override rejected at both controller (Bean Validation) and
+  Lua layers (`INVALID_REQUEST` → 400).
+
+### Wire format
+
+Additive. Existing `RESET` callers are unaffected. New enum values follow
+the spec's existing extensibility policy ("consumers MUST ignore
+unrecognised enum values").
+
+### Notes for upgraders
+
+- Operators transitioning from `RESET` for billing rollovers: switch to
+  `RESET_SPENT`. `RESET`'s semantics (preserve `spent`) are unchanged and
+  remain correct for ceiling-only resizes.
+- Idempotency cache key versioned to `idempotency:fund:v2:`. Old v1 entries
+  expire naturally within 24h; rolling deploys are safe.
+
+## [0.1.25.17] — 2026-04-14
+
+### Fixed
+
+- API-key revocation list drop ([dashboard#43](https://github.com/runcycles/cycles-dashboard/issues/43)):
+  `ApiKey.permissions` / `scope_filter` empty lists were serialized as
+  `{}` (object) instead of `[]` (array) after Lua cjson round-trips,
+  causing downstream Jackson deserialization to silently drop the record
+  from `GET /v1/admin/api-keys` responses.
+- Same cjson empty-array bug also closed on `Policy.caps.tool_allowlist` /
+  `tool_denylist` and (defensively) on `Tenant.metadata`. All three write
+  paths migrated off Lua-cjson to Jackson-in-Java read/mutate/write.
+- New lenient Jackson deserializer (`LenientStringListDeserializer`) keeps
+  legacy cjson-corrupted records readable — fleet self-heals on the next
+  mutating admin call against each record.
+- `PATCH /v1/admin/api-keys/{id}` and `POST /v1/admin/api-keys` no longer
+  fail with opaque `400 Malformed request body` on unknown permission
+  strings. Permissions typed `List<String>` at the DTO; validation moved
+  into the repository; 400 response now names the unrecognized value.
+- `revokeApiKey` on an already-revoked key now returns `409` with
+  `error=KEY_REVOKED` per spec (was: `200 OK` with the stored record).
+
+### Wire format
+
+Additive deserializer on read; new 409 response code on a specific branch
+that was previously 200. Clients that handled 200 on re-revoke idempotently
+should switch to treating 409 as success-equivalent.
+
+## [0.1.25.16] — 2026-04-13
+
+### Added
+
+- Dual-auth on 6 tenant-scoped webhook endpoints per spec v0.1.25.14:
+  `GET /v1/webhooks`, `GET /v1/webhooks/{id}`, `PATCH /v1/webhooks/{id}`,
+  `DELETE /v1/webhooks/{id}`, `POST /v1/webhooks/{id}/test`,
+  `GET /v1/webhooks/{id}/deliveries`. Admin operators can pause, inspect,
+  or force-delete tenant-provisioned webhooks during incident response
+  without the tenant's API key. `POST /v1/webhooks` (create) intentionally
+  remains tenant-only — admin-creating-on-tenant-behalf would entangle
+  provenance and obscure the audit trail.
+
+## [0.1.25.15] — 2026-04-13
+
+### Added
+
+- `ScopeValidator`: enforces canonical Cycles Protocol scope grammar on
+  budget creation / lookup and policy scope patterns. First segment must
+  be `tenant:<id>`; canonical kind order is `tenant → workspace → app →
+  workflow → agent → toolset`; wildcards allowed only in policy patterns
+  and only as a terminal segment.
+
+### Fixed
+
+- Rejects out-of-order scope segments, duplicate kinds, non-canonical kinds,
+  and malformed ids with `400 INVALID_REQUEST`.
+
+## [0.1.25.14] — 2026-04-13
+
+### Added
+
+- Dual-auth on `POST /v1/admin/budgets`, `POST /v1/admin/policies`, and
+  `PATCH /v1/admin/policies/{id}` per spec v0.1.25.13. Admin operators can
+  provision budgets and policies on behalf of tenants during onboarding /
+  migration / incident response. Body MUST include `tenant_id` under admin
+  auth; controllers enforce, and audit-log records `actor_type=admin_on_behalf_of`.
+
+## [0.1.25.13] — 2026-04-13
+
+### Fixed
+
+- `PUT /v1/admin/config/webhook-security` now works from browser dashboards.
+  CORS `allowedMethods` was missing `PUT`, so the browser preflight
+  rejected the request with 403 before it reached the server
+  ([dashboard#30](https://github.com/runcycles/cycles-dashboard/issues/30)).
+
+## [0.1.25.12] — 2026-04-12
+
+### Added
+
+- Targeted 404/409 error responses on admin endpoints that emit them (spec
+  v0.1.25.12 hardening).
+- Documented 400 Bad Request on every admin operation (additive to error
+  contracts).
+- Spec-compliance hardening pass across 16 drift points identified in the
+  prior audit (see `AUDIT.md` for the full list).
+
+## [0.1.25.11] — 2026-04-12
+
+### Added
+
+- Contract testing default ON. `ContractValidationConfig` is now imported
+  by every `*ControllerTest` and validates every 2xx/4xx/5xx JSON body
+  against the pinned spec from `cycles-protocol@main` at build time.
+  `SpecCoverageReportTest` fails the build on any spec operation with
+  zero tests.
+
+### Notes for upgraders
+
+- Offline/air-gapped builds: set `CONTRACT_VALIDATION_ENABLED=false` or
+  pass `-Dcontract.validation.enabled=false` to skip remote spec fetch.
+
+## [0.1.25.10] — 2026-04-12
+
+### Added
+
+- `Permission` enum + typed `Capabilities` class. Eliminates stringly-typed
+  permission handling at the auth-interceptor and introspect boundaries.
+
+### Fixed
+
+- Multiple spec-compliance hardening fixes across controllers and error
+  contracts (see `AUDIT.md` for the full list).
+
+[0.1.25.19]: https://github.com/runcycles/cycles-server-admin/releases/tag/0.1.25.19
+[0.1.25.18]: https://github.com/runcycles/cycles-server-admin/releases/tag/0.1.25.18
+[0.1.25.17]: https://github.com/runcycles/cycles-server-admin/releases/tag/0.1.25.17
+[0.1.25.16]: https://github.com/runcycles/cycles-server-admin/releases/tag/0.1.25.16
+[0.1.25.15]: https://github.com/runcycles/cycles-server-admin/releases/tag/0.1.25.15
+[0.1.25.14]: https://github.com/runcycles/cycles-server-admin/releases/tag/0.1.25.14
+[0.1.25.13]: https://github.com/runcycles/cycles-server-admin/releases/tag/0.1.25.13
+[0.1.25.12]: https://github.com/runcycles/cycles-server-admin/releases/tag/0.1.25.12
+[0.1.25.11]: https://github.com/runcycles/cycles-server-admin/releases/tag/0.1.25.11
+[0.1.25.10]: https://github.com/runcycles/cycles-server-admin/releases/tag/0.1.25.10

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -1,0 +1,273 @@
+# Operations guide
+
+Operator-facing runbook for running `cycles-server-admin` in production.
+Covers metrics, alerting recipes, configuration, and an incident playbook.
+
+Assumes you are already deploying via the published Docker image
+(`ghcr.io/runcycles/cycles-server-admin:<version>`) with Prometheus
+scraping `/actuator/prometheus`. If you haven't set that up yet, see the
+Monitoring section of [`README.md`](README.md) first.
+
+`cycles-server-admin` is the **governance / admin plane** for the Cycles
+Protocol on port `7979` — it owns tenant, budget, policy, API-key, webhook,
+event, and audit CRUD. The **runtime plane** (reservations, commits, the
+sub-10ms decision path) lives in the sibling `cycles-server` repo on port
+`7878` with its own [OPERATIONS.md](https://github.com/runcycles/cycles-server/blob/main/OPERATIONS.md).
+Alerts for the two planes should be routed separately.
+
+## Table of contents
+
+1. [Metrics inventory](#metrics-inventory)
+2. [Alerts worth paging on](#alerts-worth-paging-on)
+3. [Configuration tuning](#configuration-tuning)
+4. [Incident playbook](#incident-playbook)
+
+---
+
+## Metrics inventory
+
+All domain metrics live under the `cycles_admin_*` namespace. Spring Boot
+auto-metrics (`http_server_requests_seconds`, `jvm_*`, `process_*`,
+`logback_events_total`) are also emitted and worth scraping.
+
+### Event emission
+
+| Metric | Tags | What it tells you |
+|---|---|---|
+| `cycles_admin_events_emitted_total` | `type`, `result` | Every domain-event emission. `type` is the event-type value (e.g. `budget.created`); `result=success`/`failure`. |
+| `cycles_admin_events_payload_invalid_total` | `type`, `expected_class` | Orthogonal to the above — increments once per emission where the `data` payload did not round-trip through the `EventPayloadTypeMapping`-assigned class. Any nonzero count is a producer bug (the event is still persisted and dispatched). |
+
+### Webhook dispatch
+
+| Metric | Tags | What it tells you |
+|---|---|---|
+| `cycles_admin_webhook_dispatched_total` | `result` | Every webhook-delivery enqueue attempt. `result=queued` when at least one matching subscription existed and a delivery row was created; `result=failure` on dispatch/enqueue error. This is a dispatch-path counter, not a delivery-outcome one — actual HTTP-delivery outcomes live in the sibling `cycles-server-events` service. |
+
+### HTTP
+
+Standard Spring Boot `http_server_requests_seconds` timer. Good for
+availability SLOs, latency alerts, and per-endpoint traffic shape.
+
+```promql
+# Request rate per endpoint
+sum by (uri) (rate(http_server_requests_seconds_count{job="cycles-server-admin"}[1m]))
+
+# Error rate (5xx only — 400/403/404/409 are protocol-valid responses)
+sum(rate(http_server_requests_seconds_count{job="cycles-server-admin",status=~"5.."}[5m]))
+  / sum(rate(http_server_requests_seconds_count{job="cycles-server-admin"}[5m]))
+```
+
+**Percentile-histogram note (same as cycles-server):** Spring Boot doesn't
+emit histogram buckets by default. To make `histogram_quantile` queries
+return real values, set this in `application.properties`:
+
+```properties
+management.metrics.distribution.percentiles-histogram.http.server.requests=true
+```
+
+Without it, `http_server_requests_seconds_bucket` has no `le`-labelled
+series and p99 alerts silently evaluate to `NaN`. A mean-latency fallback
+alert (`sum / count`) works without any configuration.
+
+---
+
+## Alerts worth paging on
+
+Copy-paste these into your `prometheus.rules.yml` and tune thresholds to
+your actual traffic.
+
+### Availability
+
+```yaml
+- alert: CyclesAdminDown
+  expr: up{job="cycles-server-admin"} == 0
+  for: 2m
+  labels: {severity: page}
+  annotations:
+    summary: cycles-server-admin is down
+    runbook: https://github.com/runcycles/cycles-server-admin/blob/main/OPERATIONS.md#incident-playbook
+
+- alert: CyclesAdminErrorRateHigh
+  # >5% of requests returning 5xx over 5 minutes = actual server problem.
+  # Admin protocol-valid denials (400/401/403/404/409) are deliberately
+  # excluded.
+  expr: |
+    sum(rate(http_server_requests_seconds_count{job="cycles-server-admin",status=~"5.."}[5m]))
+      / sum(rate(http_server_requests_seconds_count{job="cycles-server-admin"}[5m]))
+    > 0.05
+  for: 5m
+  labels: {severity: page}
+```
+
+### Event-payload producer bug
+
+```yaml
+- alert: AdminEventPayloadInvalid
+  # Any nonzero value on this counter means a producer emitted an event
+  # whose `data` didn't round-trip through its EventPayloadTypeMapping
+  # class. This is always a code bug in the admin itself — investigate
+  # on first occurrence.
+  expr: sum(rate(cycles_admin_events_payload_invalid_total[10m])) > 0
+  for: 5m
+  labels: {severity: ticket}
+  annotations:
+    summary: "admin emitted invalid event payload: type={{ $labels.type }}"
+    description: "Check EventService + EventPayloadTypeMapping for the offending type."
+```
+
+### Admin-key misconfiguration
+
+If the admin API key env var isn't set, the server responds to every
+admin-auth request with `500 Server misconfiguration: admin API key not
+set` (`AuthInterceptor.validateAdminKey`). That pattern shows up as a
+spike of 500s on endpoints that require admin auth — the error-rate alert
+above catches it. A more specific alert:
+
+```yaml
+- alert: CyclesAdminKeyMisconfigured
+  # If the server is running but admin.api-key is unset, EVERY request to
+  # admin-only endpoints returns 500. Tight, early alert.
+  expr: |
+    sum(rate(http_server_requests_seconds_count{job="cycles-server-admin",uri=~"/v1/admin/.*",status="500"}[2m])) > 0.05
+  for: 3m
+  labels: {severity: page}
+  annotations:
+    summary: cycles-server-admin is returning 500 on admin endpoints
+    description: "Check ADMIN_API_KEY env var / admin.api-key property on the running pod."
+```
+
+### Webhook dispatch failures
+
+```yaml
+- alert: AdminWebhookDispatchFailureRate
+  # Enqueue failures (Redis stream write) — if this is nonzero, webhook
+  # deliveries are being dropped before the events service can see them.
+  expr: |
+    sum(rate(cycles_admin_webhook_dispatched_total{result="failure"}[5m]))
+      / sum(rate(cycles_admin_webhook_dispatched_total[5m]))
+    > 0.01
+  for: 10m
+  labels: {severity: ticket}
+```
+
+### Redis connectivity (infers from error rate)
+
+The admin server depends on Redis for essentially every operation. A
+Redis outage manifests as a 500-spike on all mutating endpoints. The
+`CyclesAdminErrorRateHigh` alert above catches this. For a more targeted
+signal, scrape the Spring Boot `logback_events_total{level="ERROR"}`
+metric and alert on a rate spike.
+
+---
+
+## Configuration tuning
+
+All configuration is via environment variables or `application.properties`.
+The Docker image reads env vars; source builds read `application.properties`
+with env overrides.
+
+| Property | Env var | Default | Purpose |
+|---|---|---|---|
+| `admin.api-key` | `ADMIN_API_KEY` | (unset — server refuses admin requests) | Shared secret for `X-Admin-API-Key` header on admin-plane endpoints. **Required in production.** |
+| `redis.host` | `REDIS_HOST` | `localhost` | Redis host. |
+| `redis.port` | `REDIS_PORT` | `6379` | Redis port. |
+| `redis.password` | `REDIS_PASSWORD` | (unset) | Redis AUTH password. |
+| `webhook.secret.encryption-key` | `WEBHOOK_SECRET_ENCRYPTION_KEY` | (unset) | Base64 AES-256 key used to encrypt webhook signing secrets at rest. Must match the value on `cycles-server-events`. Rotate by generating a new value, re-encrypting existing secrets, and deploying in lockstep with the events service. |
+| `events.retention.event-ttl-days` | `EVENT_TTL_DAYS` | `90` | Retention for emitted events in Redis. Tune down in high-volume deployments to bound memory. |
+| `events.retention.delivery-ttl-days` | `DELIVERY_TTL_DAYS` | `14` | Retention for webhook-delivery attempt records. |
+| `dashboard.cors.origin` | `DASHBOARD_CORS_ORIGIN` | `http://localhost:5173` | CORS allowed origin(s). Comma-separated. **In production, set to your dashboard URL** — the default only works against the local Vite dev server. |
+| `contract.validation.enabled` | `CONTRACT_VALIDATION_ENABLED` | `true` (tests) / `false` (runtime) | Fetch and validate against the live admin spec at build time. Disable for offline / air-gapped builds. Does not affect runtime — enforcement happens only in the test harness. |
+
+### Rotating the admin API key
+
+1. Generate a new random key (e.g. `openssl rand -base64 32`).
+2. Update `ADMIN_API_KEY` on all admin pods; roll the deployment.
+3. Update every operator tool (dashboards, CI, scripts) with the new key.
+
+Because the admin key is a shared secret (not per-operator), there's no
+revocation surface — the rotation itself is the revocation of the old key.
+All ongoing requests with the old key will get `401` after the last pod
+cuts over. Budget a brief read window where both keys are accepted if
+you have many operator tools (dual-admin-key support is not currently
+implemented — plan a short cutover instead).
+
+### Dashboard CORS
+
+`DASHBOARD_CORS_ORIGIN` is a comma-separated list — `https://dash.example.com,https://staging.example.com`
+is valid. Methods allowed are `GET, POST, PUT, PATCH, DELETE, OPTIONS`
+(explicitly — `PUT` is load-bearing for `PUT /v1/admin/config/webhook-security`).
+Allowed headers: `X-Admin-API-Key, X-Cycles-API-Key, X-Request-Id,
+Content-Type`. If a new auth header or a new HTTP method ever gets added
+to the spec, update `WebConfig.addCorsMappings`.
+
+---
+
+## Incident playbook
+
+### "admin API is returning 500 on everything"
+
+Fastest root-cause check: `kubectl exec -it <admin-pod> -- env | grep -i
+admin_api_key`. If empty or blank, the pod is misconfigured — the
+AuthInterceptor logs `Admin API key is not configured — rejecting admin
+request` on each attempt. Patch the env var and bounce the pod.
+
+### "events are emitting but the dashboard says they're missing data"
+
+Check `cycles_admin_events_payload_invalid_total` — any nonzero count
+points to a specific `type` + `expected_class` mismatch. The event is
+still persisted, but its `data` payload didn't round-trip through its
+mapped class. Engineering fix: inspect `EventPayloadTypeMapping` +
+`EventService.emit` for that `type`, then patch and redeploy.
+
+### "clients getting 400 'Malformed request body' on legitimate requests"
+
+As of v0.1.25.17, the admin API only returns generic `400 Malformed
+request body` for actual Jackson parse failures. Unknown permissions on
+`/v1/admin/api-keys` now return `400 Unrecognized permission: <value>`
+naming the offender. If you see the generic message, it's a real JSON
+parse error — check the client's request body, not the admin.
+
+### "list API-keys is missing some records"
+
+Pre-v0.1.25.17 bug: Lua cjson serialized empty `List<String>` fields
+as `{}` instead of `[]`, causing Jackson to fail to deserialize the
+record (see AUDIT.md v0.1.25.17 for the full root cause). Any record
+that's mutated (revoke, update) on v0.1.25.17+ self-heals to the correct
+wire format. If stale corrupted records are still missing, the
+`LenientStringListDeserializer` added in v0.1.25.17 now parses them
+on read, so upgrading the admin alone (without touching stored data)
+fixes the listing. For a fleet-wide self-heal, touch each record with
+a no-op PATCH.
+
+### "after revoking an admin-key secret, old callers are still getting through"
+
+The admin API key is a shared secret with no revocation surface — rotate
+by generating a new key, updating env vars, and rolling deployments.
+During the rolling deploy, pods with the old `ADMIN_API_KEY` env var
+will still accept the old key. This is not a security regression —
+it's the rotation semantic. Minimize the window by rolling fast.
+
+### "contract tests are red on a PR against cycles-protocol@main"
+
+`ContractValidationConfig` fetches the spec from `cycles-protocol@main`
+at build time. A breaking push to that repo will red the admin's CI
+intentionally, as an early-warning signal. Options:
+1. Fix the admin to match the new spec (usual path).
+2. Point CI at the prior spec tag temporarily:
+   `-Dcontract.spec.url=https://raw.githubusercontent.com/runcycles/cycles-protocol/<tag>/cycles-governance-admin-v0.1.25.yaml`.
+3. Disable contract validation for the local iteration:
+   `-Dcontract.validation.enabled=false`. Don't commit this — CI must
+   keep it on.
+
+For in-flight spec PRs, point the admin PR's `contract.spec.url` at the
+spec-PR branch's raw URL until the spec PR merges. The admin AUDIT.md
+entries call this out when the coordination pattern is used.
+
+---
+
+## Related docs
+
+- [`README.md`](README.md) — quickstart, architecture, build-from-source.
+- [`CHANGELOG.md`](CHANGELOG.md) — consumer-facing release notes.
+- [`AUDIT.md`](AUDIT.md) — internal engineering history.
+- [cycles-server OPERATIONS.md](https://github.com/runcycles/cycles-server/blob/main/OPERATIONS.md) — runtime-plane runbook.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@
 
 # Runcycles Admin Server
 
-Administrative API for the Complete Budget Governance System, aligned with [Cycles Protocol v0.1.25.14](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml).
+Administrative API for the Complete Budget Governance System, aligned with [Cycles Protocol v0.1.25.15](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml).
+
+## Documentation
+
+- **[`CHANGELOG.md`](CHANGELOG.md)** — consumer-facing release notes for downstream consumers pulling the Docker image / JAR.
+- **[`OPERATIONS.md`](OPERATIONS.md)** — operator-facing runbook: metrics inventory, alerting recipes, configuration tuning, incident playbook.
+- **[`AUDIT.md`](AUDIT.md)** — internal engineering history (root cause analyses, rejected alternatives, test-strategy decisions).
 
 ## Overview
 
@@ -273,7 +279,7 @@ curl -X PUT http://localhost:7979/v1/admin/config/webhook-security \
 | `GET` | `/v1/webhooks/{id}/deliveries` | List tenant deliveries | ApiKey |
 | `GET` | `/v1/events` | Query tenant events | ApiKey |
 
-Tenants can subscribe to `budget.*`, `reservation.*`, `tenant.*` (26 of 40 event types). Admin-only: `api_key.*`, `policy.*`, `system.*`.
+Tenants can subscribe to `budget.*`, `reservation.*`, `tenant.*` (27 of 41 event types). Admin-only: `api_key.*`, `policy.*`, `system.*`.
 
 ### Budget Operations (v0.1.25.6)
 
@@ -289,11 +295,11 @@ Tenants can subscribe to `budget.*`, `reservation.*`, `tenant.*` (26 of 40 event
 | Method | Path | Operation | Auth |
 |--------|------|-----------|------|
 | `GET` | `/v1/admin/overview` | Operational health overview | Admin |
-| `GET` | `/v1/auth/introspect` | Auth introspection & capabilities | Admin |
+| `GET` | `/v1/auth/introspect` | Auth introspection & capabilities | ApiKey / Admin |
 
-The overview endpoint returns a single-request aggregated payload with tenant/budget/webhook counts, top-offender arrays (over-limit, debt, failing webhooks), and recent event summaries. The introspect endpoint returns effective capabilities for dashboard UI gating.
+The overview endpoint returns a single-request aggregated payload with tenant/budget/webhook counts, top-offender arrays (over-limit, debt, failing webhooks), and recent event summaries. The introspect endpoint returns effective capabilities for dashboard UI gating — dual-auth as of v0.1.25.19 (spec v0.1.25.15): admin keys return the admin-shape (`auth_type=admin`, all 15 capabilities true); tenant API keys return the tenant-shape (`auth_type=tenant`, `tenant_id`, concrete permissions, derived per-capability flags, admin-plane caps forced to false).
 
-**40 event types** across 6 categories: budget (15), reservation (5), tenant (6), api_key (6), policy (3), system (5).
+**41 event types** across 6 categories: budget (16), reservation (5), tenant (6), api_key (6), policy (3), system (5).
 
 **Webhook features:** HMAC-SHA256 signing, at-least-once delivery, exponential backoff retry, auto-disable on consecutive failures, event replay with distributed lock (prevents duplicate replays), SSRF prevention (private IP blocking by default).
 
@@ -566,7 +572,7 @@ Multiple origins are supported for staging + prod deployments behind the same se
 
 The full OpenAPI 3.1.0 specification is [`cycles-governance-admin-v0.1.25.yaml`](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml) in the [cycles-protocol](https://github.com/runcycles/cycles-protocol) repository.
 
-v0.1.25 adds Pillar 4 (Events & Webhooks): 40 event types, 20 webhook endpoints, HMAC-SHA256 signing, at-least-once delivery, and webhook secret encryption at rest.
+v0.1.25 adds Pillar 4 (Events & Webhooks): 41 event types, 20 webhook endpoints, HMAC-SHA256 signing, at-least-once delivery, and webhook secret encryption at rest.
 
 v0.1.25.4 enforces strict spec compliance: `additionalProperties: false` on all request and response models, range/size constraints on all fields per spec, distributed replay lock (409 `REPLAY_IN_PROGRESS`), and cascading `@Valid` on nested objects.
 

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/config/AuthInterceptor.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/config/AuthInterceptor.java
@@ -49,7 +49,16 @@ public class AuthInterceptor implements HandlerInterceptor {
         // subscriptions during incident response without holding the
         // tenant's API key. Per-subscription paths (id in URL) use the
         // prefix matcher below.
-        "GET:/v1/webhooks"
+        "GET:/v1/webhooks",
+        // v0.1.25.19: dual-auth on GET /v1/auth/introspect per spec
+        // v0.1.25.15. AdminKey returns admin-shape (auth_type=admin,
+        // permissions=["*"], no tenant_id/scope_filter). Tenant ApiKey
+        // returns tenant-shape (auth_type=tenant, concrete permissions,
+        // tenant_id, optional scope_filter) with capabilities derived
+        // per the NORMATIVE table — admin-plane caps (view_tenants,
+        // view_api_keys, view_audit, view_overview, manage_tenants,
+        // manage_api_keys) forced to false under tenant auth.
+        "GET:/v1/auth/introspect"
     );
 
     // Method:path-prefix entries for dual-auth where the path includes a
@@ -167,10 +176,11 @@ public class AuthInterceptor implements HandlerInterceptor {
     private boolean requiresAdminKey(String method, String path) {
         // Admin endpoints per spec: tenants, api-keys, auth/validate, auth/introspect, audit, webhooks, events, config, overview
         // Also: PATCH /v1/admin/budgets, freeze, unfreeze require AdminKeyAuth
+        // v0.1.25.19: /v1/auth/introspect moves off admin-only to the
+        // dual-auth path (see ADMIN_ALLOWED_ENDPOINTS + requiresApiKey).
         if (path.startsWith("/v1/admin/tenants") ||
                path.startsWith("/v1/admin/api-keys") ||
                path.startsWith("/v1/auth/validate") ||
-               path.startsWith("/v1/auth/introspect") ||
                path.startsWith("/v1/admin/audit") ||
                path.startsWith("/v1/admin/webhooks") ||
                path.startsWith("/v1/admin/events") ||
@@ -211,13 +221,18 @@ public class AuthInterceptor implements HandlerInterceptor {
     }
 
     private boolean requiresApiKey(String path) {
-        // Tenant-scoped endpoints per spec: budgets, policies, balances, reservations
+        // Tenant-scoped endpoints per spec: budgets, policies, balances, reservations.
+        // v0.1.25.19: /v1/auth/introspect is dual-auth (spec v0.1.25.15) —
+        // listed here so the interceptor routes tenant keys through the
+        // ApiKey path; AdminKey variant is picked up via the
+        // ADMIN_ALLOWED_ENDPOINTS dual-auth check inside preHandle.
         return path.startsWith("/v1/admin/budgets") ||
                path.startsWith("/v1/admin/policies") ||
                path.startsWith("/v1/balances") ||
                path.startsWith("/v1/reservations") ||
                path.startsWith("/v1/webhooks") ||
-               path.startsWith("/v1/events");
+               path.startsWith("/v1/events") ||
+               path.startsWith("/v1/auth/introspect");
     }
 
     private boolean validateAdminKey(HttpServletRequest request, HttpServletResponse response) throws Exception {

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/AuthController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/AuthController.java
@@ -43,29 +43,131 @@ public class AuthController {
         return ResponseEntity.ok(response);
     }
 
+    /**
+     * Introspect the authenticated credential (spec v0.1.25.15, dual-auth).
+     *
+     * AdminKeyAuth → admin-shape: auth_type="admin", permissions=["*"], all
+     * 15 capabilities true, no tenant_id, no scope_filter.
+     *
+     * ApiKeyAuth → tenant-shape: auth_type="tenant", concrete permissions
+     * from the key, tenant_id populated, scope_filter populated when
+     * non-empty, capabilities derived per the NORMATIVE table
+     * (yaml:3105-3166) with the six admin-plane caps forced to false
+     * regardless of any admin:* permissions on the key.
+     *
+     * Dual-auth routing is wired in {@code AuthInterceptor}:
+     * {@code GET:/v1/auth/introspect} is in ADMIN_ALLOWED_ENDPOINTS and
+     * {@code /v1/auth/introspect} is in requiresApiKey(). When the
+     * admin key header is present and valid, the interceptor stamps no
+     * authenticated_* attributes and we take the admin branch; when a
+     * tenant api key header is present and valid, the interceptor stamps
+     * authenticated_tenant_id / authenticated_permissions /
+     * authenticated_scope_filter and we take the tenant branch.
+     */
     @GetMapping("/introspect") @Operation(operationId = "introspectAuth", tags = {"Dashboard"})
     public ResponseEntity<AuthIntrospectResponse> introspect(HttpServletRequest request) {
-        // Admin key already validated by interceptor (v1: AdminKeyAuth only)
-        List<String> permissions = List.of("*");
+        Object tenantIdAttr = request.getAttribute("authenticated_tenant_id");
+        if (tenantIdAttr != null) {
+            @SuppressWarnings("unchecked")
+            List<String> permissions = (List<String>) request.getAttribute("authenticated_permissions");
+            @SuppressWarnings("unchecked")
+            List<String> scopeFilter = (List<String>) request.getAttribute("authenticated_scope_filter");
+            if (permissions == null) {
+                permissions = List.of();
+            }
+            // scope_filter serializes via @JsonInclude(NON_EMPTY) — absent or
+            // empty at source → absent in response.
+            return ResponseEntity.ok(AuthIntrospectResponse.builder()
+                    .authenticated(true)
+                    .authType("tenant")
+                    .permissions(permissions)
+                    .tenantId(tenantIdAttr.toString())
+                    .scopeFilter(scopeFilter)
+                    .capabilities(deriveTenantCapabilities(permissions))
+                    .build());
+        }
+        // AdminKeyAuth path — unconstrained, all caps true.
         return ResponseEntity.ok(AuthIntrospectResponse.builder()
                 .authenticated(true)
                 .authType("admin")
-                .permissions(permissions)
-                .capabilities(deriveCapabilities(permissions))
+                .permissions(List.of("*"))
+                .capabilities(allCapabilitiesTrue())
                 .build());
     }
 
-    private Capabilities deriveCapabilities(List<String> permissions) {
-        boolean isAdmin = permissions.contains("*");
+    /**
+     * Admin-shape capabilities: every view_* and manage_* flag true.
+     * Spec yaml:3157-3159: "Under auth_type=admin the server SHOULD return
+     * all capabilities as true (permissions=[\"*\"] being unconstrained)".
+     */
+    static Capabilities allCapabilitiesTrue() {
         return Capabilities.builder()
-                .viewOverview(isAdmin)
-                .viewBudgets(isAdmin || permissions.contains("admin:read") || permissions.contains("admin:budgets:read"))
-                .viewEvents(isAdmin || permissions.contains("events:read") || permissions.contains("admin:events:read"))
-                .viewWebhooks(isAdmin || permissions.contains("webhooks:read") || permissions.contains("admin:webhooks:read"))
-                .viewAudit(isAdmin || permissions.contains("admin:audit:read"))
-                .viewTenants(isAdmin || permissions.contains("admin:tenants:read"))
-                .viewApiKeys(isAdmin || permissions.contains("admin:apikeys:read"))
-                .viewPolicies(isAdmin || permissions.contains("admin:read") || permissions.contains("admin:policies:read"))
+                .viewOverview(true)
+                .viewBudgets(true)
+                .viewEvents(true)
+                .viewWebhooks(true)
+                .viewAudit(true)
+                .viewTenants(true)
+                .viewApiKeys(true)
+                .viewPolicies(true)
+                .viewReservations(true)
+                .manageBudgets(true)
+                .managePolicies(true)
+                .manageWebhooks(true)
+                .manageTenants(true)
+                .manageApiKeys(true)
+                .manageReservations(true)
                 .build();
+    }
+
+    /**
+     * Derive capabilities under tenant auth per the NORMATIVE table at
+     * yaml:3115-3148. Admin-plane caps (view_tenants, view_api_keys,
+     * view_audit, view_overview, manage_tenants, manage_api_keys) are
+     * hard-coded to false regardless of any admin:* permissions the key
+     * holds — yaml:3138-3147 is explicit: "The admin:read / admin:write
+     * wildcard semantics apply to per-endpoint access control, NOT to
+     * dashboard capability gating. This decoupling prevents accidental
+     * admin-UI elevation via legacy admin-permission tenant keys and is
+     * intentional."
+     */
+    static Capabilities deriveTenantCapabilities(List<String> perms) {
+        return Capabilities.builder()
+                // Admin-plane: forced false under tenant auth.
+                .viewOverview(false)
+                .viewTenants(false)
+                .viewApiKeys(false)
+                .viewAudit(false)
+                .manageTenants(false)
+                .manageApiKeys(false)
+                // Tenant-plane: derived per table.
+                .viewBudgets(hasAny(perms, "budgets:read", "admin:read", "admin:budgets:read"))
+                .viewPolicies(hasAny(perms, "policies:read", "admin:read", "admin:policies:read"))
+                .viewWebhooks(hasAny(perms, "webhooks:read", "admin:read", "admin:webhooks:read"))
+                .viewEvents(hasAny(perms, "events:read", "admin:read", "admin:events:read"))
+                .viewReservations(hasAny(perms,
+                        "reservations:list", "reservations:create",
+                        "reservations:commit", "reservations:release",
+                        "reservations:extend", "admin:read"))
+                .manageBudgets(hasAny(perms, "budgets:write", "admin:write", "admin:budgets:write"))
+                .managePolicies(hasAny(perms, "policies:write", "admin:write", "admin:policies:write"))
+                .manageWebhooks(hasAny(perms, "webhooks:write", "admin:write", "admin:webhooks:write"))
+                .manageReservations(hasAny(perms,
+                        "reservations:create", "reservations:commit",
+                        "reservations:release", "reservations:extend",
+                        "admin:write"))
+                .build();
+    }
+
+    private static boolean hasAny(List<String> perms, String... needles) {
+        if (perms == null) {
+            return false;
+        }
+        for (String n : needles) {
+            if (perms.contains(n)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/config/AuthInterceptorTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/config/AuthInterceptorTest.java
@@ -528,9 +528,11 @@ class AuthInterceptorTest {
     }
 
     @Test
-    void preHandle_introspectEndpoint_withoutAdminKey_returns401() throws Exception {
+    void preHandle_introspectEndpoint_withoutAnyKey_returns401() throws Exception {
+        // v0.1.25.19: dual-auth — neither header → 401 (spec yaml:4729-4734).
         request.setMethod("GET");
         request.setRequestURI("/v1/auth/introspect");
+        request.setServletPath("/v1/auth/introspect");
 
         assertThat(interceptor.preHandle(request, response, new Object())).isFalse();
         assertThat(response.getStatus()).isEqualTo(401);
@@ -540,7 +542,68 @@ class AuthInterceptorTest {
     void preHandle_introspectEndpoint_withValidAdminKey_succeeds() throws Exception {
         request.setMethod("GET");
         request.setRequestURI("/v1/auth/introspect");
+        request.setServletPath("/v1/auth/introspect");
         request.addHeader("X-Admin-API-Key", "admin-secret-key");
+
+        assertThat(interceptor.preHandle(request, response, new Object())).isTrue();
+        // Admin auth path: no authenticated_* attributes stamped on request.
+        assertThat(request.getAttribute("authenticated_tenant_id")).isNull();
+    }
+
+    // --- v0.1.25.19: dual-auth on /v1/auth/introspect (spec v0.1.25.15) ---
+
+    @Test
+    void preHandle_introspectEndpoint_withValidTenantKey_succeedsAndStampsAttributes() throws Exception {
+        request.setMethod("GET");
+        request.setRequestURI("/v1/auth/introspect");
+        request.setServletPath("/v1/auth/introspect");
+        request.addHeader("X-Cycles-API-Key", "tenant-key");
+
+        when(apiKeyRepository.validate("tenant-key")).thenReturn(
+                ApiKeyValidationResponse.builder()
+                        .valid(true).tenantId("t-1").keyId("k-1")
+                        .permissions(List.of("budgets:read"))
+                        .scopeFilter(List.of("tenant:t-1/app:prod"))
+                        .build());
+
+        assertThat(interceptor.preHandle(request, response, new Object())).isTrue();
+        // Tenant auth path: attributes stamped so controller can branch on them.
+        assertThat(request.getAttribute("authenticated_tenant_id")).isEqualTo("t-1");
+        assertThat(request.getAttribute("authenticated_permissions"))
+                .isEqualTo(List.of("budgets:read"));
+        assertThat(request.getAttribute("authenticated_scope_filter"))
+                .isEqualTo(List.of("tenant:t-1/app:prod"));
+    }
+
+    @Test
+    void preHandle_introspectEndpoint_withInvalidTenantKey_returns403() throws Exception {
+        request.setMethod("GET");
+        request.setRequestURI("/v1/auth/introspect");
+        request.setServletPath("/v1/auth/introspect");
+        request.addHeader("X-Cycles-API-Key", "bad-key");
+
+        when(apiKeyRepository.validate("bad-key")).thenReturn(
+                ApiKeyValidationResponse.builder()
+                        .valid(false).tenantId("").reason("KEY_NOT_FOUND").build());
+
+        assertThat(interceptor.preHandle(request, response, new Object())).isFalse();
+        assertThat(response.getStatus()).isEqualTo(403);
+    }
+
+    @Test
+    void preHandle_introspectEndpoint_noPermissionRequired() throws Exception {
+        // /v1/auth/introspect is not in PERMISSION_MAP — any valid tenant key
+        // can introspect itself regardless of permissions (spec yaml:4703-4768).
+        request.setMethod("GET");
+        request.setRequestURI("/v1/auth/introspect");
+        request.setServletPath("/v1/auth/introspect");
+        request.addHeader("X-Cycles-API-Key", "minimal-key");
+
+        when(apiKeyRepository.validate("minimal-key")).thenReturn(
+                ApiKeyValidationResponse.builder()
+                        .valid(true).tenantId("t-min").keyId("k-min")
+                        .permissions(List.of()) // zero permissions
+                        .build());
 
         assertThat(interceptor.preHandle(request, response, new Object())).isTrue();
     }

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/AuthControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/AuthControllerTest.java
@@ -91,16 +91,19 @@ class AuthControllerTest {
                 .andExpect(status().isUnauthorized());
     }
 
-    // --- Introspect endpoint (v0.1.25.1) ---
+    // --- Introspect endpoint (v0.1.25.1 admin-only; v0.1.25.19 dual-auth) ---
 
     @Test
-    void introspect_withAdminKey_returnsCapabilities() throws Exception {
+    void introspect_withAdminKey_returnsAdminShape() throws Exception {
+        // Spec v0.1.25.15 yaml:3157-3159: admin auth SHOULD return all caps true,
+        // plus tenant_id and scope_filter MUST be absent.
         mockMvc.perform(get("/v1/auth/introspect")
                         .header("X-Admin-API-Key", ADMIN_KEY))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.authenticated").value(true))
                 .andExpect(jsonPath("$.auth_type").value("admin"))
                 .andExpect(jsonPath("$.permissions[0]").value("*"))
+                // All 8 required view_* caps true.
                 .andExpect(jsonPath("$.capabilities.view_overview").value(true))
                 .andExpect(jsonPath("$.capabilities.view_budgets").value(true))
                 .andExpect(jsonPath("$.capabilities.view_events").value(true))
@@ -108,13 +111,139 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.capabilities.view_audit").value(true))
                 .andExpect(jsonPath("$.capabilities.view_tenants").value(true))
                 .andExpect(jsonPath("$.capabilities.view_api_keys").value(true))
-                .andExpect(jsonPath("$.capabilities.view_policies").value(true));
+                .andExpect(jsonPath("$.capabilities.view_policies").value(true))
+                // All 7 optional caps also true under admin auth.
+                .andExpect(jsonPath("$.capabilities.view_reservations").value(true))
+                .andExpect(jsonPath("$.capabilities.manage_budgets").value(true))
+                .andExpect(jsonPath("$.capabilities.manage_policies").value(true))
+                .andExpect(jsonPath("$.capabilities.manage_webhooks").value(true))
+                .andExpect(jsonPath("$.capabilities.manage_tenants").value(true))
+                .andExpect(jsonPath("$.capabilities.manage_api_keys").value(true))
+                .andExpect(jsonPath("$.capabilities.manage_reservations").value(true))
+                // tenant_id and scope_filter MUST NOT appear under admin auth.
+                .andExpect(jsonPath("$.tenant_id").doesNotExist())
+                .andExpect(jsonPath("$.scope_filter").doesNotExist());
     }
 
     @Test
-    void introspect_withoutAdminKey_returns401() throws Exception {
+    void introspect_withoutAnyKey_returns401() throws Exception {
+        // v0.1.25.19: the endpoint is dual-auth but still rejects missing
+        // credentials. Without either header, the interceptor routes through
+        // validateApiKey (missing X-Cycles-API-Key) → 401 per spec yaml:4729-4734.
         mockMvc.perform(get("/v1/auth/introspect"))
                 .andExpect(status().isUnauthorized());
+    }
+
+    // --- v0.1.25.19: tenant-key dual-auth on /v1/auth/introspect (spec v0.1.25.15) ---
+
+    @Test
+    void introspect_withTenantKey_returnsTenantShape() throws Exception {
+        when(apiKeyRepository.validate("tenant_key_1")).thenReturn(
+                ApiKeyValidationResponse.builder()
+                        .valid(true).tenantId("tenant-1").keyId("key_1")
+                        .permissions(List.of("budgets:read", "webhooks:write"))
+                        .build());
+
+        mockMvc.perform(get("/v1/auth/introspect")
+                        .header("X-Cycles-API-Key", "tenant_key_1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.authenticated").value(true))
+                .andExpect(jsonPath("$.auth_type").value("tenant"))
+                .andExpect(jsonPath("$.tenant_id").value("tenant-1"))
+                .andExpect(jsonPath("$.permissions").isArray())
+                .andExpect(jsonPath("$.permissions[0]").value("budgets:read"))
+                .andExpect(jsonPath("$.permissions[1]").value("webhooks:write"))
+                // Admin-plane capabilities MUST be false under tenant auth
+                // (spec yaml:3138-3147 — NORMATIVE regardless of admin:* perms).
+                .andExpect(jsonPath("$.capabilities.view_overview").value(false))
+                .andExpect(jsonPath("$.capabilities.view_tenants").value(false))
+                .andExpect(jsonPath("$.capabilities.view_api_keys").value(false))
+                .andExpect(jsonPath("$.capabilities.view_audit").value(false))
+                .andExpect(jsonPath("$.capabilities.manage_tenants").value(false))
+                .andExpect(jsonPath("$.capabilities.manage_api_keys").value(false))
+                // Tenant-plane derived per the table (yaml:3115-3135).
+                .andExpect(jsonPath("$.capabilities.view_budgets").value(true))
+                .andExpect(jsonPath("$.capabilities.view_webhooks").value(false))
+                .andExpect(jsonPath("$.capabilities.manage_webhooks").value(true))
+                .andExpect(jsonPath("$.capabilities.manage_budgets").value(false))
+                .andExpect(jsonPath("$.capabilities.view_events").value(false))
+                .andExpect(jsonPath("$.capabilities.view_policies").value(false))
+                // scope_filter absent when empty/unset.
+                .andExpect(jsonPath("$.scope_filter").doesNotExist());
+    }
+
+    @Test
+    void introspect_withTenantKey_scopeFilterPresent_includesField() throws Exception {
+        when(apiKeyRepository.validate("tenant_key_scoped")).thenReturn(
+                ApiKeyValidationResponse.builder()
+                        .valid(true).tenantId("tenant-9").keyId("key_9")
+                        .permissions(List.of("budgets:read"))
+                        .scopeFilter(List.of("tenant:tenant-9/workspace:team-a"))
+                        .build());
+
+        mockMvc.perform(get("/v1/auth/introspect")
+                        .header("X-Cycles-API-Key", "tenant_key_scoped"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.auth_type").value("tenant"))
+                .andExpect(jsonPath("$.tenant_id").value("tenant-9"))
+                .andExpect(jsonPath("$.scope_filter[0]").value("tenant:tenant-9/workspace:team-a"));
+    }
+
+    @Test
+    void introspect_withTenantKey_scopeFilterEmpty_omitsField() throws Exception {
+        when(apiKeyRepository.validate("tenant_key_noscope")).thenReturn(
+                ApiKeyValidationResponse.builder()
+                        .valid(true).tenantId("tenant-1").keyId("key_1")
+                        .permissions(List.of("events:read"))
+                        .scopeFilter(List.of())
+                        .build());
+
+        mockMvc.perform(get("/v1/auth/introspect")
+                        .header("X-Cycles-API-Key", "tenant_key_noscope"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.auth_type").value("tenant"))
+                .andExpect(jsonPath("$.scope_filter").doesNotExist());
+    }
+
+    @Test
+    void introspect_tenantKeyWithAdminRead_adminPlaneCapsStillFalse() throws Exception {
+        // NORMATIVE guard (spec yaml:3138-3147): admin:read on a tenant key
+        // MUST NOT elevate the admin-plane dashboard caps. Prevents accidental
+        // admin-UI access via legacy admin-permission tenant keys.
+        when(apiKeyRepository.validate("legacy_tenant_key")).thenReturn(
+                ApiKeyValidationResponse.builder()
+                        .valid(true).tenantId("tenant-legacy").keyId("key_lg")
+                        .permissions(List.of("admin:read"))
+                        .build());
+
+        mockMvc.perform(get("/v1/auth/introspect")
+                        .header("X-Cycles-API-Key", "legacy_tenant_key"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.auth_type").value("tenant"))
+                // admin:read opens the tenant-plane read caps (table).
+                .andExpect(jsonPath("$.capabilities.view_budgets").value(true))
+                .andExpect(jsonPath("$.capabilities.view_policies").value(true))
+                .andExpect(jsonPath("$.capabilities.view_webhooks").value(true))
+                .andExpect(jsonPath("$.capabilities.view_events").value(true))
+                .andExpect(jsonPath("$.capabilities.view_reservations").value(true))
+                // …but NOT the admin-plane caps (NORMATIVE forced-false).
+                .andExpect(jsonPath("$.capabilities.view_overview").value(false))
+                .andExpect(jsonPath("$.capabilities.view_tenants").value(false))
+                .andExpect(jsonPath("$.capabilities.view_api_keys").value(false))
+                .andExpect(jsonPath("$.capabilities.view_audit").value(false))
+                .andExpect(jsonPath("$.capabilities.manage_tenants").value(false))
+                .andExpect(jsonPath("$.capabilities.manage_api_keys").value(false));
+    }
+
+    @Test
+    void introspect_invalidTenantKey_returns403() throws Exception {
+        when(apiKeyRepository.validate("bad_key")).thenReturn(
+                ApiKeyValidationResponse.builder()
+                        .valid(false).tenantId("").reason("KEY_NOT_FOUND").build());
+
+        mockMvc.perform(get("/v1/auth/introspect")
+                        .header("X-Cycles-API-Key", "bad_key"))
+                .andExpect(status().isForbidden());
     }
 
     // --- KEY_EXPIRED / KEY_REVOKED validation ---

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/integration/AdminFlowIntegrationTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/integration/AdminFlowIntegrationTest.java
@@ -157,6 +157,31 @@ class AdminFlowIntegrationTest extends BaseIntegrationTest {
         assertThat(adminDelete("/v1/admin/webhooks/" + subscriptionId).getStatusCode())
                 .isEqualTo(HttpStatus.NO_CONTENT);
 
+        // --- 17b. Tenant-key introspect (v0.1.25.19 dual-auth path; spec v0.1.25.15) ---
+        // Must happen BEFORE step 18 revokes the tenant key. Covers the
+        // ApiKeyAuth branch of /v1/auth/introspect and the tenant-shape
+        // AuthIntrospectResponse (auth_type=tenant, tenant_id, scope_filter,
+        // NORMATIVE capability derivation). Contract validator catches any
+        // schema drift on this shape against cycles-protocol@main.
+        ResponseEntity<Map> tenantIntrospect = restTemplate.exchange(
+                baseUrl() + "/v1/auth/introspect", HttpMethod.GET,
+                new HttpEntity<>(tenantH),
+                Map.class);
+        assertThat(tenantIntrospect.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(tenantIntrospect.getBody().get("auth_type")).isEqualTo("tenant");
+        assertThat(tenantIntrospect.getBody().get("tenant_id")).isEqualTo("tenant-integration");
+        Map<?,?> tenantCaps = (Map<?,?>) tenantIntrospect.getBody().get("capabilities");
+        // Admin-plane caps MUST be false under tenant auth (NORMATIVE).
+        assertThat(tenantCaps.get("view_tenants")).isEqualTo(false);
+        assertThat(tenantCaps.get("view_api_keys")).isEqualTo(false);
+        assertThat(tenantCaps.get("view_audit")).isEqualTo(false);
+        assertThat(tenantCaps.get("view_overview")).isEqualTo(false);
+        // Tenant-plane caps derived from the granted permissions.
+        assertThat(tenantCaps.get("view_budgets")).isEqualTo(true);
+        assertThat(tenantCaps.get("manage_budgets")).isEqualTo(true);
+        assertThat(tenantCaps.get("view_webhooks")).isEqualTo(true);
+        assertThat(tenantCaps.get("manage_webhooks")).isEqualTo(true);
+
         // --- 18. Revoke API key ---
         assertThat(adminDelete("/v1/admin/api-keys/" + keyId + "?reason=integration-test-cleanup")
                 .getStatusCode()).isEqualTo(HttpStatus.OK);

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/auth/AuthIntrospectResponse.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/auth/AuthIntrospectResponse.java
@@ -13,4 +13,24 @@ public class AuthIntrospectResponse {
     @JsonProperty("auth_type") private String authType;
     @JsonProperty("permissions") private List<String> permissions;
     @JsonProperty("capabilities") private Capabilities capabilities;
+
+    /**
+     * REQUIRED when auth_type=tenant — the tenant this API key is bound to.
+     * MUST be absent when auth_type=admin (admin keys have no effective tenant).
+     * Added in v0.1.25.19 per spec v0.1.25.15. Per-field NON_NULL overrides
+     * the class-level ALWAYS so admin-shape responses still omit this field.
+     */
+    @JsonProperty("tenant_id")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String tenantId;
+
+    /**
+     * OPTIONAL (tenant auth only). Present and non-empty when the API key has
+     * scope restrictions (see ApiKey.scope_filter). Absent or empty means no
+     * scope narrowing. MUST be absent when auth_type=admin.
+     * Added in v0.1.25.19 per spec v0.1.25.15.
+     */
+    @JsonProperty("scope_filter")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private List<String> scopeFilter;
 }

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/auth/Capabilities.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/auth/Capabilities.java
@@ -8,8 +8,23 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /**
- * Derived boolean capabilities for dashboard UI. Per spec, all 8 fields are
- * always present (explicit false, never omitted).
+ * Derived boolean capabilities for dashboard UI.
+ *
+ * The 8 required `view_*` fields are always present (explicit false, never
+ * omitted) per spec v0.1.25.9+.
+ *
+ * The 7 optional fields added in v0.1.25.19 per spec v0.1.25.15
+ * (`view_reservations`, `manage_budgets`, `manage_policies`, `manage_webhooks`,
+ * `manage_tenants`, `manage_api_keys`, `manage_reservations`) are serialized
+ * only when set. Using boxed `Boolean` + per-field `@JsonInclude(NON_NULL)`
+ * overrides the class-level `ALWAYS`, so legacy admin-only responses that
+ * don't populate them stay wire-identical to pre-v0.1.25.19 output.
+ *
+ * Capability-derivation rules are NORMATIVE under `auth_type=tenant` per
+ * spec yaml:3105-3166. `AuthController.deriveTenantCapabilities` implements
+ * the table; admin-plane caps (view_tenants, view_api_keys, view_audit,
+ * view_overview, manage_tenants, manage_api_keys) are forced to `false`
+ * under tenant auth regardless of admin:* permissions.
  */
 @Data
 @Builder
@@ -25,4 +40,34 @@ public class Capabilities {
     @JsonProperty("view_tenants") private boolean viewTenants;
     @JsonProperty("view_api_keys") private boolean viewApiKeys;
     @JsonProperty("view_policies") private boolean viewPolicies;
+
+    // --- v0.1.25.19 optional fields (spec v0.1.25.15). Absent unless set. ---
+
+    @JsonProperty("view_reservations")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean viewReservations;
+
+    @JsonProperty("manage_budgets")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean manageBudgets;
+
+    @JsonProperty("manage_policies")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean managePolicies;
+
+    @JsonProperty("manage_webhooks")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean manageWebhooks;
+
+    @JsonProperty("manage_tenants")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean manageTenants;
+
+    @JsonProperty("manage_api_keys")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean manageApiKeys;
+
+    @JsonProperty("manage_reservations")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean manageReservations;
 }

--- a/cycles-admin-service/cycles-admin-service-model/src/test/java/io/runcycles/admin/model/AuthModelTest.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/test/java/io/runcycles/admin/model/AuthModelTest.java
@@ -7,6 +7,8 @@ import io.runcycles.admin.model.auth.ApiKey;
 import io.runcycles.admin.model.auth.ApiKeyCreateRequest;
 import io.runcycles.admin.model.auth.ApiKeyResponse;
 import io.runcycles.admin.model.auth.ApiKeyStatus;
+import io.runcycles.admin.model.auth.AuthIntrospectResponse;
+import io.runcycles.admin.model.auth.Capabilities;
 import io.runcycles.admin.model.auth.Permission;
 import jakarta.validation.*;
 import org.junit.jupiter.api.BeforeAll;
@@ -169,5 +171,110 @@ class AuthModelTest {
         // Verify round-trip: deserialize back and check hash is preserved
         ApiKey deserialized = mapper.readValue(json, ApiKey.class);
         assertEquals("$2a$12$secret_hash", deserialized.getKeyHash());
+    }
+
+    // --- v0.1.25.19 introspect dual-auth (spec v0.1.25.15) ---
+
+    @Test
+    void authIntrospectResponse_adminShape_omitsTenantAndScopeFilter() throws Exception {
+        // Under auth_type=admin, tenant_id and scope_filter MUST be absent
+        // (spec yaml:3187-3198). Per-field @JsonInclude on the DTO takes care
+        // of this as long as the fields are left null.
+        AuthIntrospectResponse admin = AuthIntrospectResponse.builder()
+                .authenticated(true)
+                .authType("admin")
+                .permissions(List.of("*"))
+                .capabilities(Capabilities.builder()
+                        .viewOverview(true).viewBudgets(true).viewEvents(true)
+                        .viewWebhooks(true).viewAudit(true).viewTenants(true)
+                        .viewApiKeys(true).viewPolicies(true)
+                        .build())
+                .build();
+        String json = mapper.writeValueAsString(admin);
+        assertTrue(json.contains("\"auth_type\":\"admin\""));
+        assertFalse(json.contains("\"tenant_id\""), "admin shape must not include tenant_id");
+        assertFalse(json.contains("\"scope_filter\""), "admin shape must not include scope_filter");
+    }
+
+    @Test
+    void authIntrospectResponse_tenantShape_includesTenantIdAndScopeFilterWhenSet() throws Exception {
+        AuthIntrospectResponse tenant = AuthIntrospectResponse.builder()
+                .authenticated(true)
+                .authType("tenant")
+                .permissions(List.of("budgets:read"))
+                .tenantId("t-1")
+                .scopeFilter(List.of("tenant:t-1/workspace:a"))
+                .capabilities(Capabilities.builder()
+                        .viewOverview(false).viewBudgets(true).viewEvents(false)
+                        .viewWebhooks(false).viewAudit(false).viewTenants(false)
+                        .viewApiKeys(false).viewPolicies(false)
+                        .build())
+                .build();
+        String json = mapper.writeValueAsString(tenant);
+        assertTrue(json.contains("\"auth_type\":\"tenant\""));
+        assertTrue(json.contains("\"tenant_id\":\"t-1\""));
+        assertTrue(json.contains("\"scope_filter\":[\"tenant:t-1/workspace:a\"]"));
+    }
+
+    @Test
+    void authIntrospectResponse_tenantShape_emptyScopeFilterOmitted() throws Exception {
+        // scope_filter is @JsonInclude(NON_EMPTY) — an empty list serializes
+        // as absent per spec yaml:3194-3198 ("absent or empty means no scope
+        // narrowing"). Prevents wire ambiguity between "no restrictions" and
+        // "explicitly empty restrictions".
+        AuthIntrospectResponse tenant = AuthIntrospectResponse.builder()
+                .authenticated(true)
+                .authType("tenant")
+                .permissions(List.of("events:read"))
+                .tenantId("t-2")
+                .scopeFilter(List.of())
+                .capabilities(Capabilities.builder().build())
+                .build();
+        String json = mapper.writeValueAsString(tenant);
+        assertFalse(json.contains("\"scope_filter\""),
+                "empty scope_filter must serialize as absent");
+    }
+
+    @Test
+    void capabilities_optionalManageFields_absentWhenUnset() throws Exception {
+        // Legacy shape (pre-v0.1.25.19): only the 8 view_* booleans. Optional
+        // manage_* fields are @JsonInclude(NON_NULL) so they stay absent when
+        // left null — wire-compatible with pre-v0.1.25.19 consumers.
+        Capabilities legacy = Capabilities.builder()
+                .viewOverview(true).viewBudgets(true).viewEvents(true)
+                .viewWebhooks(true).viewAudit(true).viewTenants(true)
+                .viewApiKeys(true).viewPolicies(true)
+                .build();
+        String json = mapper.writeValueAsString(legacy);
+        assertTrue(json.contains("\"view_overview\":true"));
+        assertFalse(json.contains("manage_budgets"));
+        assertFalse(json.contains("manage_policies"));
+        assertFalse(json.contains("manage_webhooks"));
+        assertFalse(json.contains("manage_tenants"));
+        assertFalse(json.contains("manage_api_keys"));
+        assertFalse(json.contains("manage_reservations"));
+        assertFalse(json.contains("view_reservations"));
+    }
+
+    @Test
+    void capabilities_allFieldsSet_serializesEverything() throws Exception {
+        Capabilities full = Capabilities.builder()
+                .viewOverview(true).viewBudgets(true).viewEvents(true)
+                .viewWebhooks(true).viewAudit(true).viewTenants(true)
+                .viewApiKeys(true).viewPolicies(true)
+                .viewReservations(true)
+                .manageBudgets(true).managePolicies(true).manageWebhooks(true)
+                .manageTenants(true).manageApiKeys(true).manageReservations(true)
+                .build();
+        String json = mapper.writeValueAsString(full);
+        // All 15 fields present.
+        assertTrue(json.contains("\"view_overview\":true"));
+        assertTrue(json.contains("\"view_reservations\":true"));
+        assertTrue(json.contains("\"manage_budgets\":true"));
+        assertTrue(json.contains("\"manage_policies\":true"));
+        assertTrue(json.contains("\"manage_webhooks\":true"));
+        assertTrue(json.contains("\"manage_tenants\":true"));
+        assertTrue(json.contains("\"manage_api_keys\":true"));
+        assertTrue(json.contains("\"manage_reservations\":true"));
     }
 }

--- a/cycles-admin-service/pom.xml
+++ b/cycles-admin-service/pom.xml
@@ -18,7 +18,7 @@
         <module>cycles-admin-service-api</module>
     </modules>
     <properties>
-        <revision>0.1.25.18</revision>
+        <revision>0.1.25.19</revision>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/docker-compose.full-stack.prod.yml
+++ b/docker-compose.full-stack.prod.yml
@@ -13,7 +13,7 @@ services:
       retries: 5
 
   cycles-admin:
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.18
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.19
     restart: unless-stopped
     ports:
       - "7979:7979"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,7 +13,7 @@ services:
       retries: 5
 
   cycles-admin:
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.18
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.19
     restart: unless-stopped
     ports:
       - "7979:7979"


### PR DESCRIPTION
## Summary

Closes the one remaining parity gap vs the admin spec: `GET /v1/auth/introspect` now accepts both `AdminKeyAuth` (admin-shape) and `ApiKeyAuth` (tenant-shape) per spec v0.1.25.15 ([cycles-protocol#43](https://github.com/runcycles/cycles-protocol/pull/43)). Prior releases returned the admin-only stub the spec's BACKWARD COMPATIBILITY clause explicitly allowed as a forward-compat position — this release closes it so tenants can introspect their own API keys through the dashboard.

Also adds consumer-facing `CHANGELOG.md` and operator-facing `OPERATIONS.md`, mirroring the shape cycles-server just added (cycles-server#98). `AUDIT.md` stays as engineering history.

Full parity audit against `cycles-governance-admin-v0.1.25.yaml` v0.1.25.11→v0.1.25.17 found every prior spec change already covered (admin v0.1.25.11→v0.1.25.18). cycles-server#103 mirrored `BUDGET_RESET_SPENT` into its runtime `EventType` — admin has had that enum value since v0.1.25.18; **byte-for-byte EventType parity confirmed (41 entries each)**.

## Auth shapes (NORMATIVE, spec yaml:3105-3166)

| Branch | `auth_type` | `permissions` | `tenant_id` | `scope_filter` | Capabilities |
|---|---|---|---|---|---|
| AdminKeyAuth | `admin` | `["*"]` | absent | absent | all 15 true |
| ApiKeyAuth | `tenant` | concrete perms | populated | populated if non-empty | per NORMATIVE table |

Admin-plane caps (`view_tenants`, `view_api_keys`, `view_audit`, `view_overview`, `manage_tenants`, `manage_api_keys`) are hard-coded `false` under tenant auth regardless of any `admin:*` permissions — yaml:3138-3147 is explicit: "prevents accidental admin-UI elevation via legacy admin-permission tenant keys."

## Wire format

Additive. Pre-v0.1.25.19 admin-shape responses remain byte-identical:
- Per-field `@JsonInclude(NON_NULL)` on `tenant_id` overrides class-level `ALWAYS`.
- Per-field `@JsonInclude(NON_EMPTY)` on `scope_filter` handles both null and empty list.
- Boxed `Boolean` on the 7 new `manage_*` / `view_reservations` cap fields stays absent unless set.

## Changes

- **AuthInterceptor** — `/v1/auth/introspect` moved off `requiresAdminKey` to dual-auth path (`ADMIN_ALLOWED_ENDPOINTS` + `requiresApiKey`).
- **AuthController** — `introspect()` branches on `authenticated_tenant_id` attr; new `allCapabilitiesTrue()` + `deriveTenantCapabilities()` helpers; obsolete `deriveCapabilities()` removed.
- **AuthIntrospectResponse** — nullable `tenant_id` + `scope_filter` fields.
- **Capabilities** — 7 optional boxed Boolean fields.
- **Tests** — +5 in `AuthControllerTest`, +3 in `AuthInterceptorTest`, +5 in `AuthModelTest`, +1 step (tenant introspect, contract-validated) in `AdminFlowIntegrationTest`.
- **Release** — `pom.xml` 0.1.25.18 → 0.1.25.19; docker-compose prod tags; `README.md` spec ref + event counts (stale since v0.1.25.18, fixed to 41) + Documentation cross-link section.
- **Docs** — new `CHANGELOG.md` (Keep-a-Changelog, v0.1.25.10 → v0.1.25.19); new `OPERATIONS.md` (metrics inventory, alerts, tuning, playbook).

## Test plan

- [x] `mvn verify` — 528 tests, 0 failures, JaCoCo ≥95% on all modules, `SpecCoverageReportTest` 43/43.
- [x] `OpenApiContractDiffTest` — zero INCOMPATIBLE diff; new optional fields on `AuthIntrospectResponse`/`Capabilities` show as COMPATIBLE (additive).
- [x] `ContractValidationConfig` validates both admin-shape and tenant-shape responses against pinned spec on `cycles-protocol@main`.
- [x] Three-round review: (1) docs/accuracy, (2) code/quality, (3) testing + cycles-server parity.
- [ ] CI integration job (`mvn verify -Pintegration-tests` with Testcontainers Redis).
- [ ] Manual smoke in staging:
  - `curl -H "X-Admin-API-Key: …" localhost:7979/v1/auth/introspect` → `auth_type=admin`, all caps true, no `tenant_id`.
  - `curl -H "X-Cycles-API-Key: …" localhost:7979/v1/auth/introspect` → `auth_type=tenant`, concrete perms, `tenant_id`, admin-plane caps false.
  - Unauthenticated → 401.

## Cross-refs

- Implements: runcycles/cycles-protocol#43 (spec v0.1.25.15 tenant-introspect dual-auth).
- Mirrors doc shape: runcycles/cycles-server#98 (CHANGELOG + OPERATIONS).
- Event vocab parity confirmed: runcycles/cycles-server#103 (BUDGET_RESET_SPENT mirror).