### PR TITLE
feat(audit): v0.1.25.20 audit log on failure paths + tiered TTL + DDoS sampling

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,9 +1,113 @@
 # Complete Budget Governance v0.1.25.8 — Admin Server Audit
 
-**Server version:** 0.1.25.19 (2026-04-16 — /v1/auth/introspect dual-auth: spec v0.1.25.15)
-**Date:** 2026-04-16 (v0.1.25.19 introspect dual-auth + operator docs), 2026-04-15 (v0.1.25.18 RESET_SPENT operation), 2026-04-14 (v0.1.25.17 cjson round-trip sweep: apikey + policy + tenant), 2026-04-13 (v0.1.25.16 webhooks dual-auth), 2026-04-13 (v0.1.25.15 ScopeValidator), 2026-04-13 (v0.1.25.14 admin-on-behalf-of dual-auth), 2026-04-13 (v0.1.25.13 CORS PUT fix), 2026-04-12 (v0.1.25.12 spec-compliance hardening + observability), 2026-04-12 (v0.1.25.11 contract-testing default ON), 2026-04-12 (v0.1.25.10 spec-compliance hardening), 2026-04-10 (v0.1.25.9 release), 2026-04-10 (CORS hardening + prod config), 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
+**Server version:** 0.1.25.20 (2026-04-16 — audit log on failure paths: 4xx/5xx coverage via GlobalExceptionHandler + AuthInterceptor)
+**Date:** 2026-04-16 (v0.1.25.20 audit-on-failure), 2026-04-16 (v0.1.25.19 introspect dual-auth + operator docs), 2026-04-15 (v0.1.25.18 RESET_SPENT operation), 2026-04-14 (v0.1.25.17 cjson round-trip sweep: apikey + policy + tenant), 2026-04-13 (v0.1.25.16 webhooks dual-auth), 2026-04-13 (v0.1.25.15 ScopeValidator), 2026-04-13 (v0.1.25.14 admin-on-behalf-of dual-auth), 2026-04-13 (v0.1.25.13 CORS PUT fix), 2026-04-12 (v0.1.25.12 spec-compliance hardening + observability), 2026-04-12 (v0.1.25.11 contract-testing default ON), 2026-04-12 (v0.1.25.10 spec-compliance hardening), 2026-04-10 (v0.1.25.9 release), 2026-04-10 (CORS hardening + prod config), 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
 **Spec:** [`cycles-governance-admin-v0.1.25.yaml`](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml) (OpenAPI 3.1.0, info.version `0.1.25.16`; content includes RESET_SPENT from spec PR #45 v0.1.25.17) in [cycles-protocol](https://github.com/runcycles/cycles-protocol)
 **Server:** Spring Boot 3.5.11 / Java 21 / Redis
+
+### 2026-04-16 — v0.1.25.20 audit log on failure paths (hybrid — success writes unchanged)
+
+Closes a real compliance-auditing gap reported during post-v0.1.25.19 review: `GET /v1/admin/audit/logs` only returned STATUS 201 / 200 / 204 entries because admin-server writes audit records **exclusively on success paths** — each controller hardcodes `auditRepository.log(...)` *after* the repository/service call returns. Every error path (401/403 in `AuthInterceptor`, 400/404/409/500 in `GlobalExceptionHandler`) short-circuits before the audit write, leaving auth rejections, malformed requests, and server errors invisible to SOC2/GDPR reviewers.
+
+**Approach: hybrid, not full replacement, with tiered retention + DDoS protection.** Success-path per-controller writes stay verbatim — they carry rich operation-specific metadata (funded amount, budget scope, policy caps, subject/action/amount) that a catch-all interceptor couldn't reconstruct. Failure writes land in two new places:
+
+1. **`GlobalExceptionHandler`** — every `@ExceptionHandler` method calls `auditFailure.logFailure(...)` before returning the error response. Covers 4xx/5xx that make it *into* the controller and then throw.
+2. **`AuthInterceptor.writeError`** — every pre-controller auth rejection calls the same helper. Covers 401/403/400/500 failures that never reach the controller.
+
+Plus two defense-in-depth measures that make this safe to ship against a DDoS amplification risk:
+
+3. **Tiered TTL** (configurable, indefinite by default for compliance-critical entries).
+4. **Unauthenticated-tier sampling** (configurable, off by default).
+
+### DDoS amplification and the tiered-retention response
+
+A naïve failure-audit implementation converts every failed request into a Redis write — at 10k req/s sustained that's ~10 MB/s of Redis memory growth and 30k Redis ops/s on a single Lua-serialized surface. The `audit:logs:<unauthenticated>` sorted set becomes a hotspot, `audit:logs:_all` grows unboundedly, and under `volatile-*` eviction policies the non-TTL audit keys survive while legitimate operational data (keys with TTL — idempotency caches, session data) gets evicted. Worst of both worlds.
+
+Solution: **differentiate retention by authentication tier.** Compliance-critical entries (authenticated success + authenticated failure) keep long retention by default; DDoS-amplifiable entries (pre-auth failures, marked by the `<unauthenticated>` sentinel) get short retention and optional sampling.
+
+| Tier | Example entries | Default TTL | Rationale |
+|---|---|---|---|
+| **Authenticated** (`tenant_id != "<unauthenticated>"`) | success mutations, 403 by valid tenant key, 404 / 409 on owned resource, 500 in authenticated path | **400 days** (`audit.retention.authenticated.days=400`) | SOC2 Type II covers a 12-month period. Auditor engagement usually begins ~30 days after period close. 400 days = 365 + ~35 buffer — the audit-of-record trail is intact when the auditor arrives. Set to `0` for indefinite (legal hold, HIPAA-adjacent, forever-retain deployments). |
+| **Unauthenticated** (`tenant_id == "<unauthenticated>"`) | missing / invalid admin key 401, pre-auth path traversal 400, admin-key-only requests failing before the controller runs | **30 days** (`audit.retention.unauthenticated.days=30`) | Enough for brute-force / credential-stuffing post-mortem. Aggregate attempt volume stays visible via `cycles_admin_audit_writes_total` regardless of TTL. Set to `0` for indefinite. |
+
+Setting a retention to `0` disables expiry for that tier. Setting BOTH to `0` also disables the index sweep entirely (`sweepStaleIndexEntries()` short-circuits when `authenticatedRetentionDays <= 0` to avoid accidentally removing pointers to live indefinite-retention records).
+
+### Unauthenticated-tier sampling (`audit.sample.unauthenticated`, default `1`)
+
+Independent of TTL. Records 1 in N unauthenticated entries. Default `1` preserves full fidelity — operator must opt in. Typical DDoS-exposed deployment sets this to `100`, cutting Redis write volume by 100× while keeping aggregate attempt volume visible via a new Prometheus counter outcome `sampled-out`.
+
+Values `<= 0` are treated as `1` (no sampling) defensively — a misconfigured `0` must never silently drop every audit entry. Authenticated failures are **never** sampled regardless of the setting; they're compliance-relevant security signals, not DDoS noise.
+
+### Daily index sweep (`audit.sweep.cron`, default `0 0 3 * * *`)
+
+When `audit:log:{logId}` keys TTL-expire, the matching sorted-set entries in `audit:logs:_all` and `audit:logs:{tenant}` still hold pointers to the now-dead keys. Without cleanup those indexes grow unboundedly even though the underlying records are gone (~32 bytes per stale pointer).
+
+`AuditRepository.sweepStaleIndexEntries()` runs daily (03:00 server time by default): `ZREMRANGEBYSCORE` on the global index and — via `SCAN` — each per-tenant index, removing pointers older than the longest retention window. `AuditRepository.list()` already tolerates `null` from `GET audit:log:{id}` (line 71-74), so the sweep is eventual-consistency cleanup, not on the read critical path. Sweep is best-effort: Redis-unavailable failures are logged ERROR and swallowed; next tick retries. `@EnableScheduling` added to `BudgetGovernanceApplication`.
+
+**Single-write invariant by construction.** If the controller threw, execution never reached the controller's `audit.log(...)` — `GlobalExceptionHandler` is the only audit source for that request. Pre-auth failures never enter the controller at all — `AuthInterceptor.writeError` is the only source. No idempotency key, no dedup logic: a request produces either a success entry or a failure entry, never both. The generic `handleGenericException` branch explicitly delegates `GovernanceException` to `handleGovernanceException` to avoid double-writing on dispatch-order corner cases.
+
+**Unauthenticated tenant sentinel.** Spec marks `AuditLogEntry.tenant_id` as **required**. Pre-auth failures have no authenticated tenant. Sentinel value `"<unauthenticated>"` preserves the spec required-field invariant — no spec change needed — and keeps failed attempts queryable via `GET /v1/admin/audit/logs?tenant_id=%3Cunauthenticated%3E`. Admin-key auth (e.g. `X-Admin-API-Key` present but paired with malformed JSON) also falls back to the sentinel because `AuthInterceptor.validateAdminKey` doesn't stamp `authenticated_tenant_id` on the request — by design, admin keys have no effective tenant.
+
+**Failure entry shape:**
+
+| Field | Source on failure | Example |
+|---|---|---|
+| `tenant_id` | `authenticated_tenant_id` attr OR sentinel | `"<unauthenticated>"`, `"tenant-1"` |
+| `key_id` | `authenticated_key_id` attr (absent under admin auth) | omitted when null |
+| `operation` | `"<METHOD>:<URI>"` | `"POST:/v1/admin/budgets"` |
+| `status` | actual HTTP status | 401, 403, 400, 404, 409, 500 |
+| `error_code` | `ErrorCode.name()` | `UNAUTHORIZED`, `INVALID_REQUEST` |
+| `metadata.error_message` | CR/LF-stripped, 1024-cap sanitized | `"Missing X-Admin-API-Key header"` |
+| `metadata.method`, `metadata.path` | request method + URI | `"POST"`, `"/v1/admin/budgets"` |
+| `metadata.exception_class` | fully-qualified name (generic handler only) | `"java.lang.RuntimeException"` |
+| `resource_type`, `resource_id`, `subject`, `action`, `amount` | omitted — not derivable on failure paths | `null` |
+| `source_ip`, `user_agent`, `request_id` | from request | unchanged from success side |
+
+**Non-fatal contract preserved.** `AuditRepository.log()` already swallowed all exceptions (logs ERROR, returns). New `AuditFailureService` wraps its own body in a separate `try/catch` as defense-in-depth — if the metric-registry call or anything else ever threw, the error response is guaranteed to reach the client. A Prometheus counter `cycles_admin_audit_writes_total{path_class, outcome}` exposes silent audit-write failures to ops:
+- `path_class=failure, outcome=written` — failure audit entry written successfully
+- `path_class=failure, outcome=error` — failure audit write itself failed (alert on nonzero)
+
+**Log-injection hardening.** Failure audit entries carry the server-side error message in `metadata.error_message`. `AuditFailureService.sanitizeMessage(...)` replaces CR/LF with spaces and caps at 1024 chars. Server-side messages are typically fixed strings (`"Missing X-Admin-API-Key header"`, `"Validation failed: name: must not be blank"`), but sanitize defensively in case any caller-controlled content ever leaks in.
+
+**Changes:**
+
+| File | Change |
+|---|---|
+| `cycles-admin-service-model/.../audit/AuditLogEntry.java` | Added `UNAUTHENTICATED_TENANT = "<unauthenticated>"` public constant. Source of truth — both `AuditRepository` (data) and `AuditFailureService` (api) reference it without cross-layer coupling. |
+| `cycles-admin-service-api/.../service/AuditFailureService.java` (new) | Shared failure-audit writer. `logFailure(HttpServletRequest, int status, ErrorCode, String message, Map extras)`. Populates `tenant_id` via attr-or-sentinel, `operation=METHOD:URI`, sanitized message + handler extras in metadata. Non-throwing. Emits `cycles_admin_audit_writes_total{path_class, outcome}` counter with outcome values `written` / `error` / `sampled-out`. New `@Value("${audit.sample.unauthenticated:1}")` sampling gate applied ONLY to unauthenticated-tier entries — authenticated failures always persist at full fidelity. Values `<= 1` treated as "no sampling" (defense against misconfigured zero). `ThreadLocalRandom` for lock-free sampling under contention. |
+| `cycles-admin-service-data/.../repository/AuditRepository.java` | Widened `LOG_AUDIT_LUA` to accept per-entry TTL (seconds) via `ARGV[4]`. Lua branches on `ttl > 0` — non-positive → plain `SET`, positive → `SET ... EX ttl`. Two new `@Value`-bound fields: `audit.retention.authenticated.days:400` and `audit.retention.unauthenticated.days:30`. New `resolveTtlSeconds(entry)` picks tier by `AuditLogEntry.UNAUTHENTICATED_TENANT` check. New `@Scheduled(cron = "${audit.sweep.cron:0 0 3 * * *}") sweepStaleIndexEntries()` method purges TTL-expired pointers from global + per-tenant indexes via `ZREMRANGEBYSCORE` (uses `SCAN` to enumerate per-tenant indexes; O(log N + M) per remove). Sweep skipped when `authenticatedRetentionDays <= 0` (indefinite retention). `list()` debug log message updated to note TTL-expired entries are expected. |
+| `cycles-admin-service-api/.../BudgetGovernanceApplication.java` | Added `@EnableScheduling` so `AuditRepository.sweepStaleIndexEntries()` fires on the configured cron. |
+| `cycles-admin-service-api/src/main/resources/application.properties` | Added 4 new properties: `audit.retention.authenticated.days` (default 400), `audit.retention.unauthenticated.days` (default 30), `audit.sample.unauthenticated` (default 1), `audit.sweep.cron` (default `0 0 3 * * *`). All env-var overridable. |
+| `cycles-admin-service-api/.../exception/GlobalExceptionHandler.java` | Constructor inject `AuditFailureService`. All 7 `@ExceptionHandler` methods call `logFailure(...)` before returning. Generic handler passes `exception_class` in metadata for post-incident triage; delegates `GovernanceException` to its dedicated handler to prevent double-writes. |
+| `cycles-admin-service-api/.../config/AuthInterceptor.java` | Constructor widened from 2 → 3 deps (added `AuditFailureService`). `writeError(...)` calls `logFailure(...)` before writing the error body. Covers all 7 call sites: path traversal 400; admin key missing 401; admin key blank/invalid 401; admin key misconfigured 500; api key missing 401; api key invalid 403; insufficient permissions 403. |
+| `cycles-admin-service-api/.../config/AuthInterceptorTest.java` | Added `@Mock AuditFailureService`; updated constructor call. +8 tests locking the failure-audit contract at the interceptor layer (7 failure call sites + 1 single-write-invariant guard for the success path). |
+| `cycles-admin-service-api/.../exception/GlobalExceptionHandlerTest.java` | Added `AuditFailureService` mock injection to setUp. +8 tests verifying every `@ExceptionHandler` branch writes the failure audit entry with correct status + error_code; explicit single-write-invariant test for the `GovernanceException` → generic-dispatch edge case. |
+| `cycles-admin-service-api/.../service/AuditFailureServiceTest.java` (new) | 15 unit tests: sentinel resolution (null attr, empty attr); authenticated tier not sampled at any rate (guard against widened gate); unauthenticated tier at rate 1 (never sampled, 200 iterations deterministic); unauthenticated at rate 100 (statistical bounds, 1000 iterations); rate 0 treated as 1 (misconfig safety); CR/LF sanitization; 1024-char truncation; null message omits key; extras merged; non-throwing under `AuditRepository` failure (error counter increments); null request safe. **Plus 2 DDoS-in-miniature concurrency tests**: (a) 1000 concurrent `logFailure` calls on 16 threads at rate=100 — asserts `written + sampled-out + error == 1000` exactly (no lost increments), `error == 0` (non-throwing under contention), and statistical sampling bounds hold; (b) 500 concurrent authenticated failures at rate=10000 — asserts 100% fidelity (authenticated tier immune to sampling under load). |
+| `cycles-admin-service-data/.../repository/AuditRepositoryTest.java` | +7 tests: `resolveTtlSeconds` for authenticated / unauthenticated / zero tiers; `log()` passes correct TTL in `ARGV[4]` per tier; `log()` with retention 0 passes 0 (Lua skips EX); `sweepStaleIndexEntries` skipped when retention is indefinite; sweep removes from both global and per-tenant indexes without double-sweeping `audit:logs:_all` through the SCAN enumeration; sweep Redis-failure non-throwing. |
+| `cycles-admin-service-api/.../integration/AuditRetentionIntegrationTest.java` (new) | 3 end-to-end tests against real Redis (Testcontainers): authenticated failure produces key with `ttl ≈ 400d`; unauthenticated failure produces key with `ttl ≈ 30d`; the two tiers produce materially distinct TTLs (diff > 300d). Closes the Lua-mock gap — proves Redis actually applies the EX, not just that the Lua receives the right value. Runs under `-Pintegration-tests`. |
+| `cycles-admin-service-api/.../integration/AuditRetentionIndefiniteIntegrationTest.java` (new) | 3 end-to-end tests with `@TestPropertySource(audit.retention.*.days=0)` overriding defaults: unauthenticated failure produces key with `ttl = -1` (no expiry); authenticated failure same; `sweepStaleIndexEntries` under retention=0 does not touch live pointers (regression guard — a future refactor that re-enables sweep under indefinite retention would delete pointers to forever-retain records). |
+| `cycles-admin-service-api/.../integration/AdminFlowIntegrationTest.java` | New step 25 — 3 deliberate failures (unauth 401, malformed JSON 400, nonexistent resource 404) followed by audit-log query asserting each failure landed with correct status, error_code, operation, and tenant_id sentinel on unauth case. Contract-validated end-to-end against `cycles-protocol@main`. |
+| `OPERATIONS.md` | New "Audit coverage" subsection documenting success-path (per-controller, rich metadata) vs failure-path (handler/interceptor, coarse but status + error_code). Added `cycles_admin_audit_writes_total` to Metrics inventory with alert recipe on `outcome=error` rate. |
+| `CHANGELOG.md` | New `## [0.1.25.20]` section. |
+| `pom.xml` | `revision` 0.1.25.19 → 0.1.25.20. |
+| `docker-compose.prod.yml` + `docker-compose.full-stack.prod.yml` | Image tag 0.1.25.19 → 0.1.25.20. |
+
+**Design choices:**
+- **Sentinel over nullable tenant_id.** Spec declares `tenant_id` required. Making it nullable would need a cycles-protocol PR and block this release on spec-first merge ordering. Sentinel is backward-compatible: existing queries that filter `tenant_id=<real-tenant>` continue returning only that tenant's entries; failed-attempt review uses the sentinel as a filter value.
+- **Include error_message in metadata (operator confirmed).** Queryable `error_code` is the machine key; `error_message` is the "what specifically went wrong" for the human reviewer. Sanitization keeps it safe.
+- **"METHOD:URI" operation format on failure.** Per-controller operation names (`createBudget`, `fundBudget`) aren't available pre-controller or in `GlobalExceptionHandler`. Ops queries can still group by operation; success entries use the rich name, failure entries use the coarse form. Different format across success/failure is deliberate — failure entries are intentionally less specific.
+- **Prometheus counter outcome=error as the alert surface.** If audit writes silently fail (Redis down, auth-chain breakage), `outcome=error` spikes while the error responses themselves still reach clients. Critical for compliance: never trust that "zero failure entries in Redis" means "zero failures occurred" without also checking this counter.
+
+**Verification:**
+- `mvn verify` passes 560 unit tests (up from 528), JaCoCo ≥95% on all modules, `SpecCoverageReportTest` 43/43 endpoints. 2 new integration tests (`AuditRetentionIntegrationTest`, `AuditRetentionIndefiniteIntegrationTest`) run under `-Pintegration-tests` against Testcontainers Redis.
+- `OpenApiContractDiffTest` — zero INCOMPATIBLE diff. No wire-format changes: `AuditLogEntry` schema already had every field populated on failure (`error_code` was already declared optional, `metadata` was already `Map<String, Object>`).
+- `AdminFlowIntegrationTest` — 25-step flow ends with an audit-log query that asserts each deliberate failure landed with correct status, error_code, and tenant_id sentinel. Entries validated on the wire by `ContractValidatingRestTemplateInterceptor`.
+
+**Operator note:** Queries that filter `status=201` / `status=200` are unaffected — those return exactly the same rows as before. Queries without a status filter (or with `status=401/403/400/404/409/500`) now surface the new failure entries. Dashboards that assume "audit entry exists ⇒ operation succeeded" are broken by this change — callers must now check `status` or `error_code` to distinguish success from failure. No CLAUDE.md/integration-tests change required: the admin-owned integration tests (`runcycles/.github`) only read audit logs for post-flow verification and don't make the success-assumption.
+
+**Cross-refs:** this release has no cycles-protocol dependency — the fix is entirely admin-side and the spec already accommodates the failure entry shape. No change to cycles-server or cycles-server-events.
+
+---
 
 ### 2026-04-16 — v0.1.25.19 /v1/auth/introspect dual-auth + operator docs (spec v0.1.25.15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,109 @@ changes to request/response bodies or Lua-script semantics would require a
 minor bump. Additive fields (new optional response fields, new enum values,
 new optional request fields) are **not** considered breaking.
 
+## [0.1.25.20] — 2026-04-16
+
+### Added
+
+- `GET /v1/admin/audit/logs` now returns entries for **failed** requests
+  (401 / 403 / 400 / 404 / 409 / 500) alongside the existing success-path
+  entries. Previously the audit log only captured successful operations
+  (STATUS 201 / 200 / 204) because writes happened inside each controller
+  method after the service call returned; errors short-circuited before
+  the write. Closes a real compliance-auditing gap for SOC2 / GDPR
+  reviewers who need authz denials, malformed requests, and state-
+  transition violations on the record.
+- Failure entries carry `status`, `error_code` (e.g. `UNAUTHORIZED`,
+  `INVALID_REQUEST`, `TENANT_NOT_FOUND`), `operation="<METHOD>:<URI>"`
+  (e.g. `POST:/v1/admin/budgets`), `metadata.error_message` (sanitized,
+  1024-char capped), `metadata.method`, `metadata.path`, and — on
+  `500 INTERNAL_ERROR` — `metadata.exception_class` for post-incident
+  triage. `request_id`, `source_ip`, `user_agent` populated from the
+  request the same way as success entries.
+- New sentinel tenant value `"<unauthenticated>"` on failure entries
+  where no authenticated tenant exists (missing / invalid API key, pre-
+  auth failure). Preserves the spec's `tenant_id: required` invariant
+  without a wire-format change. Queryable via
+  `GET /v1/admin/audit/logs?tenant_id=%3Cunauthenticated%3E` for
+  failed-attempt review.
+- New Prometheus counter `cycles_admin_audit_writes_total{path_class,
+  outcome}`. `path_class=failure,outcome=written` increments per
+  failure entry persisted. `path_class=failure,outcome=error`
+  increments when an audit write itself fails (Redis down, meter
+  registry wedged, …). `path_class=failure,outcome=sampled-out`
+  increments when an unauthenticated-tier entry was intentionally
+  dropped by sampling. **Alert on `outcome=error` nonzero** — audit
+  writes are non-fatal to the request but silent coverage loss is the
+  exact failure mode this release is trying to prevent.
+- **Tiered TTL on audit entries** with SOC2-compliant defaults
+  (configurable, settable to 0 for indefinite):
+  - `audit.retention.authenticated.days` — default **400** (SOC2 Type
+    II 12-month lookback + 1-month auditor-engagement buffer). Applies
+    to every entry where `tenant_id != "<unauthenticated>"` — success
+    entries and authenticated failures alike. Set to `0` for
+    indefinite retention (legal hold, HIPAA-adjacent, forever-retain
+    deployments).
+  - `audit.retention.unauthenticated.days` — default **30**. Applies
+    to pre-auth failures attributed to the sentinel tenant. Enough
+    for brute-force / credential-stuffing post-mortem; aggregate
+    attempt volume stays visible via the Prometheus counter regardless
+    of TTL. Set to `0` for indefinite.
+- **Optional sampling for unauthenticated entries** —
+  `audit.sample.unauthenticated` (default **1** = no sampling).
+  Setting to `100` records 1 in 100 pre-auth failures; operator
+  opt-in only. Authenticated entries are **never** sampled.
+- **Daily audit index sweep** — new `@Scheduled` job
+  (`audit.sweep.cron`, default `0 0 3 * * *`) purges TTL-expired
+  pointers from the `audit:logs:_all` + per-tenant sorted-set indexes.
+  Without this, indexes grow unboundedly even though the underlying
+  log records have expired. Sweep is best-effort and non-fatal; skipped
+  entirely when `audit.retention.authenticated.days=0` (indefinite
+  retention — no expiry means no zombies to clean up).
+
+### Wire format
+
+Additive. Success-path entries are byte-identical to 0.1.25.19. Failure
+entries reuse the existing `AuditLogEntry` schema — `error_code` was
+already defined as optional; `metadata` was already `Map<String,
+Object>`. No spec change required.
+
+Retention is a Redis-side TTL on audit-log keys — it's an *infrastructure*
+change, not a wire-format change. Clients that persist audit-log
+responses locally aren't affected by retention settings server-side.
+
+### Notes for upgraders
+
+- **Breaking semantic change for audit-log consumers.** Queries filtered
+  by `status=201` / `status=200` / `status=204` return exactly the same
+  rows as before. Queries without a `status` filter (or with
+  `status=4xx/5xx`) now surface failure entries that didn't exist in
+  0.1.25.19. Dashboards that assumed "audit entry exists ⇒ operation
+  succeeded" must switch to checking `status` or `error_code` to
+  distinguish.
+- Redis memory footprint grows with failure traffic. The existing
+  retention (Redis TTL on `audit:log:{logId}` + sorted sets) applies
+  unchanged — no separate knob for failure entries. If failure volume
+  dominates (e.g. under an authz misconfiguration causing sustained
+  403s), consider lowering the TTL or reviewing the traffic pattern
+  rather than the audit layer.
+- Grafana / Prometheus: add an alert on
+  `sum(rate(cycles_admin_audit_writes_total{outcome="error"}[5m])) > 0`
+  so silent audit-write failures page ops.
+- **Retention defaults are SOC2-compliant out of the box**. Operators
+  with different compliance regimes should set the retention properties
+  (or their env-var equivalents `AUDIT_RETENTION_AUTHENTICATED_DAYS`,
+  `AUDIT_RETENTION_UNAUTHENTICATED_DAYS`) before first boot. HIPAA and
+  certain financial regulations require multi-year retention — set
+  `audit.retention.authenticated.days=0` for indefinite, then archive
+  externally on whatever cadence your policy requires. Legal hold:
+  also `0`, never decrement while the hold is active.
+- **DDoS exposure assessment**: if the admin endpoint is internet-
+  facing with no upstream rate limiter, set `audit.sample.unauthenticated`
+  to `100` (or higher) to cap write amplification from failed-auth
+  floods. Aggregate attempt volume remains observable via
+  `cycles_admin_audit_writes_total` — sampling reduces Redis load, not
+  monitoring fidelity.
+
 ## [0.1.25.19] — 2026-04-16
 
 ### Added
@@ -207,6 +310,7 @@ should switch to treating 409 as success-equivalent.
 - Multiple spec-compliance hardening fixes across controllers and error
   contracts (see `AUDIT.md` for the full list).
 
+[0.1.25.20]: https://github.com/runcycles/cycles-server-admin/releases/tag/0.1.25.20
 [0.1.25.19]: https://github.com/runcycles/cycles-server-admin/releases/tag/0.1.25.19
 [0.1.25.18]: https://github.com/runcycles/cycles-server-admin/releases/tag/0.1.25.18
 [0.1.25.17]: https://github.com/runcycles/cycles-server-admin/releases/tag/0.1.25.17

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -17,10 +17,74 @@ Alerts for the two planes should be routed separately.
 
 ## Table of contents
 
-1. [Metrics inventory](#metrics-inventory)
-2. [Alerts worth paging on](#alerts-worth-paging-on)
-3. [Configuration tuning](#configuration-tuning)
-4. [Incident playbook](#incident-playbook)
+1. [Audit coverage](#audit-coverage)
+2. [Metrics inventory](#metrics-inventory)
+3. [Alerts worth paging on](#alerts-worth-paging-on)
+4. [Configuration tuning](#configuration-tuning)
+5. [Incident playbook](#incident-playbook)
+
+---
+
+## Audit coverage
+
+`GET /v1/admin/audit/logs` returns entries for every authenticated write
+operation **and every failed request** (since v0.1.25.20). The write side
+is split across two distinct code paths.
+
+**Success-path entries** — written by each controller after the
+repository / service call returns successfully. Rich, operation-specific
+metadata:
+
+| Field | Typical value on success |
+|---|---|
+| `operation` | Rich per-op name, e.g. `createBudget`, `fundBudget`, `updateTenant` |
+| `status` | HTTP status of the successful response — 201, 200, 204 |
+| `resource_type`, `resource_id` | Populated for mutations — `budget` / `scope:unit`, `tenant` / `tenant_id`, `policy` / `policy_id` |
+| `subject`, `action`, `amount` | Populated on funding operations, policy changes, etc. |
+| `metadata` | Operation-specific extras — fund reason, before/after spent (RESET_SPENT), policy caps diff, actor_type=admin_on_behalf_of on dual-auth writes |
+
+**Failure-path entries** (v0.1.25.20+) — written by
+`GlobalExceptionHandler` (4xx/5xx inside the controller) and
+`AuthInterceptor` (401/403/400/500 rejections before the controller
+runs). Coarse but always-present:
+
+| Field | Typical value on failure |
+|---|---|
+| `operation` | `METHOD:URI` form — e.g. `POST:/v1/admin/budgets`, `GET:/v1/auth/introspect` |
+| `status` | Actual HTTP status of the error response — 401, 403, 400, 404, 409, 500 |
+| `error_code` | `ErrorCode.name()` — `UNAUTHORIZED`, `INVALID_REQUEST`, `TENANT_NOT_FOUND`, `KEY_REVOKED`, `INSUFFICIENT_PERMISSIONS`, `INTERNAL_ERROR`, … |
+| `tenant_id` | Real tenant id if authenticated; sentinel `"<unauthenticated>"` if the request never produced a bound tenant (missing / invalid API key, admin-key-only auth where no `authenticated_tenant_id` attr is stamped) |
+| `metadata.error_message` | Sanitized server-side message (CR/LF stripped, 1024-char capped) |
+| `metadata.method`, `metadata.path` | Request method and URI |
+| `metadata.exception_class` | Only on `500 INTERNAL_ERROR` — fully-qualified Java class name for post-incident triage |
+| `resource_type`, `resource_id`, `subject`, `action`, `amount` | Absent — not derivable on failure paths |
+
+**Single-write invariant.** One request produces one audit entry: either
+a success entry (controller reached the audit-log line) or a failure
+entry (`GlobalExceptionHandler` or `AuthInterceptor.writeError` handled
+the request). Never both. Never zero either — failed writes themselves
+are captured in the `cycles_admin_audit_writes_total{outcome}` counter.
+
+**Dashboards that pre-date v0.1.25.20** may assume "audit entry exists ⇒
+operation succeeded". That's no longer true. Check `status` (2xx vs
+4xx/5xx) or `error_code` (null on success, populated on failure) to
+distinguish.
+
+**Query examples:**
+
+```bash
+# Failed admin attempts (unauthenticated).
+GET /v1/admin/audit/logs?tenant_id=%3Cunauthenticated%3E
+
+# All 401 rejections in the last hour.
+GET /v1/admin/audit/logs?status=401&from=<iso8601>
+
+# All budget-plane failures by a specific tenant.
+GET /v1/admin/audit/logs?tenant_id=tenant-1&operation=POST:/v1/admin/budgets
+
+# Single-request trace — pairs the audit entry with the server log by request_id.
+GET /v1/admin/audit/logs  # then filter client-side by request_id
+```
 
 ---
 
@@ -42,6 +106,12 @@ auto-metrics (`http_server_requests_seconds`, `jvm_*`, `process_*`,
 | Metric | Tags | What it tells you |
 |---|---|---|
 | `cycles_admin_webhook_dispatched_total` | `result` | Every webhook-delivery enqueue attempt. `result=queued` when at least one matching subscription existed and a delivery row was created; `result=failure` on dispatch/enqueue error. This is a dispatch-path counter, not a delivery-outcome one — actual HTTP-delivery outcomes live in the sibling `cycles-server-events` service. |
+
+### Audit log writes (v0.1.25.20+)
+
+| Metric | Tags | What it tells you |
+|---|---|---|
+| `cycles_admin_audit_writes_total` | `path_class`, `outcome` | Every failure-path audit-write attempt. `path_class=failure` (only value currently emitted — success-path writes come from per-controller `AuditRepository.log()` calls directly, no counter). Outcomes: `written` (persisted), `error` (write itself failed — Redis down, meter registry wedged, serialization bug; business request still returned correctly), `sampled-out` (unauthenticated-tier entry intentionally dropped by `audit.sample.unauthenticated` > 1). **`outcome=error` is the silent-coverage-loss alert surface** — alert on any nonzero rate. **`outcome=sampled-out` is operator-intentional** — high values under DDoS are the sampling working as configured; aggregate volume is (`written` + `sampled-out`). |
 
 ### HTTP
 
@@ -136,6 +206,22 @@ above catches it. A more specific alert:
     description: "Check ADMIN_API_KEY env var / admin.api-key property on the running pod."
 ```
 
+### Audit-write silent-coverage loss
+
+```yaml
+- alert: AdminAuditWriteErrors
+  # v0.1.25.20+: failure-path audit writes that themselves fail. The
+  # business request still returns the correct error response, but the
+  # audit trail silently loses coverage. Compliance-critical — page on
+  # first occurrence.
+  expr: sum(rate(cycles_admin_audit_writes_total{outcome="error"}[5m])) > 0
+  for: 5m
+  labels: {severity: page}
+  annotations:
+    summary: admin audit writes failing — compliance coverage at risk
+    description: "Failure-path audit entries are not persisting. Check Redis health + AuditRepository error logs."
+```
+
 ### Webhook dispatch failures
 
 ```yaml
@@ -175,8 +261,63 @@ with env overrides.
 | `webhook.secret.encryption-key` | `WEBHOOK_SECRET_ENCRYPTION_KEY` | (unset) | Base64 AES-256 key used to encrypt webhook signing secrets at rest. Must match the value on `cycles-server-events`. Rotate by generating a new value, re-encrypting existing secrets, and deploying in lockstep with the events service. |
 | `events.retention.event-ttl-days` | `EVENT_TTL_DAYS` | `90` | Retention for emitted events in Redis. Tune down in high-volume deployments to bound memory. |
 | `events.retention.delivery-ttl-days` | `DELIVERY_TTL_DAYS` | `14` | Retention for webhook-delivery attempt records. |
+| `audit.retention.authenticated.days` | `AUDIT_RETENTION_AUTHENTICATED_DAYS` | `400` | Retention (days) for authenticated audit entries (success + authenticated failure). Default 400 = SOC2 Type II 12-month lookback + 1-month buffer. **Set to `0` for indefinite** (legal hold, HIPAA-adjacent, forever-retain deployments, or when archiving externally). See [Audit retention tuning](#audit-retention-tuning) below. |
+| `audit.retention.unauthenticated.days` | `AUDIT_RETENTION_UNAUTHENTICATED_DAYS` | `30` | Retention for pre-auth failure audit entries (sentinel `tenant_id=<unauthenticated>`). Enough for brute-force / credential-stuffing forensic window. Set to `0` for indefinite. |
+| `audit.sample.unauthenticated` | `AUDIT_SAMPLE_UNAUTHENTICATED` | `1` | Sampling rate for unauthenticated-tier entries — record 1 in N. Default `1` = record every attempt (full fidelity). Tune to `100` in DDoS-exposed deployments to cut Redis write volume 100×. Aggregate volume remains visible via the `cycles_admin_audit_writes_total` counter. Authenticated entries are **never** sampled regardless of this setting. Values `≤ 0` treated as `1` (misconfig safety). |
+| `audit.sweep.cron` | `AUDIT_SWEEP_CRON` | `0 0 3 * * *` | Cron schedule for the daily audit index sweep (`ZREMRANGEBYSCORE` on expired pointers). Default 03:00 server time. Sweep is best-effort; skipped entirely when `audit.retention.authenticated.days=0` (indefinite — nothing to sweep). |
 | `dashboard.cors.origin` | `DASHBOARD_CORS_ORIGIN` | `http://localhost:5173` | CORS allowed origin(s). Comma-separated. **In production, set to your dashboard URL** — the default only works against the local Vite dev server. |
 | `contract.validation.enabled` | `CONTRACT_VALIDATION_ENABLED` | `true` (tests) / `false` (runtime) | Fetch and validate against the live admin spec at build time. Disable for offline / air-gapped builds. Does not affect runtime — enforcement happens only in the test harness. |
+
+### Audit retention tuning
+
+The retention defaults (400 days authenticated, 30 days unauthenticated)
+are calibrated for SOC2 Type II out of the box. Different compliance
+regimes and operational realities warrant different settings:
+
+**Scenario: SOC2 only — standard deployment.** Defaults work as shipped.
+No changes needed.
+
+**Scenario: HIPAA-adjacent / multi-year retention required.** Set
+`audit.retention.authenticated.days=0` (indefinite). The authenticated
+tier now retains forever in Redis. Plan for external archival (S3,
+SIEM) — Redis isn't designed to be a long-term store. Pair this with
+explicit monitoring of Redis memory, and consider shipping audit events
+to an immutable archive on a schedule.
+
+**Scenario: legal hold triggered on a specific tenant.** Set
+`audit.retention.authenticated.days=0` during the hold period. After
+resolution, restore the previous value — entries written during the
+hold will still age out normally (TTL is applied at write time, not
+retroactively).
+
+**Scenario: internet-facing admin endpoint, no upstream WAF.** Set
+`audit.sample.unauthenticated=100` (or higher) to reduce DDoS
+write-amplification. A sustained 10k req/s failed-auth flood at rate 1
+would write ~30k Redis ops/s on a single Lua-serialized surface; rate
+100 cuts that to 300 ops/s. Aggregate attempt volume stays visible via
+`cycles_admin_audit_writes_total{outcome=sampled-out}`.
+
+**Scenario: memory-constrained deployment.** Tune retention down
+(e.g. `authenticated.days=90`, `unauthenticated.days=7`) BEFORE adjusting
+sampling. TTL + sweep bound memory footprint at a predictable rate;
+sampling reduces fidelity. If ops really needs to trade memory for
+fidelity, both levers together work — just understand which compliance
+controls you're affecting.
+
+**Checking what you actually have stored:**
+
+```bash
+# Authenticated entries for a specific tenant, TTL remaining on first hit:
+redis-cli -h $REDIS_HOST KEYS 'audit:log:*' | head -1 | xargs redis-cli -h $REDIS_HOST TTL
+
+# Global index size (unbounded if no sweep or retention=0):
+redis-cli -h $REDIS_HOST ZCARD audit:logs:_all
+
+# Per-tenant index sizes (top 10 by cardinality):
+redis-cli -h $REDIS_HOST KEYS 'audit:logs:*' | while read k; do
+  echo "$(redis-cli -h $REDIS_HOST ZCARD "$k") $k"
+done | sort -rn | head -10
+```
 
 ### Rotating the admin API key
 

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/BudgetGovernanceApplication.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/BudgetGovernanceApplication.java
@@ -6,10 +6,14 @@ import org.springframework.boot.*;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.info.BuildProperties;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.stereotype.Component;
 
 @SpringBootApplication
 @ComponentScan(basePackages = "io.runcycles.admin")
+// v0.1.25.20: @EnableScheduling activates AuditRepository.sweepStaleIndexEntries
+// (cron-driven index-pointer GC) and any future @Scheduled tasks.
+@EnableScheduling
 public class BudgetGovernanceApplication {
 
     public static void main(String[] args) {

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/config/AuthInterceptor.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/config/AuthInterceptor.java
@@ -1,5 +1,6 @@
 package io.runcycles.admin.api.config;
 
+import io.runcycles.admin.api.service.AuditFailureService;
 import io.runcycles.admin.data.repository.ApiKeyRepository;
 import io.runcycles.admin.model.auth.ApiKeyValidationResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -110,10 +111,18 @@ public class AuthInterceptor implements HandlerInterceptor {
 
     private final ApiKeyRepository apiKeyRepository;
     private final ObjectMapper objectMapper;
+    // v0.1.25.20: pre-controller auth rejections (401/403/400/500) never
+    // reach the controller, so GlobalExceptionHandler doesn't see them.
+    // AuditFailureService closes that gap — every writeError() call also
+    // emits an audit entry with the pending response status and error code.
+    private final AuditFailureService auditFailure;
 
-    public AuthInterceptor(ApiKeyRepository apiKeyRepository, ObjectMapper objectMapper) {
+    public AuthInterceptor(ApiKeyRepository apiKeyRepository,
+                           ObjectMapper objectMapper,
+                           AuditFailureService auditFailure) {
         this.apiKeyRepository = apiKeyRepository;
         this.objectMapper = objectMapper;
+        this.auditFailure = auditFailure;
     }
 
     @Override
@@ -320,6 +329,11 @@ public class AuthInterceptor implements HandlerInterceptor {
     }
 
     private void writeError(HttpServletRequest request, HttpServletResponse response, int status, ErrorCode code, String message) throws Exception {
+        // v0.1.25.20: audit first, respond second. logFailure is non-throwing —
+        // if it ever fails internally it increments the outcome=error counter
+        // and logs a warning but never propagates, so the error response is
+        // guaranteed to reach the client even if audit-write is broken.
+        auditFailure.logFailure(request, status, code, message, null);
         response.setStatus(status);
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         Object reqId = request.getAttribute(RequestIdFilter.REQUEST_ID_ATTRIBUTE);

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/exception/GlobalExceptionHandler.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package io.runcycles.admin.api.exception;
 
 import io.runcycles.admin.api.filter.RequestIdFilter;
+import io.runcycles.admin.api.service.AuditFailureService;
 import io.runcycles.admin.data.exception.GovernanceException;
 import io.runcycles.admin.model.shared.ErrorCode;
 import io.runcycles.admin.model.shared.ErrorResponse;
@@ -20,6 +21,12 @@ import java.util.stream.Collectors;
 public class GlobalExceptionHandler {
     private static final Logger LOG = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
+    private final AuditFailureService auditFailure;
+
+    public GlobalExceptionHandler(AuditFailureService auditFailure) {
+        this.auditFailure = auditFailure;
+    }
+
     private String resolveRequestId(HttpServletRequest request) {
         Object attr = request != null ? request.getAttribute(RequestIdFilter.REQUEST_ID_ATTRIBUTE) : null;
         return attr != null ? attr.toString() : UUID.randomUUID().toString();
@@ -28,6 +35,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(GovernanceException.class)
     public ResponseEntity<ErrorResponse> handleGovernanceException(GovernanceException ex, HttpServletRequest request) {
         LOG.info("Landed in governance exception handler: clazz={}", ex.getClass());
+        auditFailure.logFailure(request, ex.getHttpStatus(), ex.getErrorCode(), ex.getMessage(), null);
         return ResponseEntity.status(ex.getHttpStatus()).body(ErrorResponse.builder()
             .error(ex.getErrorCode()).message(ex.getMessage()).requestId(resolveRequestId(request)).details(ex.getDetails()).build());
     }
@@ -37,8 +45,10 @@ public class GlobalExceptionHandler {
         String message = ex.getBindingResult().getFieldErrors().stream()
             .map(e -> e.getField() + ": " + e.getDefaultMessage())
             .collect(Collectors.joining(", "));
+        String fullMessage = "Validation failed: " + message;
+        auditFailure.logFailure(request, HttpStatus.BAD_REQUEST.value(), ErrorCode.INVALID_REQUEST, fullMessage, null);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-            .body(ErrorResponse.builder().error(ErrorCode.INVALID_REQUEST).message("Validation failed: " + message).requestId(resolveRequestId(request)).build());
+            .body(ErrorResponse.builder().error(ErrorCode.INVALID_REQUEST).message(fullMessage).requestId(resolveRequestId(request)).build());
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
@@ -50,13 +60,16 @@ public class GlobalExceptionHandler {
                 return param + ": " + v.getMessage();
             })
             .collect(Collectors.joining(", "));
+        String fullMessage = "Validation failed: " + message;
+        auditFailure.logFailure(request, HttpStatus.BAD_REQUEST.value(), ErrorCode.INVALID_REQUEST, fullMessage, null);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-            .body(ErrorResponse.builder().error(ErrorCode.INVALID_REQUEST).message("Validation failed: " + message).requestId(resolveRequestId(request)).build());
+            .body(ErrorResponse.builder().error(ErrorCode.INVALID_REQUEST).message(fullMessage).requestId(resolveRequestId(request)).build());
     }
 
     @ExceptionHandler(MissingServletRequestParameterException.class)
     public ResponseEntity<ErrorResponse> handleMissingParam(MissingServletRequestParameterException ex, HttpServletRequest request) {
         String message = "Missing required parameter: " + ex.getParameterName();
+        auditFailure.logFailure(request, HttpStatus.BAD_REQUEST.value(), ErrorCode.INVALID_REQUEST, message, null);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
             .body(ErrorResponse.builder().error(ErrorCode.INVALID_REQUEST).message(message).requestId(resolveRequestId(request)).build());
     }
@@ -64,12 +77,14 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<ErrorResponse> handleTypeMismatch(MethodArgumentTypeMismatchException ex, HttpServletRequest request) {
         String message = "Invalid value for parameter '" + ex.getName() + "': " + ex.getValue();
+        auditFailure.logFailure(request, HttpStatus.BAD_REQUEST.value(), ErrorCode.INVALID_REQUEST, message, null);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
             .body(ErrorResponse.builder().error(ErrorCode.INVALID_REQUEST).message(message).requestId(resolveRequestId(request)).build());
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ErrorResponse> handleMalformedJson(HttpMessageNotReadableException ex, HttpServletRequest request) {
+        auditFailure.logFailure(request, HttpStatus.BAD_REQUEST.value(), ErrorCode.INVALID_REQUEST, "Malformed request body", null);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
             .body(ErrorResponse.builder().error(ErrorCode.INVALID_REQUEST).message("Malformed request body").requestId(resolveRequestId(request)).build());
     }
@@ -78,14 +93,25 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleGenericException(Exception ex, HttpServletRequest request) {
         LOG.error("Unhandled exception: clazz={}", ex.getClass(), ex);
         if (ex instanceof GovernanceException) {
+            // Dispatch-order safety: if a GovernanceException ever reaches the
+            // generic branch (Spring's handler-order behaviour corner cases),
+            // defer to the dedicated handler — it already writes the audit
+            // entry, so we must NOT double-write.
             return handleGovernanceException((GovernanceException) ex, request);
-        } else {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ErrorResponse.builder()
-                    .error(ErrorCode.INTERNAL_ERROR)
-                    .message("Internal error")
-                    .requestId(resolveRequestId(request))
-                    .build());
         }
+        // Record metadata captures exception class for post-incident triage.
+        // Message intentionally generic on the wire ("Internal error") — full
+        // class and stack stay in the server logs, but the class name in the
+        // audit entry lets ops correlate an audit row to the matching log line.
+        Map<String, Object> extras = new HashMap<>();
+        extras.put("exception_class", ex.getClass().getName());
+        auditFailure.logFailure(request, HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                ErrorCode.INTERNAL_ERROR, ex.getMessage(), extras);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(ErrorResponse.builder()
+                .error(ErrorCode.INTERNAL_ERROR)
+                .message("Internal error")
+                .requestId(resolveRequestId(request))
+                .build());
     }
 }

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/AuditFailureService.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/AuditFailureService.java
@@ -1,0 +1,246 @@
+package io.runcycles.admin.api.service;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.runcycles.admin.api.filter.RequestIdFilter;
+import io.runcycles.admin.data.repository.AuditRepository;
+import io.runcycles.admin.model.audit.AuditLogEntry;
+import io.runcycles.admin.model.shared.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Shared failure-path audit writer. Used by {@code GlobalExceptionHandler}
+ * (controller-level exceptions → 4xx/5xx) and {@code AuthInterceptor}
+ * (pre-controller auth rejections → 401/403/400/500 before any controller
+ * runs).
+ *
+ * <p><b>Design (v0.1.25.20).</b> Admin server writes audit entries on
+ * success paths from within each controller method; failures never reached
+ * those writes (controller throws → {@code GlobalExceptionHandler} runs →
+ * no audit entry). This service closes that gap.
+ *
+ * <p><b>Single-write invariant by construction.</b> Success-path writes
+ * execute only after the repository/service call returns, so a thrown
+ * exception can never produce both a success entry and a failure entry
+ * for the same request. Pre-controller auth failures never reach the
+ * controller at all.
+ *
+ * <p><b>Non-fatal contract preserved.</b> {@code AuditRepository.log()}
+ * already swallows all exceptions. This service wraps its own code in
+ * {@code try/catch} as defense-in-depth — an audit-write failure must
+ * never mask the real error response. The {@code outcome=error} counter
+ * increment lets ops alert on silent coverage loss.
+ *
+ * <p><b>Unauthenticated tenant sentinel.</b> Admin-plane spec marks
+ * {@code tenant_id} as required on every audit entry. Pre-auth failures
+ * (missing key, invalid key) have no authenticated tenant. Sentinel
+ * {@link #UNAUTHENTICATED_TENANT} preserves the {@code required} invariant
+ * and stays queryable for failed-attempt review
+ * ({@code GET /v1/admin/audit/logs?tenant_id=%3Cunauthenticated%3E}).
+ */
+@Service
+public class AuditFailureService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AuditFailureService.class);
+
+    /**
+     * Tenant-id sentinel for pre-auth failures.
+     *
+     * <p><b>Source of truth lives on {@link AuditLogEntry#UNAUTHENTICATED_TENANT}</b>
+     * so {@code AuditRepository} (data layer) can reference it for tiered-TTL
+     * decisions without depending on this api/service-layer class. This
+     * reference is kept as a convenience alias for callers already on this
+     * service.
+     */
+    public static final String UNAUTHENTICATED_TENANT = AuditLogEntry.UNAUTHENTICATED_TENANT;
+
+    /**
+     * Cap on {@code metadata.error_message} length. Bounds audit row size,
+     * prevents a pathological error message from bloating Redis memory, and
+     * limits exposure surface if a message ever carries caller-controlled
+     * content (defense in depth — exception messages SHOULD be server-side
+     * strings, but sanitize regardless).
+     */
+    private static final int ERROR_MESSAGE_MAX_LEN = 1024;
+
+    private final AuditRepository auditRepository;
+    private final MeterRegistry meterRegistry;
+
+    /**
+     * Sampling rate for {@link #UNAUTHENTICATED_TENANT} failure entries —
+     * record 1 in N. Value {@code 1} (default) records every attempt —
+     * safe default preserving full fidelity for small deployments.
+     * Set to {@code 100} (or higher) in DDoS-exposed deployments to cut
+     * Redis write volume by 100×; aggregate attempt rate stays visible
+     * via {@code cycles_admin_audit_writes_total{outcome=sampled-out}}.
+     *
+     * <p>Authenticated failure entries (valid tenant key, 403 / 404 /
+     * 409 / 500) are <b>never</b> sampled — they're compliance-relevant
+     * security signals, not DDoS noise.
+     *
+     * <p>Values {@code <= 0} are treated as {@code 1} (no sampling) for
+     * safety: a misconfigured zero must not silently drop all audit writes.
+     *
+     * @since 0.1.25.20
+     */
+    @Value("${audit.sample.unauthenticated:1}")
+    private int unauthenticatedSampleRate;
+
+    public AuditFailureService(AuditRepository auditRepository, MeterRegistry meterRegistry) {
+        this.auditRepository = auditRepository;
+        this.meterRegistry = meterRegistry;
+    }
+
+    /**
+     * Write a failure-path audit entry. Never throws — an exception here
+     * must not mask the caller's pending error response.
+     *
+     * @param request     the servlet request (required — used to derive
+     *                    tenant_id, request_id, source_ip, user_agent,
+     *                    operation="METHOD:/path")
+     * @param status      HTTP status code of the pending error response
+     *                    (e.g. 401, 403, 400, 404, 409, 500)
+     * @param code        structured error code (non-null)
+     * @param message     server-side error message (nullable; sanitized
+     *                    + length-capped before write)
+     * @param extras      optional per-handler metadata to merge into the
+     *                    entry's {@code metadata} (nullable)
+     */
+    public void logFailure(HttpServletRequest request,
+                           int status,
+                           ErrorCode code,
+                           String message,
+                           Map<String, Object> extras) {
+        try {
+            String tenantId = resolveTenantId(request);
+
+            // v0.1.25.20: sampling gate for the DDoS-amplifiable tier.
+            // Only the unauthenticated-sentinel entries are sampled; every
+            // authenticated failure (valid key, 403/404/409/500) persists
+            // at full fidelity because it's a real security signal.
+            // Default sampleRate=1 means "record every attempt" — operator
+            // must opt in to reduce volume.
+            if (UNAUTHENTICATED_TENANT.equals(tenantId) && shouldSampleOut()) {
+                recordWrite("failure", "sampled-out");
+                return;
+            }
+
+            String method = request != null ? request.getMethod() : "UNKNOWN";
+            String uri = request != null ? request.getRequestURI() : "";
+            String operation = method + ":" + uri;
+
+            Map<String, Object> metadata = new HashMap<>();
+            metadata.put("method", method);
+            metadata.put("path", uri);
+            String sanitized = sanitizeMessage(message);
+            if (sanitized != null) {
+                metadata.put("error_message", sanitized);
+            }
+            if (extras != null) {
+                metadata.putAll(extras);
+            }
+
+            AuditLogEntry entry = AuditLogEntry.builder()
+                    .tenantId(tenantId)
+                    .keyId(resolveAttr(request, "authenticated_key_id"))
+                    .userAgent(request != null ? request.getHeader("User-Agent") : null)
+                    .sourceIp(request != null ? request.getRemoteAddr() : null)
+                    .operation(operation)
+                    .requestId(resolveRequestId(request))
+                    .status(status)
+                    .errorCode(code != null ? code.name() : null)
+                    .metadata(metadata)
+                    .build();
+
+            auditRepository.log(entry);
+            recordWrite("failure", "written");
+        } catch (Exception e) {
+            // Defense in depth: AuditRepository.log() already swallows. If
+            // anything here still throws (e.g. MeterRegistry wedged), don't
+            // propagate — the real error response MUST go out.
+            recordWrite("failure", "error");
+            LOG.warn("Failed to write failure audit entry (non-fatal): {}", e.getMessage());
+        }
+    }
+
+    private String resolveTenantId(HttpServletRequest request) {
+        Object t = resolveAttrRaw(request, "authenticated_tenant_id");
+        if (t == null) {
+            return UNAUTHENTICATED_TENANT;
+        }
+        String s = t.toString();
+        return s.isEmpty() ? UNAUTHENTICATED_TENANT : s;
+    }
+
+    private String resolveRequestId(HttpServletRequest request) {
+        Object attr = resolveAttrRaw(request, RequestIdFilter.REQUEST_ID_ATTRIBUTE);
+        return attr != null ? attr.toString() : UUID.randomUUID().toString();
+    }
+
+    private String resolveAttr(HttpServletRequest request, String name) {
+        Object v = resolveAttrRaw(request, name);
+        return v != null ? v.toString() : null;
+    }
+
+    private Object resolveAttrRaw(HttpServletRequest request, String name) {
+        return request != null ? request.getAttribute(name) : null;
+    }
+
+    /**
+     * Decide whether to drop this unauthenticated-tier write under the
+     * current sampling rate. Called ONLY after confirming the entry is
+     * the unauthenticated tier.
+     *
+     * <p>Rate {@code <= 1} never samples out — the {@code > 1} gate
+     * preserves full fidelity at default config and defends against a
+     * misconfigured {@code 0} or negative value that would otherwise
+     * silently drop every audit entry.
+     */
+    private boolean shouldSampleOut() {
+        int rate = unauthenticatedSampleRate;
+        if (rate <= 1) {
+            return false;
+        }
+        // Keep 1 slot out of N → sample-out probability (N-1)/N.
+        // ThreadLocalRandom is lock-free and preferred over Math.random()
+        // under contention.
+        return ThreadLocalRandom.current().nextInt(rate) != 0;
+    }
+
+    /**
+     * Strip CR/LF (log-injection guard) and cap length. Null in → null out.
+     */
+    private String sanitizeMessage(String msg) {
+        if (msg == null || msg.isEmpty()) {
+            return null;
+        }
+        String stripped = msg.replace('\r', ' ').replace('\n', ' ');
+        return stripped.length() > ERROR_MESSAGE_MAX_LEN
+                ? stripped.substring(0, ERROR_MESSAGE_MAX_LEN)
+                : stripped;
+    }
+
+    private void recordWrite(String pathClass, String outcome) {
+        try {
+            Counter.builder("cycles_admin_audit_writes_total")
+                    .description("Count of audit-log write attempts, labelled by path class "
+                            + "(success|failure) and outcome "
+                            + "(written|error|sampled-out).")
+                    .tag("path_class", pathClass)
+                    .tag("outcome", outcome)
+                    .register(meterRegistry)
+                    .increment();
+        } catch (Exception ignored) {
+            // Metrics must never break the main path.
+        }
+    }
+}

--- a/cycles-admin-service/cycles-admin-service-api/src/main/resources/application.properties
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/resources/application.properties
@@ -48,3 +48,26 @@ webhook.secret.encryption-key=${WEBHOOK_SECRET_ENCRYPTION_KEY:}
 # Event/delivery retention TTL (spec: 90 days hot for events)
 events.retention.event-ttl-days=${EVENT_TTL_DAYS:90}
 events.retention.delivery-ttl-days=${DELIVERY_TTL_DAYS:14}
+
+# Audit log retention (v0.1.25.20+) — tiered by authentication tier.
+# Authenticated entries (success + authenticated failure): 400 days default
+#   = SOC2 Type II 12-month lookback + 1-month buffer. Set to 0 for
+#   indefinite (legal hold, HIPAA, forever-retain deployments).
+# Unauthenticated entries (sentinel tenant_id on pre-auth failures):
+#   30 days default — brute-force / credential-stuffing forensic window.
+#   Set to 0 for indefinite. Aggregate attempt volume stays visible via
+#   cycles_admin_audit_writes_total counter regardless of this setting.
+audit.retention.authenticated.days=${AUDIT_RETENTION_AUTHENTICATED_DAYS:400}
+audit.retention.unauthenticated.days=${AUDIT_RETENTION_UNAUTHENTICATED_DAYS:30}
+
+# Sampling for unauthenticated-tier audit writes — record 1 in N. Default
+# 1 (record every attempt). Tune to 100+ in DDoS-exposed deployments to
+# cut Redis write volume; aggregate volume observable via
+# cycles_admin_audit_writes_total{outcome=sampled-out}. Authenticated
+# entries are NEVER sampled — they're real security / compliance signals.
+audit.sample.unauthenticated=${AUDIT_SAMPLE_UNAUTHENTICATED:1}
+
+# Audit index sweep cron — daily purge of stale sorted-set pointers to
+# TTL-expired log keys. Default 03:00 server time. Sweep is non-fatal
+# (best-effort); a failed tick retries on the next cron fire.
+audit.sweep.cron=${AUDIT_SWEEP_CRON:0 0 3 * * *}

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/config/AuthInterceptorTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/config/AuthInterceptorTest.java
@@ -1,11 +1,14 @@
 package io.runcycles.admin.api.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.runcycles.admin.api.service.AuditFailureService;
 import io.runcycles.admin.data.repository.ApiKeyRepository;
 import io.runcycles.admin.model.auth.ApiKeyValidationResponse;
+import io.runcycles.admin.model.shared.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -15,13 +18,18 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class AuthInterceptorTest {
 
     @Mock private ApiKeyRepository apiKeyRepository;
+    @Mock private AuditFailureService auditFailure;
     private AuthInterceptor interceptor;
     private ObjectMapper objectMapper = new ObjectMapper();
     private MockHttpServletRequest request;
@@ -29,7 +37,7 @@ class AuthInterceptorTest {
 
     @BeforeEach
     void setUp() {
-        interceptor = new AuthInterceptor(apiKeyRepository, objectMapper);
+        interceptor = new AuthInterceptor(apiKeyRepository, objectMapper, auditFailure);
         ReflectionTestUtils.setField(interceptor, "adminApiKey", "admin-secret-key");
         request = new MockHttpServletRequest();
         response = new MockHttpServletResponse();
@@ -909,5 +917,109 @@ class AuthInterceptorTest {
 
         assertThat(interceptor.preHandle(request, response, new Object())).isFalse();
         assertThat(response.getStatus()).isEqualTo(401);
+    }
+
+    // --- v0.1.25.20: audit-on-failure — every writeError() call site must
+    // emit an audit entry with matching status + error_code via
+    // AuditFailureService. Locks the contract at the interceptor layer
+    // so subsequent refactors can't silently drop audit coverage. ---
+
+    @Test
+    void preHandle_adminEndpointMissingHeader_writesFailureAudit_401Unauthorized() throws Exception {
+        request.setMethod("POST");
+        request.setRequestURI("/v1/admin/tenants");
+
+        interceptor.preHandle(request, response, new Object());
+
+        verify(auditFailure).logFailure(eq(request), eq(401), eq(ErrorCode.UNAUTHORIZED), anyString(), isNull());
+    }
+
+    @Test
+    void preHandle_adminEndpointInvalidKey_writesFailureAudit_401Unauthorized() throws Exception {
+        request.setMethod("POST");
+        request.setRequestURI("/v1/admin/tenants");
+        request.addHeader("X-Admin-API-Key", "wrong-key");
+
+        interceptor.preHandle(request, response, new Object());
+
+        verify(auditFailure).logFailure(eq(request), eq(401), eq(ErrorCode.UNAUTHORIZED), anyString(), isNull());
+    }
+
+    @Test
+    void preHandle_adminKeyMisconfigured_writesFailureAudit_500Internal() throws Exception {
+        ReflectionTestUtils.setField(interceptor, "adminApiKey", "");
+        request.setMethod("POST");
+        request.setRequestURI("/v1/admin/tenants");
+        request.addHeader("X-Admin-API-Key", "any-value");
+
+        interceptor.preHandle(request, response, new Object());
+
+        verify(auditFailure).logFailure(eq(request), eq(500), eq(ErrorCode.INTERNAL_ERROR), anyString(), isNull());
+    }
+
+    @Test
+    void preHandle_pathTraversal_writesFailureAudit_400InvalidRequest() throws Exception {
+        request.setMethod("PATCH");
+        request.setRequestURI("/v1/admin/policies/..%2Ftenants/t_1");
+        request.setServletPath("/v1/admin/policies/../tenants/t_1");
+        request.addHeader("X-Admin-API-Key", "admin-secret-key");
+
+        interceptor.preHandle(request, response, new Object());
+
+        verify(auditFailure).logFailure(eq(request), eq(400), eq(ErrorCode.INVALID_REQUEST), anyString(), isNull());
+    }
+
+    @Test
+    void preHandle_apiKeyEndpointMissingHeader_writesFailureAudit_401Unauthorized() throws Exception {
+        request.setMethod("POST");
+        request.setRequestURI("/v1/admin/budgets");
+
+        interceptor.preHandle(request, response, new Object());
+
+        verify(auditFailure).logFailure(eq(request), eq(401), eq(ErrorCode.UNAUTHORIZED), anyString(), isNull());
+    }
+
+    @Test
+    void preHandle_apiKeyInvalid_writesFailureAudit_403Forbidden() throws Exception {
+        request.setMethod("POST");
+        request.setRequestURI("/v1/admin/budgets");
+        request.addHeader("X-Cycles-API-Key", "bad-key");
+        when(apiKeyRepository.validate("bad-key")).thenReturn(
+                ApiKeyValidationResponse.builder().valid(false).tenantId("").reason("KEY_NOT_FOUND").build());
+
+        interceptor.preHandle(request, response, new Object());
+
+        verify(auditFailure).logFailure(eq(request), eq(403), eq(ErrorCode.FORBIDDEN), anyString(), isNull());
+    }
+
+    @Test
+    void preHandle_apiKeyInsufficientPermissions_writesFailureAudit_403InsufficientPermissions() throws Exception {
+        request.setMethod("POST");
+        request.setRequestURI("/v1/admin/budgets");
+        request.addHeader("X-Cycles-API-Key", "valid-key");
+        when(apiKeyRepository.validate("valid-key")).thenReturn(
+                ApiKeyValidationResponse.builder()
+                        .valid(true).tenantId("tenant-1").keyId("key_1")
+                        .permissions(List.of("balances:read")) // missing budgets:write
+                        .build());
+
+        interceptor.preHandle(request, response, new Object());
+
+        verify(auditFailure).logFailure(eq(request), eq(403),
+                eq(ErrorCode.INSUFFICIENT_PERMISSIONS), anyString(), isNull());
+    }
+
+    @Test
+    void preHandle_adminKeyValid_noFailureAuditWritten() throws Exception {
+        // Single-write invariant sanity check — success paths never trigger
+        // a failure-side write. Controllers do their own (richer) success
+        // audit-log.
+        request.setMethod("GET");
+        request.setRequestURI("/v1/admin/audit/logs");
+        request.addHeader("X-Admin-API-Key", "admin-secret-key");
+
+        interceptor.preHandle(request, response, new Object());
+
+        verify(auditFailure, never()).logFailure(any(), anyInt(), any(), anyString(), any());
     }
 }

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/exception/GlobalExceptionHandlerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/exception/GlobalExceptionHandlerTest.java
@@ -1,5 +1,6 @@
 package io.runcycles.admin.api.exception;
 
+import io.runcycles.admin.api.service.AuditFailureService;
 import io.runcycles.admin.data.exception.GovernanceException;
 import io.runcycles.admin.model.shared.ErrorCode;
 import io.runcycles.admin.model.shared.ErrorResponse;
@@ -24,17 +25,27 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class GlobalExceptionHandlerTest {
 
     private GlobalExceptionHandler handler;
     private HttpServletRequest mockRequest;
+    private AuditFailureService auditFailure;
 
     @BeforeEach
     void setUp() {
-        handler = new GlobalExceptionHandler();
+        auditFailure = mock(AuditFailureService.class);
+        handler = new GlobalExceptionHandler(auditFailure);
         mockRequest = mock(HttpServletRequest.class);
     }
 
@@ -255,5 +266,110 @@ class GlobalExceptionHandlerTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(response.getBody().getMessage()).contains("scope");
         assertThat(response.getBody().getMessage()).contains("must not be blank");
+    }
+
+    // --- v0.1.25.20: audit-on-failure — every @ExceptionHandler branch must
+    // emit a failure audit entry via AuditFailureService.logFailure before
+    // the error response is returned. Locks the contract so future refactors
+    // can't silently drop audit coverage on 4xx/5xx paths. ---
+
+    @Test
+    void handleGovernanceException_writesFailureAudit() {
+        GovernanceException ex = GovernanceException.tenantNotFound("tenant-1");
+
+        handler.handleGovernanceException(ex, mockRequest);
+
+        verify(auditFailure).logFailure(eq(mockRequest), eq(404),
+                eq(ErrorCode.TENANT_NOT_FOUND), anyString(), isNull());
+    }
+
+    @Test
+    void handleValidationException_writesFailureAudit() throws Exception {
+        BeanPropertyBindingResult bindingResult = new BeanPropertyBindingResult(new Object(), "request");
+        bindingResult.addError(new FieldError("request", "name", "must not be blank"));
+        MethodParameter param = new MethodParameter(Object.class.getDeclaredMethod("toString"), -1);
+        MethodArgumentNotValidException ex = new MethodArgumentNotValidException(param, bindingResult);
+
+        handler.handleValidationException(ex, mockRequest);
+
+        verify(auditFailure).logFailure(eq(mockRequest), eq(400),
+                eq(ErrorCode.INVALID_REQUEST), anyString(), isNull());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void handleConstraintViolation_writesFailureAudit() {
+        ConstraintViolation<Object> violation = mock(ConstraintViolation.class);
+        Path path = mock(Path.class);
+        when(path.toString()).thenReturn("create.request.scope");
+        when(violation.getPropertyPath()).thenReturn(path);
+        when(violation.getMessage()).thenReturn("must not be null");
+        ConstraintViolationException ex = new ConstraintViolationException(Set.of(violation));
+
+        handler.handleConstraintViolation(ex, mockRequest);
+
+        verify(auditFailure).logFailure(eq(mockRequest), eq(400),
+                eq(ErrorCode.INVALID_REQUEST), anyString(), isNull());
+    }
+
+    @Test
+    void handleMissingParam_writesFailureAudit() throws Exception {
+        MissingServletRequestParameterException ex =
+                new MissingServletRequestParameterException("tenant_id", "String");
+
+        handler.handleMissingParam(ex, mockRequest);
+
+        verify(auditFailure).logFailure(eq(mockRequest), eq(400),
+                eq(ErrorCode.INVALID_REQUEST), anyString(), isNull());
+    }
+
+    @Test
+    void handleTypeMismatch_writesFailureAudit() {
+        MethodArgumentTypeMismatchException ex = new MethodArgumentTypeMismatchException(
+                "abc", Integer.class, "limit", null, new NumberFormatException("bad"));
+
+        handler.handleTypeMismatch(ex, mockRequest);
+
+        verify(auditFailure).logFailure(eq(mockRequest), eq(400),
+                eq(ErrorCode.INVALID_REQUEST), anyString(), isNull());
+    }
+
+    @Test
+    void handleMalformedJson_writesFailureAudit() {
+        HttpMessageNotReadableException ex = mock(HttpMessageNotReadableException.class);
+
+        handler.handleMalformedJson(ex, mockRequest);
+
+        verify(auditFailure).logFailure(eq(mockRequest), eq(400),
+                eq(ErrorCode.INVALID_REQUEST), eq("Malformed request body"), isNull());
+    }
+
+    @Test
+    void handleGenericException_writesFailureAudit_withExceptionClassInExtras() {
+        Exception ex = new RuntimeException("unexpected boom");
+
+        handler.handleGenericException(ex, mockRequest);
+
+        // Generic-branch audit carries exception_class in extras so ops can
+        // correlate audit entry to server log line post-incident.
+        verify(auditFailure).logFailure(eq(mockRequest), eq(500),
+                eq(ErrorCode.INTERNAL_ERROR), eq("unexpected boom"),
+                any(Map.class));
+    }
+
+    @Test
+    void handleGenericException_wrappedGovernance_delegatesWithoutDoubleAudit() {
+        // Single-write invariant: when a GovernanceException reaches the
+        // generic branch it must delegate to handleGovernanceException, which
+        // does exactly ONE audit write. The generic branch must not also
+        // write (would produce two rows for the same failure).
+        GovernanceException governance = GovernanceException.budgetNotFound("scope1");
+
+        handler.handleGenericException(governance, mockRequest);
+
+        verify(auditFailure, times(1)).logFailure(eq(mockRequest), eq(404),
+                eq(ErrorCode.BUDGET_NOT_FOUND), anyString(), isNull());
+        verify(auditFailure, never()).logFailure(eq(mockRequest), eq(500),
+                eq(ErrorCode.INTERNAL_ERROR), anyString(), any());
     }
 }

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/integration/AdminFlowIntegrationTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/integration/AdminFlowIntegrationTest.java
@@ -222,5 +222,72 @@ class AdminFlowIntegrationTest extends BaseIntegrationTest {
                         adminHeaders()),
                 Map.class);
         assertThat(putConfig.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        // --- 25. v0.1.25.20: failure-path audit coverage ---
+        // Deliberate failures exercise all three audit-on-failure sources:
+        //   - AuthInterceptor (missing key → 401, unauthenticated tenant sentinel)
+        //   - GlobalExceptionHandler (HttpMessageNotReadable → 400, authenticated tenant)
+        //   - GlobalExceptionHandler (GovernanceException 404)
+        // Every entry is contract-validated on the wire against the pinned
+        // spec by ContractValidatingRestTemplateInterceptor.
+
+        // 25a. Unauthenticated admin call — writeError path in AuthInterceptor.
+        HttpHeaders noAuth = new HttpHeaders();
+        noAuth.set("Content-Type", "application/json");
+        ResponseEntity<Map> unauth = restTemplate.exchange(
+                baseUrl() + "/v1/admin/tenants", HttpMethod.GET,
+                new HttpEntity<>(noAuth), Map.class);
+        assertThat(unauth.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+
+        // 25b. Malformed JSON under valid admin auth — handleMalformedJson branch.
+        HttpHeaders adminRaw = adminHeaders();
+        adminRaw.set("Content-Type", "application/json");
+        ResponseEntity<Map> malformed = restTemplate.exchange(
+                baseUrl() + "/v1/admin/tenants", HttpMethod.POST,
+                new HttpEntity<>("this is not json", adminRaw),
+                Map.class);
+        assertThat(malformed.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+
+        // 25c. Nonexistent resource under valid admin auth — GovernanceException branch.
+        ResponseEntity<Map> notFound = restTemplate.exchange(
+                baseUrl() + "/v1/admin/tenants/does-not-exist", HttpMethod.GET,
+                new HttpEntity<>(adminHeaders()),
+                Map.class);
+        assertThat(notFound.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+
+        // 25d. Query audit log and confirm each failure landed with the right
+        // status + error_code + operation shape. Cursor-paginated, so fetch
+        // a wide slice (200) to cover the whole flow.
+        ResponseEntity<Map> auditAfter = adminGet("/v1/admin/audit/logs?limit=200");
+        assertThat(auditAfter.getStatusCode()).isEqualTo(HttpStatus.OK);
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> logs = (List<Map<String, Object>>) auditAfter.getBody().get("logs");
+
+        // Unauth 401 → tenant_id sentinel, operation=GET:/v1/admin/tenants,
+        // error_code=UNAUTHORIZED.
+        assertThat(logs).anyMatch(e ->
+                Integer.valueOf(401).equals(e.get("status")) &&
+                "UNAUTHORIZED".equals(e.get("error_code")) &&
+                "GET:/v1/admin/tenants".equals(e.get("operation")) &&
+                "<unauthenticated>".equals(e.get("tenant_id")));
+
+        // 400 malformed JSON → authenticated admin (no tenant_id stamped;
+        // sentinel still applies since admin key does NOT stamp
+        // authenticated_tenant_id per AuthInterceptor contract).
+        assertThat(logs).anyMatch(e ->
+                Integer.valueOf(400).equals(e.get("status")) &&
+                "INVALID_REQUEST".equals(e.get("error_code")) &&
+                "POST:/v1/admin/tenants".equals(e.get("operation")));
+
+        // 404 governance → error_code=TENANT_NOT_FOUND.
+        assertThat(logs).anyMatch(e ->
+                Integer.valueOf(404).equals(e.get("status")) &&
+                "TENANT_NOT_FOUND".equals(e.get("error_code")) &&
+                "GET:/v1/admin/tenants/does-not-exist".equals(e.get("operation")));
+
+        // Sanity: success entries from steps 1-24 still present alongside
+        // the new failure entries (single-write invariant preserved).
+        assertThat(logs).anyMatch(e ->
+                Integer.valueOf(201).equals(e.get("status")));
     }
 }

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/integration/AuditRetentionIndefiniteIntegrationTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/integration/AuditRetentionIndefiniteIntegrationTest.java
@@ -1,0 +1,151 @@
+package io.runcycles.admin.api.integration;
+
+import io.runcycles.admin.api.BaseIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+import redis.clients.jedis.Jedis;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end verification that {@code audit.retention.*.days=0} produces
+ * Redis entries <b>without</b> a TTL (Lua's {@code if ttl > 0} branch
+ * skipping the {@code EX} arg). {@code jedis.ttl()} returns {@code -1}
+ * for keys with no expiry set.
+ *
+ * <p>Separate from {@link AuditRetentionIntegrationTest} because overriding
+ * the retention properties requires a separate Spring context per
+ * {@code @TestPropertySource}. Two test classes = two contexts = clean
+ * isolation between "default retention" and "indefinite retention"
+ * assertions.
+ *
+ * <p>Covers the operator-facing contract: setting a retention property
+ * to {@code 0} means "never expire" (for legal hold, HIPAA, forever-
+ * retain deployments). Verified end-to-end through the real Redis
+ * container — not just via Lua-mock unit tests.
+ *
+ * <p>Also asserts {@code AuditRepository.sweepStaleIndexEntries()}
+ * short-circuits when retention is indefinite — the sweep must NOT
+ * remove pointers to never-expiring records.
+ *
+ * @since 0.1.25.20
+ */
+@TestPropertySource(properties = {
+        "audit.retention.authenticated.days=0",
+        "audit.retention.unauthenticated.days=0"
+})
+class AuditRetentionIndefiniteIntegrationTest extends BaseIntegrationTest {
+
+    @Test
+    void unauthenticatedFailure_retentionZero_auditKeyHasNoTtl() {
+        // Fire a 401 → audit entry with sentinel tenant_id → resolveTtl
+        // sees unauthenticatedRetentionDays=0 → Lua skips EX → TTL is -1.
+        ResponseEntity<Map> unauth = restTemplate.exchange(
+                baseUrl() + "/v1/admin/tenants", HttpMethod.GET,
+                new HttpEntity<>(new HttpHeaders()), Map.class);
+        assertThat(unauth.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+
+        String logId = pullMostRecentLogId("audit:logs:<unauthenticated>");
+        assertThat(logId).isNotNull();
+
+        try (Jedis jedis = jedisPool.getResource()) {
+            long ttl = jedis.ttl("audit:log:" + logId);
+            // -1 = key exists, no expire set. -2 = key does not exist.
+            assertThat(ttl)
+                    .as("unauthenticated retention=0 must produce a key with NO expiry")
+                    .isEqualTo(-1L);
+        }
+    }
+
+    @Test
+    void authenticatedFailure_retentionZero_auditKeyHasNoTtl() {
+        adminPost("/v1/admin/tenants", Map.of(
+                "tenant_id", "tenant-indef", "name", "Indefinite Retention Test"));
+        ResponseEntity<Map> keyResp = adminPost("/v1/admin/api-keys", Map.of(
+                "tenant_id", "tenant-indef", "name", "minimal-perms-key",
+                "permissions", List.of("balances:read")));
+        String keySecret = (String) keyResp.getBody().get("key_secret");
+
+        // Tenant key with balances:read hitting POST /v1/admin/budgets →
+        // 403 INSUFFICIENT_PERMISSIONS → audit entry with real tenant_id
+        // → authenticatedRetentionDays=0 → Lua skips EX → TTL -1.
+        ResponseEntity<Map> denied = restTemplate.exchange(
+                baseUrl() + "/v1/admin/budgets", HttpMethod.POST,
+                new HttpEntity<>(Map.of(
+                        "scope", "tenant:tenant-indef",
+                        "unit", "USD_MICROCENTS",
+                        "allocated", Map.of("unit", "USD_MICROCENTS", "amount", 100)),
+                        tenantHeaders(keySecret)),
+                Map.class);
+        assertThat(denied.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+
+        String logId = pullMostRecentLogId("audit:logs:tenant-indef");
+        assertThat(logId).isNotNull();
+
+        try (Jedis jedis = jedisPool.getResource()) {
+            long ttl = jedis.ttl("audit:log:" + logId);
+            assertThat(ttl)
+                    .as("authenticated retention=0 must produce a key with NO expiry")
+                    .isEqualTo(-1L);
+        }
+    }
+
+    @Test
+    void sweepStaleIndexEntries_retentionZero_doesNotTouchLivePointers() {
+        // Write one indefinite-retention entry, run the sweep,
+        // assert the index pointer is untouched. Regression guard:
+        // a future refactor that accidentally enables sweep under
+        // retention=0 would delete pointers to forever-retain records.
+        restTemplate.exchange(baseUrl() + "/v1/admin/tenants", HttpMethod.GET,
+                new HttpEntity<>(new HttpHeaders()), Map.class);
+        String logId = pullMostRecentLogId("audit:logs:<unauthenticated>");
+        assertThat(logId).isNotNull();
+
+        try (Jedis jedis = jedisPool.getResource()) {
+            long sizeBefore = jedis.zcard("audit:logs:<unauthenticated>");
+            long sizeBeforeGlobal = jedis.zcard("audit:logs:_all");
+            assertThat(sizeBefore).isGreaterThan(0);
+            assertThat(sizeBeforeGlobal).isGreaterThan(0);
+
+            // Run the sweep in-process (not waiting for cron). Under
+            // retention=0 it should early-return and touch nothing.
+            // We need access to the repo bean — pull it via Spring.
+            io.runcycles.admin.data.repository.AuditRepository repo =
+                    applicationContext().getBean(io.runcycles.admin.data.repository.AuditRepository.class);
+            repo.sweepStaleIndexEntries();
+
+            long sizeAfter = jedis.zcard("audit:logs:<unauthenticated>");
+            long sizeAfterGlobal = jedis.zcard("audit:logs:_all");
+            assertThat(sizeAfter)
+                    .as("sweep under retention=0 must not remove any tenant-index pointers")
+                    .isEqualTo(sizeBefore);
+            assertThat(sizeAfterGlobal)
+                    .as("sweep under retention=0 must not remove any global-index pointers")
+                    .isEqualTo(sizeBeforeGlobal);
+        }
+    }
+
+    // --- helpers ---
+
+    private String pullMostRecentLogId(String indexKey) {
+        try (Jedis jedis = jedisPool.getResource()) {
+            List<String> ids = jedis.zrevrange(indexKey, 0, 0);
+            return ids.isEmpty() ? null : ids.get(0);
+        }
+    }
+
+    @org.springframework.beans.factory.annotation.Autowired
+    private org.springframework.context.ApplicationContext springContext;
+
+    private org.springframework.context.ApplicationContext applicationContext() {
+        return springContext;
+    }
+}

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/integration/AuditRetentionIntegrationTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/integration/AuditRetentionIntegrationTest.java
@@ -1,0 +1,196 @@
+package io.runcycles.admin.api.integration;
+
+import io.runcycles.admin.api.BaseIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import redis.clients.jedis.Jedis;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end verification that tiered TTL (v0.1.25.20) is actually applied
+ * on the {@code audit:log:&#123;logId&#125;} keys in Redis, not just that
+ * the Lua script <i>receives</i> the right TTL argument.
+ *
+ * <p>Unit-level {@code AuditRepositoryTest} already asserts that
+ * {@code resolveTtlSeconds()} picks the right tier and that the correct
+ * value lands in {@code ARGV[4]} of the eval call. This test closes the
+ * trust-chain by driving real requests through the admin server, then
+ * querying Redis directly via {@code JedisPool} to confirm the TTL was
+ * actually applied. Fast (no real-time waits) — the test verifies the
+ * expected TTL value, not the expiry event itself.
+ *
+ * <p>Covers both tiers at default retention:
+ * <ul>
+ *   <li>Authenticated tier → default 400 days = 34,560,000 s</li>
+ *   <li>Unauthenticated tier → default 30 days = 2,592,000 s</li>
+ * </ul>
+ *
+ * <p>Indefinite-retention case ({@code days=0} → no EX on SET, TTL = -1)
+ * lives in {@link AuditRetentionIndefiniteIntegrationTest} because the
+ * @{@code TestPropertySource} override requires a separate Spring context.
+ *
+ * @since 0.1.25.20
+ */
+class AuditRetentionIntegrationTest extends BaseIntegrationTest {
+
+    private static final long DAYS = 86_400L;
+    // Allow a few seconds of slack between Lua EX and jedis.ttl() — the
+    // Redis clock ticks between the SET and the TTL query, and depending on
+    // CI load there can be 1-3s latency. Keep slack tight (not minutes)
+    // to catch genuine drift.
+    private static final long TTL_TOLERANCE_SECONDS = 30L;
+
+    @Test
+    void authenticatedFailure_auditKeyHasAuthenticatedTierTtl() {
+        // Trigger a 404 under valid admin auth — lands in
+        // GlobalExceptionHandler.handleGovernanceException → audit written
+        // with the caller's admin context (no tenant_id attr stamped,
+        // so the entry uses the unauthenticated sentinel). Wait — that
+        // means this case doesn't actually exercise the authenticated
+        // tier TTL path.
+        //
+        // To exercise the authenticated tier we need a request that stamps
+        // authenticated_tenant_id on the request. Admin-key auth does NOT
+        // stamp it (per AuthInterceptor.validateAdminKey contract). Only
+        // ApiKeyAuth stamps tenant_id. So we need a tenant API key that
+        // fails authorization on a path — e.g. a valid tenant key calling
+        // a path that requires a permission the key doesn't have.
+
+        // --- Setup: create a tenant + API key with limited permissions ---
+        adminPost("/v1/admin/tenants", Map.of(
+                "tenant_id", "tenant-audit-ttl",
+                "name", "Audit TTL Test Tenant"));
+
+        ResponseEntity<Map> keyResp = adminPost("/v1/admin/api-keys", Map.of(
+                "tenant_id", "tenant-audit-ttl",
+                "name", "minimal-perms-key",
+                "permissions", List.of("balances:read")));
+        assertThat(keyResp.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        String keySecret = (String) keyResp.getBody().get("key_secret");
+
+        // --- Trigger: tenant key calls an endpoint requiring a permission
+        // it lacks. Hits AuthInterceptor.validateApiKey successfully
+        // (stamps authenticated_tenant_id), then fails the permission
+        // check → 403 INSUFFICIENT_PERMISSIONS → writeError →
+        // AuditFailureService.logFailure with real tenant_id.
+        HttpHeaders tenantHeaders = tenantHeaders(keySecret);
+        ResponseEntity<Map> denied = restTemplate.exchange(
+                baseUrl() + "/v1/admin/budgets", HttpMethod.POST,
+                new HttpEntity<>(Map.of(
+                        "scope", "tenant:tenant-audit-ttl",
+                        "unit", "USD_MICROCENTS",
+                        "allocated", Map.of("unit", "USD_MICROCENTS", "amount", 1_000_000)),
+                        tenantHeaders),
+                Map.class);
+        assertThat(denied.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+
+        // --- Verify: the audit entry was written with the authenticated
+        // tier's TTL. Pull the most recent entry from the tenant index
+        // and ask Redis for its TTL directly.
+        String logId = pullMostRecentLogId("audit:logs:tenant-audit-ttl");
+        assertThat(logId)
+                .as("audit entry for tenant-audit-ttl's 403 must be indexed")
+                .isNotNull();
+
+        long ttlSeconds = readTtlSeconds("audit:log:" + logId);
+        long expected = 400L * DAYS;  // default audit.retention.authenticated.days=400
+        assertThat(ttlSeconds)
+                .as("authenticated-tier audit entry TTL should be within ±%ds of %ds "
+                        + "(default 400 days)", TTL_TOLERANCE_SECONDS, expected)
+                .isBetween(expected - TTL_TOLERANCE_SECONDS, expected + TTL_TOLERANCE_SECONDS);
+    }
+
+    @Test
+    void unauthenticatedFailure_auditKeyHasUnauthenticatedTierTtl() {
+        // Trigger a 401 with no credentials at all → AuthInterceptor.
+        // writeError → AuditFailureService.logFailure with sentinel
+        // tenant_id → AuditRepository.resolveTtlSeconds picks the
+        // unauthenticated tier.
+        HttpHeaders noAuth = new HttpHeaders();
+        ResponseEntity<Map> unauth = restTemplate.exchange(
+                baseUrl() + "/v1/admin/tenants", HttpMethod.GET,
+                new HttpEntity<>(noAuth), Map.class);
+        assertThat(unauth.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+
+        String logId = pullMostRecentLogId("audit:logs:<unauthenticated>");
+        assertThat(logId)
+                .as("audit entry for unauth 401 must be indexed under the sentinel")
+                .isNotNull();
+
+        long ttlSeconds = readTtlSeconds("audit:log:" + logId);
+        long expected = 30L * DAYS;  // default audit.retention.unauthenticated.days=30
+        assertThat(ttlSeconds)
+                .as("unauthenticated-tier audit entry TTL should be within ±%ds of %ds "
+                        + "(default 30 days)", TTL_TOLERANCE_SECONDS, expected)
+                .isBetween(expected - TTL_TOLERANCE_SECONDS, expected + TTL_TOLERANCE_SECONDS);
+    }
+
+    @Test
+    void unauthenticatedAndAuthenticatedTiers_distinctTtls() {
+        // Belt-and-suspenders: same Redis, two entries from two tiers,
+        // assert the TTLs are materially different — guards against a
+        // regression where both tiers end up sharing one TTL knob.
+        // Fire both in-order, pull each, diff > 1 year → tiers split.
+
+        // Fire unauth failure.
+        restTemplate.exchange(baseUrl() + "/v1/admin/tenants", HttpMethod.GET,
+                new HttpEntity<>(new HttpHeaders()), Map.class);
+        String unauthLogId = pullMostRecentLogId("audit:logs:<unauthenticated>");
+        long unauthTtl = readTtlSeconds("audit:log:" + unauthLogId);
+
+        // Fire authenticated failure (403 via insufficient permissions).
+        adminPost("/v1/admin/tenants", Map.of("tenant_id", "t-tier-diff", "name", "t"));
+        ResponseEntity<Map> keyResp = adminPost("/v1/admin/api-keys", Map.of(
+                "tenant_id", "t-tier-diff", "name", "k",
+                "permissions", List.of("balances:read")));
+        String keySecret = (String) keyResp.getBody().get("key_secret");
+        restTemplate.exchange(
+                baseUrl() + "/v1/admin/budgets", HttpMethod.POST,
+                new HttpEntity<>(Map.of(
+                        "scope", "tenant:t-tier-diff",
+                        "unit", "USD_MICROCENTS",
+                        "allocated", Map.of("unit", "USD_MICROCENTS", "amount", 100)),
+                        tenantHeaders(keySecret)),
+                Map.class);
+        String authLogId = pullMostRecentLogId("audit:logs:t-tier-diff");
+        long authTtl = readTtlSeconds("audit:log:" + authLogId);
+
+        // Default 400 days vs 30 days → 370 days difference minimum. Use
+        // a large floor (300 days) so any slack in TTL rounding or clock
+        // drift doesn't flake; the absolute difference will always be
+        // measured in hundreds of days under default config.
+        assertThat(authTtl - unauthTtl)
+                .as("authenticated TTL (400d default) minus unauthenticated TTL "
+                        + "(30d default) must clearly separate — regression floor 300 days")
+                .isGreaterThan(300L * DAYS);
+    }
+
+    // --- helpers ---
+
+    /**
+     * Pull the newest log id from a sorted-set index and return it. Returns
+     * null if the index is empty. Uses {@code ZREVRANGE ... 0 0} to grab
+     * the top-scoring entry without paging.
+     */
+    private String pullMostRecentLogId(String indexKey) {
+        try (Jedis jedis = jedisPool.getResource()) {
+            List<String> ids = jedis.zrevrange(indexKey, 0, 0);
+            return ids.isEmpty() ? null : ids.get(0);
+        }
+    }
+
+    private long readTtlSeconds(String key) {
+        try (Jedis jedis = jedisPool.getResource()) {
+            // -1 = no expire, -2 = key does not exist, >= 0 = remaining seconds
+            return jedis.ttl(key);
+        }
+    }
+}

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/AuditFailureServiceTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/AuditFailureServiceTest.java
@@ -1,0 +1,395 @@
+package io.runcycles.admin.api.service;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.runcycles.admin.data.repository.AuditRepository;
+import io.runcycles.admin.model.audit.AuditLogEntry;
+import io.runcycles.admin.model.shared.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for {@link AuditFailureService} focused on v0.1.25.20 behaviour:
+ * unauthenticated-tier sampling, sentinel tenant-id resolution, log-injection
+ * guard on {@code metadata.error_message}, and non-throwing contract under
+ * internal errors.
+ *
+ * <p>Interceptor-level integration (i.e. that {@code AuthInterceptor} actually
+ * calls {@code logFailure}) is covered in {@code AuthInterceptorTest}; handler-
+ * level integration is covered in {@code GlobalExceptionHandlerTest}; real-Redis
+ * end-to-end in {@code AdminFlowIntegrationTest}.
+ */
+@ExtendWith(MockitoExtension.class)
+class AuditFailureServiceTest {
+
+    @Mock private AuditRepository auditRepository;
+    private MeterRegistry meterRegistry;
+    private AuditFailureService service;
+    private MockHttpServletRequest request;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        service = new AuditFailureService(auditRepository, meterRegistry);
+        // Default sampling rate = 1 (safe default). Individual tests override.
+        ReflectionTestUtils.setField(service, "unauthenticatedSampleRate", 1);
+        request = new MockHttpServletRequest();
+        request.setMethod("GET");
+        request.setRequestURI("/v1/admin/budgets");
+    }
+
+    // --- sentinel resolution + operation encoding ---
+
+    @Test
+    void logFailure_noAuthenticatedTenant_usesUnauthenticatedSentinel() {
+        service.logFailure(request, 401, ErrorCode.UNAUTHORIZED, "missing key", null);
+
+        ArgumentCaptor<AuditLogEntry> captor = ArgumentCaptor.forClass(AuditLogEntry.class);
+        verify(auditRepository).log(captor.capture());
+        AuditLogEntry entry = captor.getValue();
+        assertThat(entry.getTenantId()).isEqualTo(AuditLogEntry.UNAUTHENTICATED_TENANT);
+        assertThat(entry.getOperation()).isEqualTo("GET:/v1/admin/budgets");
+        assertThat(entry.getStatus()).isEqualTo(401);
+        assertThat(entry.getErrorCode()).isEqualTo("UNAUTHORIZED");
+    }
+
+    @Test
+    void logFailure_authenticatedTenantAttribute_preservesRealTenantId() {
+        request.setAttribute("authenticated_tenant_id", "tenant-1");
+        request.setAttribute("authenticated_key_id", "key_1");
+
+        service.logFailure(request, 403, ErrorCode.INSUFFICIENT_PERMISSIONS, "no perm", null);
+
+        ArgumentCaptor<AuditLogEntry> captor = ArgumentCaptor.forClass(AuditLogEntry.class);
+        verify(auditRepository).log(captor.capture());
+        AuditLogEntry entry = captor.getValue();
+        assertThat(entry.getTenantId()).isEqualTo("tenant-1");
+        assertThat(entry.getKeyId()).isEqualTo("key_1");
+    }
+
+    @Test
+    void logFailure_emptyStringTenantAttribute_fallsBackToSentinel() {
+        // Defensive: an attribute set to "" must not produce an empty-string
+        // tenant_id in the audit row (spec requires non-empty string).
+        request.setAttribute("authenticated_tenant_id", "");
+
+        service.logFailure(request, 401, ErrorCode.UNAUTHORIZED, "x", null);
+
+        ArgumentCaptor<AuditLogEntry> captor = ArgumentCaptor.forClass(AuditLogEntry.class);
+        verify(auditRepository).log(captor.capture());
+        assertThat(captor.getValue().getTenantId())
+                .isEqualTo(AuditLogEntry.UNAUTHENTICATED_TENANT);
+    }
+
+    // --- sampling gate ---
+
+    @Test
+    void logFailure_unauthenticated_sampleRateOne_neverSamplesOut() {
+        // Default sampling rate 1 must always write — run many iterations
+        // and confirm zero sampled-out. Deterministic guard against a
+        // regression where `<=1` ever samples any entry.
+        for (int i = 0; i < 200; i++) {
+            service.logFailure(request, 401, ErrorCode.UNAUTHORIZED, "x", null);
+        }
+
+        verify(auditRepository, org.mockito.Mockito.times(200))
+                .log(org.mockito.ArgumentMatchers.any(AuditLogEntry.class));
+        assertThat(counter("written")).isEqualTo(200.0);
+        assertThat(counter("sampled-out")).isEqualTo(0.0);
+    }
+
+    @Test
+    void logFailure_unauthenticated_highSampleRate_samplesOutMostWrites() {
+        // Rate = 100 → expected ~1% recorded, ~99% sampled-out. Over 1000
+        // iterations the statistical variance is tight — asserting
+        // 0 < written < 50 and sampled-out > 900 catches regression where
+        // sampling no-ops entirely (all 1000 written) or drops all
+        // (0 written).
+        ReflectionTestUtils.setField(service, "unauthenticatedSampleRate", 100);
+        int total = 1000;
+
+        for (int i = 0; i < total; i++) {
+            service.logFailure(request, 401, ErrorCode.UNAUTHORIZED, "x", null);
+        }
+
+        double written = counter("written");
+        double sampledOut = counter("sampled-out");
+        assertThat(written).isBetween(1.0, 50.0);
+        assertThat(sampledOut).isBetween(950.0, (double) total);
+        assertThat(written + sampledOut).isEqualTo((double) total);
+    }
+
+    @Test
+    void logFailure_authenticatedTenant_sampleRateHigh_neverSamplesOut() {
+        // Sampling applies ONLY to the unauthenticated tier. Authenticated
+        // entries are compliance-critical — they must persist at full
+        // fidelity regardless of sample rate. Guard against a future
+        // refactor that widens the gate.
+        ReflectionTestUtils.setField(service, "unauthenticatedSampleRate", 1000);
+        request.setAttribute("authenticated_tenant_id", "tenant-auth");
+
+        for (int i = 0; i < 100; i++) {
+            service.logFailure(request, 403, ErrorCode.FORBIDDEN, "x", null);
+        }
+
+        verify(auditRepository, org.mockito.Mockito.times(100))
+                .log(org.mockito.ArgumentMatchers.any(AuditLogEntry.class));
+        assertThat(counter("sampled-out")).isEqualTo(0.0);
+    }
+
+    @Test
+    void logFailure_sampleRateZero_treatedAsOne_recordsAll() {
+        // Defense against misconfiguration: zero or negative rate must not
+        // silently drop every entry. The `<= 1` guard in shouldSampleOut
+        // treats these as "no sampling".
+        ReflectionTestUtils.setField(service, "unauthenticatedSampleRate", 0);
+
+        for (int i = 0; i < 10; i++) {
+            service.logFailure(request, 401, ErrorCode.UNAUTHORIZED, "x", null);
+        }
+
+        verify(auditRepository, org.mockito.Mockito.times(10))
+                .log(org.mockito.ArgumentMatchers.any(AuditLogEntry.class));
+        assertThat(counter("sampled-out")).isEqualTo(0.0);
+    }
+
+    // --- message sanitization ---
+
+    @Test
+    void logFailure_message_crlfStripped() {
+        service.logFailure(request, 400, ErrorCode.INVALID_REQUEST,
+                "line1\r\nline2\ninjected", null);
+
+        ArgumentCaptor<AuditLogEntry> captor = ArgumentCaptor.forClass(AuditLogEntry.class);
+        verify(auditRepository).log(captor.capture());
+        String sanitized = (String) captor.getValue().getMetadata().get("error_message");
+        assertThat(sanitized).doesNotContain("\r");
+        assertThat(sanitized).doesNotContain("\n");
+        assertThat(sanitized).contains("line1");
+        assertThat(sanitized).contains("line2");
+        assertThat(sanitized).contains("injected");
+    }
+
+    @Test
+    void logFailure_message_longerThan1024_truncated() {
+        String longMsg = "x".repeat(2000);
+
+        service.logFailure(request, 400, ErrorCode.INVALID_REQUEST, longMsg, null);
+
+        ArgumentCaptor<AuditLogEntry> captor = ArgumentCaptor.forClass(AuditLogEntry.class);
+        verify(auditRepository).log(captor.capture());
+        String sanitized = (String) captor.getValue().getMetadata().get("error_message");
+        assertThat(sanitized).hasSize(1024);
+    }
+
+    @Test
+    void logFailure_nullMessage_omitsErrorMessageKey() {
+        service.logFailure(request, 400, ErrorCode.INVALID_REQUEST, null, null);
+
+        ArgumentCaptor<AuditLogEntry> captor = ArgumentCaptor.forClass(AuditLogEntry.class);
+        verify(auditRepository).log(captor.capture());
+        assertThat(captor.getValue().getMetadata()).doesNotContainKey("error_message");
+        // method and path still present.
+        assertThat(captor.getValue().getMetadata()).containsKey("method");
+        assertThat(captor.getValue().getMetadata()).containsKey("path");
+    }
+
+    @Test
+    void logFailure_extrasMerged_alongsideDefaultMetadata() {
+        java.util.Map<String, Object> extras = new java.util.HashMap<>();
+        extras.put("exception_class", "java.lang.RuntimeException");
+
+        service.logFailure(request, 500, ErrorCode.INTERNAL_ERROR, "boom", extras);
+
+        ArgumentCaptor<AuditLogEntry> captor = ArgumentCaptor.forClass(AuditLogEntry.class);
+        verify(auditRepository).log(captor.capture());
+        assertThat(captor.getValue().getMetadata())
+                .containsEntry("exception_class", "java.lang.RuntimeException")
+                .containsEntry("method", "GET")
+                .containsEntry("path", "/v1/admin/budgets")
+                .containsEntry("error_message", "boom");
+    }
+
+    // --- non-throwing contract ---
+
+    @Test
+    void logFailure_auditRepositoryThrows_swallowed_errorCounterIncremented() {
+        org.mockito.Mockito.doThrow(new RuntimeException("Redis down"))
+                .when(auditRepository)
+                .log(org.mockito.ArgumentMatchers.any(AuditLogEntry.class));
+
+        // Must not propagate.
+        service.logFailure(request, 401, ErrorCode.UNAUTHORIZED, "x", null);
+
+        assertThat(counter("error")).isEqualTo(1.0);
+        assertThat(counter("written")).isEqualTo(0.0);
+    }
+
+    @Test
+    void logFailure_nullRequest_noNpe() {
+        service.logFailure(null, 500, ErrorCode.INTERNAL_ERROR, "x", null);
+
+        ArgumentCaptor<AuditLogEntry> captor = ArgumentCaptor.forClass(AuditLogEntry.class);
+        verify(auditRepository).log(captor.capture());
+        AuditLogEntry entry = captor.getValue();
+        assertThat(entry.getTenantId()).isEqualTo(AuditLogEntry.UNAUTHENTICATED_TENANT);
+        assertThat(entry.getOperation()).isEqualTo("UNKNOWN:");
+        assertThat(entry.getRequestId()).isNotNull(); // UUID fallback
+    }
+
+    @Test
+    void logFailure_successPath_notTriggeredFromSuccessControllerFlow() {
+        // Sanity: the service is only called from failure paths. Zero
+        // interactions when nothing calls it. Guards against a future
+        // refactor that accidentally wires this into a success code path
+        // (double-write risk).
+        verify(auditRepository, never())
+                .log(org.mockito.ArgumentMatchers.any(AuditLogEntry.class));
+    }
+
+    // --- concurrency / DDoS-in-miniature ---
+
+    @Test
+    void logFailure_concurrent1000Calls_noLostCounterIncrements() throws Exception {
+        // DDoS-in-miniature: fire 1000 parallel unauthenticated failures
+        // through a thread pool and assert (written + sampled-out + error)
+        // == 1000 exactly. ThreadLocalRandom is lock-free and Micrometer
+        // counters are atomic, so any discrepancy indicates a real bug
+        // (lost increment, double-count, swallowed exception escaping the
+        // try/catch, etc.). Rate 100 → expected ~10 written — statistical
+        // bounds identical to the serial test, but now under contention.
+        ReflectionTestUtils.setField(service, "unauthenticatedSampleRate", 100);
+        final int total = 1000;
+        final int threads = 16;
+
+        java.util.concurrent.ExecutorService pool =
+                java.util.concurrent.Executors.newFixedThreadPool(threads);
+        java.util.concurrent.CountDownLatch startGate =
+                new java.util.concurrent.CountDownLatch(1);
+        java.util.concurrent.CountDownLatch doneGate =
+                new java.util.concurrent.CountDownLatch(total);
+
+        try {
+            for (int i = 0; i < total; i++) {
+                pool.submit(() -> {
+                    try {
+                        startGate.await();
+                        // Each thread builds its own request to avoid
+                        // MockHttpServletRequest thread-unsafety.
+                        MockHttpServletRequest req = new MockHttpServletRequest();
+                        req.setMethod("GET");
+                        req.setRequestURI("/v1/admin/tenants");
+                        service.logFailure(req, 401, ErrorCode.UNAUTHORIZED, "x", null);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        doneGate.countDown();
+                    }
+                });
+            }
+            startGate.countDown();
+            boolean completed = doneGate.await(30, java.util.concurrent.TimeUnit.SECONDS);
+            assertThat(completed)
+                    .as("all %d logFailure calls must complete within 30s", total)
+                    .isTrue();
+        } finally {
+            pool.shutdownNow();
+        }
+
+        double written = counter("written");
+        double sampledOut = counter("sampled-out");
+        double error = counter("error");
+
+        // Exactness: every call must land in exactly one bucket. A lost
+        // increment or double-count breaks this sum.
+        assertThat(written + sampledOut + error)
+                .as("written + sampled-out + error must equal total=%d (no lost increments)", total)
+                .isEqualTo((double) total);
+
+        // No concurrency-induced errors: the non-throwing contract must
+        // hold even under contention.
+        assertThat(error)
+                .as("logFailure must never produce outcome=error under normal concurrent load")
+                .isEqualTo(0.0);
+
+        // Statistical bound on sampling: same as serial test, just under
+        // parallel load. Binomial(1000, 0.01) → mean=10, stddev~3.15,
+        // 99.9% CI roughly [1, 20]. [1, 50] is the conservative bound.
+        assertThat(written).isBetween(1.0, 50.0);
+        assertThat(sampledOut).isBetween(950.0, (double) total);
+    }
+
+    @Test
+    void logFailure_concurrent_authenticatedNeverSampled_evenUnderLoad() throws Exception {
+        // Authenticated tier must persist at full fidelity even under
+        // heavy contention — compliance-of-record guarantee.
+        ReflectionTestUtils.setField(service, "unauthenticatedSampleRate", 10000);
+        final int total = 500;
+        final int threads = 8;
+
+        java.util.concurrent.ExecutorService pool =
+                java.util.concurrent.Executors.newFixedThreadPool(threads);
+        java.util.concurrent.CountDownLatch startGate =
+                new java.util.concurrent.CountDownLatch(1);
+        java.util.concurrent.CountDownLatch doneGate =
+                new java.util.concurrent.CountDownLatch(total);
+
+        try {
+            for (int i = 0; i < total; i++) {
+                pool.submit(() -> {
+                    try {
+                        startGate.await();
+                        MockHttpServletRequest req = new MockHttpServletRequest();
+                        req.setMethod("POST");
+                        req.setRequestURI("/v1/admin/budgets");
+                        req.setAttribute("authenticated_tenant_id", "tenant-load");
+                        service.logFailure(req, 403, ErrorCode.FORBIDDEN, "x", null);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        doneGate.countDown();
+                    }
+                });
+            }
+            startGate.countDown();
+            boolean completed = doneGate.await(30, java.util.concurrent.TimeUnit.SECONDS);
+            assertThat(completed).isTrue();
+        } finally {
+            pool.shutdownNow();
+        }
+
+        assertThat(counter("written"))
+                .as("authenticated-tier entries persist at full fidelity regardless of "
+                        + "sampleRate=%d", 10000)
+                .isEqualTo((double) total);
+        assertThat(counter("sampled-out"))
+                .as("authenticated entries must NEVER be sampled out")
+                .isEqualTo(0.0);
+        assertThat(counter("error")).isEqualTo(0.0);
+    }
+
+    // --- helpers ---
+
+    private double counter(String outcome) {
+        return meterRegistry.find("cycles_admin_audit_writes_total")
+                .tag("path_class", "failure")
+                .tag("outcome", outcome)
+                .counter() == null
+                        ? 0.0
+                        : meterRegistry.find("cycles_admin_audit_writes_total")
+                                .tag("path_class", "failure")
+                                .tag("outcome", outcome)
+                                .counter()
+                                .count();
+    }
+}

--- a/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/AuditRepository.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/AuditRepository.java
@@ -3,8 +3,12 @@ import io.runcycles.admin.model.audit.AuditLogEntry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.*;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Repository;
 import redis.clients.jedis.*;
+import redis.clients.jedis.params.ScanParams;
+import redis.clients.jedis.resps.ScanResult;
 import java.time.Instant;
 import java.util.*;
 @Repository
@@ -13,10 +17,57 @@ public class AuditRepository {
     @Autowired private JedisPool jedisPool;
     @Autowired private ObjectMapper objectMapper;
 
-    // Lua script for atomic audit log creation: SET + 2x ZADD in one call
-    // Prevents orphaned log entries if process crashes between operations
+    /**
+     * Retention for entries whose {@code tenant_id != "<unauthenticated>"} —
+     * every success entry and every authenticated failure. Default 400 days
+     * = SOC2 Type II 12-month lookback + 1-month buffer for post-period
+     * auditor lag. Set to {@code 0} for indefinite retention (legal hold,
+     * HIPAA-adjacent deployments, or environments that offload to an
+     * archive store).
+     *
+     * @since 0.1.25.20
+     */
+    @Value("${audit.retention.authenticated.days:400}")
+    private int authenticatedRetentionDays;
+
+    /**
+     * Retention for entries whose {@code tenant_id == "<unauthenticated>"}.
+     * Applies to pre-auth failures (missing / invalid credentials, path
+     * traversal rejections, admin-key-only requests failing before the
+     * controller runs). Default 30 days — enough for brute-force /
+     * credential-stuffing post-mortem; aggregate attempt volume stays
+     * visible via the {@code cycles_admin_audit_writes_total} Prometheus
+     * counter regardless of this setting. Set to {@code 0} for indefinite.
+     *
+     * @since 0.1.25.20
+     */
+    @Value("${audit.retention.unauthenticated.days:30}")
+    private int unauthenticatedRetentionDays;
+
+    /**
+     * Lua script for atomic audit-log creation. Now supports optional TTL
+     * via ARGV[4] (seconds; 0 or negative = no expiry). The Lua runs:
+     * <pre>
+     *   SET audit:log:&#123;logId&#125; &lt;json&gt; [EX ttlSeconds]
+     *   ZADD audit:logs:&#123;tenantId&#125; &lt;score&gt; &lt;logId&gt;
+     *   ZADD audit:logs:_all         &lt;score&gt; &lt;logId&gt;
+     * </pre>
+     * Atomicity prevents orphaned index pointers if the process crashes
+     * mid-write. Index sorted-set entries don't need per-entry TTL —
+     * they're cleaned up by {@link #sweepStaleIndexEntries()} once per day.
+     * Under steady state, index lookups in {@link #list} tolerate stale
+     * pointers (null-body check at the read site), so the sweep is
+     * eventual-consistency cleanup, not read-path critical.
+     *
+     * @since 0.1.25.20 (TTL added; script formerly had no expiry support)
+     */
     private static final String LOG_AUDIT_LUA =
-        "redis.call('SET', KEYS[1], ARGV[1])\n" +
+        "local ttl = tonumber(ARGV[4])\n" +
+        "if ttl and ttl > 0 then\n" +
+        "    redis.call('SET', KEYS[1], ARGV[1], 'EX', ttl)\n" +
+        "else\n" +
+        "    redis.call('SET', KEYS[1], ARGV[1])\n" +
+        "end\n" +
         "redis.call('ZADD', KEYS[2], ARGV[2], ARGV[3])\n" +
         "redis.call('ZADD', KEYS[3], ARGV[2], ARGV[3])\n" +
         "return 1\n";
@@ -28,17 +79,97 @@ public class AuditRepository {
             entry.setTimestamp(Instant.now());
             String json = objectMapper.writeValueAsString(entry);
             String score = String.valueOf(entry.getTimestamp().toEpochMilli());
-            // Atomic write: SET log + ZADD tenant index + ZADD global index
+            long ttlSeconds = resolveTtlSeconds(entry);
+            // Atomic write: SET log (with optional EX) + ZADD tenant index + ZADD global index
             jedis.eval(LOG_AUDIT_LUA,
                 List.of("audit:log:" + logId,
                         "audit:logs:" + entry.getTenantId(),
                         "audit:logs:_all"),
-                List.of(json, score, logId));
+                List.of(json, score, logId, String.valueOf(ttlSeconds)));
         } catch (Exception e) {
             // Audit log failure should not break the business operation that triggered it
             LOG.error("Failed to write audit log (non-fatal)", e);
         }
     }
+
+    /**
+     * Pick the per-entry TTL based on whether the entry is attributed to a
+     * real tenant or the unauthenticated sentinel. Returns seconds; 0 means
+     * "no expiry" (Lua branch skips the {@code EX} argument).
+     */
+    long resolveTtlSeconds(AuditLogEntry entry) {
+        boolean unauth = AuditLogEntry.UNAUTHENTICATED_TENANT.equals(entry.getTenantId());
+        int days = unauth ? unauthenticatedRetentionDays : authenticatedRetentionDays;
+        return days > 0 ? (long) days * 86400L : 0L;
+    }
+
+    /**
+     * Daily sweep of the audit sorted-set indexes to remove pointers whose
+     * target {@code audit:log:{id}} key has already expired. Without this
+     * sweep the {@code audit:logs:_all} and per-tenant sorted sets would
+     * grow unbounded even though the underlying log records are gone —
+     * stale pointers still cost memory (~32 bytes per entry) and lengthen
+     * read-side scans in {@link #list}.
+     *
+     * <p>Runs at 03:00 server time by default (configurable via
+     * {@code audit.sweep.cron}). Uses the {@code authenticatedRetentionDays}
+     * as the global upper-bound — since unauthenticated entries expire
+     * sooner, they're safely swept too. Deployments with {@code
+     * authenticated.days=0} (indefinite) skip the sweep to avoid accidental
+     * data loss.
+     *
+     * <p>The sweep is best-effort and non-fatal: any exception is logged
+     * at ERROR but never propagates. Skipped on the current tick if Redis
+     * is unavailable — the next tick retries.
+     *
+     * @since 0.1.25.20
+     */
+    @Scheduled(cron = "${audit.sweep.cron:0 0 3 * * *}")
+    public void sweepStaleIndexEntries() {
+        if (authenticatedRetentionDays <= 0) {
+            // Indefinite retention — nothing to sweep. Skip explicitly so
+            // ops can see "sweep disabled" in the absence of log lines
+            // rather than guess at behavior.
+            LOG.debug("Audit index sweep skipped — authenticated retention is indefinite");
+            return;
+        }
+        try (Jedis jedis = jedisPool.getResource()) {
+            // Upper bound: entries older than the longest retention window
+            // have definitely expired, so their index pointers can be
+            // removed without risk of deleting a live entry.
+            long cutoffMillis = Instant.now().toEpochMilli()
+                    - ((long) authenticatedRetentionDays * 86400L * 1000L);
+            long removedGlobal = jedis.zremrangeByScore("audit:logs:_all",
+                    Double.NEGATIVE_INFINITY, cutoffMillis);
+            long removedTenants = 0;
+            // Per-tenant indexes: SCAN for audit:logs:* keys (excludes :_all).
+            // Audit write rate per tenant is low enough that even a large
+            // fleet produces a bounded number of per-tenant keys. SCAN is
+            // non-blocking and preferred over KEYS for any production
+            // operation.
+            ScanParams params = new ScanParams().match("audit:logs:*").count(100);
+            String cursor = ScanParams.SCAN_POINTER_START;
+            do {
+                ScanResult<String> scan = jedis.scan(cursor, params);
+                for (String indexKey : scan.getResult()) {
+                    if ("audit:logs:_all".equals(indexKey)) {
+                        continue; // already handled above
+                    }
+                    removedTenants += jedis.zremrangeByScore(indexKey,
+                            Double.NEGATIVE_INFINITY, cutoffMillis);
+                }
+                cursor = scan.getCursor();
+            } while (!ScanParams.SCAN_POINTER_START.equals(cursor));
+            LOG.info("Audit index sweep completed — removed {} global + {} per-tenant stale pointers "
+                            + "older than {} ms",
+                    removedGlobal, removedTenants, cutoffMillis);
+        } catch (Exception e) {
+            // Sweep is best-effort — a failed tick does not impact business
+            // operations. The next scheduled run retries.
+            LOG.error("Audit index sweep failed (non-fatal — next tick will retry)", e);
+        }
+    }
+
     public List<AuditLogEntry> list(String tenantId, String keyId, String operation, Integer status,
                                      String resourceType, String resourceId,
                                      Instant from, Instant to, String cursor, int limit) {
@@ -70,7 +201,11 @@ public class AuditRepository {
                 try {
                     String data = jedis.get("audit:log:" + id);
                     if (data == null) {
-                        LOG.warn("Audit log data missing for id: {}", id);
+                        // Expired entry — pointer still in the index but the
+                        // underlying log key has been evicted by its TTL. The
+                        // daily sweep will remove stale pointers eventually;
+                        // read side just skips them transparently.
+                        LOG.debug("Audit log data missing for id: {} (likely TTL-expired)", id);
                         continue;
                     }
                     AuditLogEntry entry = objectMapper.readValue(data, AuditLogEntry.class);

--- a/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/AuditRepositoryTest.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/AuditRepositoryTest.java
@@ -11,8 +11,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.params.ScanParams;
+import redis.clients.jedis.resps.ScanResult;
 
 import java.time.Instant;
 import java.util.*;
@@ -305,5 +308,145 @@ class AuditRepositoryTest {
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getLogId()).isEqualTo("log_good");
+    }
+
+    // --- v0.1.25.20: tiered TTL + index sweep ---
+
+    @Test
+    void resolveTtlSeconds_authenticatedTenant_usesAuthenticatedRetention() {
+        ReflectionTestUtils.setField(repository, "authenticatedRetentionDays", 400);
+        ReflectionTestUtils.setField(repository, "unauthenticatedRetentionDays", 30);
+
+        AuditLogEntry entry = AuditLogEntry.builder().tenantId("tenant-1").build();
+
+        // 400 days × 86400s
+        assertThat(repository.resolveTtlSeconds(entry)).isEqualTo(400L * 86400L);
+    }
+
+    @Test
+    void resolveTtlSeconds_unauthenticatedSentinel_usesShortRetention() {
+        ReflectionTestUtils.setField(repository, "authenticatedRetentionDays", 400);
+        ReflectionTestUtils.setField(repository, "unauthenticatedRetentionDays", 30);
+
+        AuditLogEntry entry = AuditLogEntry.builder()
+                .tenantId(AuditLogEntry.UNAUTHENTICATED_TENANT).build();
+
+        // 30 days × 86400s
+        assertThat(repository.resolveTtlSeconds(entry)).isEqualTo(30L * 86400L);
+    }
+
+    @Test
+    void resolveTtlSeconds_zeroDays_meansIndefinite() {
+        ReflectionTestUtils.setField(repository, "authenticatedRetentionDays", 0);
+        ReflectionTestUtils.setField(repository, "unauthenticatedRetentionDays", 0);
+
+        AuditLogEntry authed = AuditLogEntry.builder().tenantId("tenant-1").build();
+        AuditLogEntry unauthed = AuditLogEntry.builder()
+                .tenantId(AuditLogEntry.UNAUTHENTICATED_TENANT).build();
+
+        assertThat(repository.resolveTtlSeconds(authed)).isEqualTo(0L);
+        assertThat(repository.resolveTtlSeconds(unauthed)).isEqualTo(0L);
+    }
+
+    @Test
+    void log_authenticatedEntry_evalReceivesAuthenticatedTtlInArgv() {
+        ReflectionTestUtils.setField(repository, "authenticatedRetentionDays", 400);
+        ReflectionTestUtils.setField(repository, "unauthenticatedRetentionDays", 30);
+
+        AuditLogEntry entry = AuditLogEntry.builder()
+                .tenantId("tenant-1").operation("createTenant").status(201).build();
+
+        repository.log(entry);
+
+        // ARGV[4] (index 3 in 0-based args list) must be the authenticated
+        // retention in seconds.
+        verify(jedis).eval(anyString(), anyList(), argThat(args ->
+                String.valueOf(400L * 86400L).equals(args.get(3))));
+    }
+
+    @Test
+    void log_unauthenticatedSentinelEntry_evalReceivesUnauthenticatedTtlInArgv() {
+        ReflectionTestUtils.setField(repository, "authenticatedRetentionDays", 400);
+        ReflectionTestUtils.setField(repository, "unauthenticatedRetentionDays", 30);
+
+        AuditLogEntry entry = AuditLogEntry.builder()
+                .tenantId(AuditLogEntry.UNAUTHENTICATED_TENANT)
+                .operation("POST:/v1/admin/budgets")
+                .status(401).errorCode("UNAUTHORIZED").build();
+
+        repository.log(entry);
+
+        verify(jedis).eval(anyString(), anyList(), argThat(args ->
+                String.valueOf(30L * 86400L).equals(args.get(3))));
+    }
+
+    @Test
+    void log_retentionZero_evalReceivesZeroTtl_luaSkipsExpire() {
+        // Retention 0 days → 0 seconds → Lua's `if ttl > 0` check short-
+        // circuits → plain SET without EX. Contract test locks the
+        // "0 == indefinite" semantic.
+        ReflectionTestUtils.setField(repository, "authenticatedRetentionDays", 0);
+        ReflectionTestUtils.setField(repository, "unauthenticatedRetentionDays", 0);
+
+        AuditLogEntry entry = AuditLogEntry.builder()
+                .tenantId("tenant-indefinite").operation("op").status(200).build();
+
+        repository.log(entry);
+
+        verify(jedis).eval(anyString(), anyList(), argThat(args ->
+                "0".equals(args.get(3))));
+    }
+
+    @Test
+    void sweepStaleIndexEntries_retentionZero_skipsSweep() {
+        ReflectionTestUtils.setField(repository, "authenticatedRetentionDays", 0);
+
+        repository.sweepStaleIndexEntries();
+
+        // No Redis ops when retention is indefinite — we don't want to
+        // accidentally delete index pointers whose target keys are still
+        // valid (indefinite TTL means targets never expire).
+        verify(jedis, never()).zremrangeByScore(anyString(), anyDouble(), anyDouble());
+        verify(jedis, never()).scan(anyString(), any(ScanParams.class));
+    }
+
+    @Test
+    void sweepStaleIndexEntries_removesGlobalAndPerTenantPointers() {
+        ReflectionTestUtils.setField(repository, "authenticatedRetentionDays", 400);
+
+        // Global index removes some stale entries.
+        when(jedis.zremrangeByScore(eq("audit:logs:_all"), eq(Double.NEGATIVE_INFINITY), anyDouble()))
+                .thenReturn(5L);
+
+        // SCAN returns two per-tenant indexes and the global one (which
+        // should be skipped since it's already swept).
+        @SuppressWarnings("unchecked")
+        ScanResult<String> scan1 = mock(ScanResult.class);
+        when(scan1.getResult()).thenReturn(List.of(
+                "audit:logs:_all", "audit:logs:tenant-a", "audit:logs:tenant-b"));
+        when(scan1.getCursor()).thenReturn(ScanParams.SCAN_POINTER_START);
+        when(jedis.scan(eq(ScanParams.SCAN_POINTER_START), any(ScanParams.class))).thenReturn(scan1);
+
+        when(jedis.zremrangeByScore(eq("audit:logs:tenant-a"), anyDouble(), anyDouble()))
+                .thenReturn(3L);
+        when(jedis.zremrangeByScore(eq("audit:logs:tenant-b"), anyDouble(), anyDouble()))
+                .thenReturn(2L);
+
+        repository.sweepStaleIndexEntries();
+
+        verify(jedis).zremrangeByScore(eq("audit:logs:_all"), eq(Double.NEGATIVE_INFINITY), anyDouble());
+        verify(jedis).zremrangeByScore(eq("audit:logs:tenant-a"), anyDouble(), anyDouble());
+        verify(jedis).zremrangeByScore(eq("audit:logs:tenant-b"), anyDouble(), anyDouble());
+        // Must NOT double-sweep the global index via the SCAN loop.
+        verify(jedis, times(1)).zremrangeByScore(eq("audit:logs:_all"), anyDouble(), anyDouble());
+    }
+
+    @Test
+    void sweepStaleIndexEntries_redisFailure_swallowsException() {
+        ReflectionTestUtils.setField(repository, "authenticatedRetentionDays", 400);
+        when(jedisPool.getResource()).thenThrow(new RuntimeException("Redis unavailable"));
+
+        // Must not throw — sweep is best-effort.
+        repository.sweepStaleIndexEntries();
     }
 }

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/audit/AuditLogEntry.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/audit/AuditLogEntry.java
@@ -8,6 +8,28 @@ import java.time.Instant;
 import java.util.Map;
 @Data @Builder @NoArgsConstructor @AllArgsConstructor
 public class AuditLogEntry {
+
+    /**
+     * Sentinel tenant id used on failure audit entries where no authenticated
+     * tenant is bound to the request (missing / invalid API key, pre-auth
+     * path-traversal rejection, admin-key-only requests that fail before the
+     * controller runs). Preserves the spec's {@code tenant_id: required}
+     * invariant without a wire-format change, and gives ops a queryable
+     * filter value: {@code GET /v1/admin/audit/logs?tenant_id=%3Cunauthenticated%3E}.
+     *
+     * <p>Tenants use the grammar {@code ^[a-z0-9-]+$} per AuditController
+     * validation, so the angle brackets guarantee no collision with any
+     * real tenant id.
+     *
+     * <p>Defined at the model layer so both the failure-side writer
+     * ({@code AuditFailureService}) and the data-layer repository
+     * ({@code AuditRepository} — which branches on this value for tiered
+     * TTL) can reference it without a cross-layer dependency.
+     *
+     * @since 0.1.25.20
+     */
+    public static final String UNAUTHENTICATED_TENANT = "<unauthenticated>";
+
     @JsonProperty("log_id") private String logId;
     @JsonProperty("timestamp") private Instant timestamp;
     @JsonProperty("tenant_id") private String tenantId;

--- a/cycles-admin-service/pom.xml
+++ b/cycles-admin-service/pom.xml
@@ -18,7 +18,7 @@
         <module>cycles-admin-service-api</module>
     </modules>
     <properties>
-        <revision>0.1.25.19</revision>
+        <revision>0.1.25.20</revision>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/docker-compose.full-stack.prod.yml
+++ b/docker-compose.full-stack.prod.yml
@@ -13,7 +13,7 @@ services:
       retries: 5
 
   cycles-admin:
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.19
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.20
     restart: unless-stopped
     ports:
       - "7979:7979"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,7 +13,7 @@ services:
       retries: 5
 
   cycles-admin:
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.19
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.20
     restart: unless-stopped
     ports:
       - "7979:7979"


### PR DESCRIPTION
## Summary

Closes a real compliance-auditing gap: `GET /v1/admin/audit/logs` only returned STATUS 201/200/204 entries because writes happened inside each controller *after* the service call returned. Every error path (401/403 in `AuthInterceptor`, 400/404/409/500 in `GlobalExceptionHandler`) short-circuited before the audit write — invisible to SOC2/GDPR reviewers.

**Hybrid approach — success-side per-controller writes stay verbatim** (rich operation-specific metadata); failure writes land in two new sites, guarded by tiered retention + opt-in sampling to neutralize DDoS amplification.

## What's new

**Failure-audit coverage**
- `GlobalExceptionHandler` — all 7 `@ExceptionHandler` methods audit before returning error response
- `AuthInterceptor.writeError` — all 7 pre-controller rejection points audit
- Single-write invariant by construction (no dedup logic needed)

**Tiered TTL (SOC2-compliant defaults, configurable to indefinite)**
- `audit.retention.authenticated.days=400` — SOC2 Type II 12mo + 1mo buffer. Applies to all entries where `tenant_id != sentinel`. Set `0` for indefinite.
- `audit.retention.unauthenticated.days=30` — DDoS-surface tier. Set `0` for indefinite.

**DDoS amplification protection**
- `audit.sample.unauthenticated=1` default (no sampling). Tune to 100+ under DDoS exposure. Authenticated tier **never** sampled.
- `@Scheduled` daily sweep purges TTL-expired pointers from global + per-tenant indexes. Skipped entirely when retention is indefinite.

**Sentinel design**
- `tenant_id="<unauthenticated>"` preserves spec's required-field invariant — no wire-format change.
- Source of truth at `AuditLogEntry.UNAUTHENTICATED_TENANT` (model layer). Referenced by both `AuditFailureService` (api) and `AuditRepository` (data) without cross-layer coupling.

**Non-throwing contract preserved**
- `AuditRepository.log()` swallows (existing). `AuditFailureService.logFailure()` wraps its body as defense-in-depth.
- Sweep is best-effort; retries next tick on Redis unavailability.

**New metric** — `cycles_admin_audit_writes_total{path_class, outcome}` with outcomes `written` / `error` / `sampled-out`. **Alert on `outcome=error` nonzero** (silent-coverage-loss surface).

**Log-injection hardening** — `metadata.error_message` CR/LF-stripped and 1024-char-capped.

## Wire format

Additive. `AuditLogEntry` schema already accommodated failure shape (`error_code` optional; `metadata` `Map<String, Object>`). No spec change.

**Breaking semantic change for audit-log consumers**: queries filtered by `status=201/200/204` return exactly the same rows as before. Queries without a status filter now surface failure entries. Dashboards that assumed "entry exists ⇒ operation succeeded" must switch to checking `status` or `error_code`.

## Changes

| Layer | Files |
|---|---|
| Model | `AuditLogEntry.java` (+`UNAUTHENTICATED_TENANT` constant) |
| Data | `AuditRepository.java` (Lua widened for per-entry TTL, `resolveTtlSeconds`, `@Scheduled sweepStaleIndexEntries`) |
| API — new | `AuditFailureService.java` (shared failure writer + sampling + counter) |
| API — modified | `AuthInterceptor.java` (ctor +1, writeError audits), `GlobalExceptionHandler.java` (ctor +1, 7 handlers audit), `BudgetGovernanceApplication.java` (+`@EnableScheduling`) |
| Config | `application.properties` (4 new properties with SOC2-compliant defaults + env-var overrides) |
| Docs | `AUDIT.md`, `CHANGELOG.md`, `OPERATIONS.md` (new "Audit retention tuning" section with DDoS / HIPAA / legal-hold scenarios) |
| Tests | +33 unit tests across `AuditFailureServiceTest` (new), `AuthInterceptorTest`, `GlobalExceptionHandlerTest`, `AuditRepositoryTest`. +6 integration tests across `AuditRetentionIntegrationTest` (new), `AuditRetentionIndefiniteIntegrationTest` (new), `AdminFlowIntegrationTest` |
| Release | `pom.xml` 0.1.25.19 → 0.1.25.20; docker-compose prod tags bumped |

## Test plan

- [x] `mvn verify` — **560 unit tests** pass (up from 528), JaCoCo ≥95% on all modules, `SpecCoverageReportTest` 43/43 endpoints.
- [x] 2 DDoS-in-miniature concurrency tests in `AuditFailureServiceTest` — 1000 parallel unauth failures on 16 threads + 500 parallel authenticated failures on 8 threads. Assert `written+sampled_out+error==N` exactly (no lost increments under contention) and authenticated-never-sampled under load.
- [x] `OpenApiContractDiffTest` — zero INCOMPATIBLE diff. No wire-format change.
- [x] Three-round review (docs/accuracy, code/quality, testing+parity).
- [ ] CI integration job (`mvn verify -Pintegration-tests`) — runs `AuditRetentionIntegrationTest` (end-to-end TTL proof against real Testcontainers Redis) + `AuditRetentionIndefiniteIntegrationTest` (TTL=0 indefinite + sweep no-op guard) + existing `AdminFlowIntegrationTest` with 3 new deliberate-failure assertions.
- [ ] Manual smoke in staging:
  - Generate failures: `curl` unauth → 401, malformed POST → 400, nonexistent DELETE → 404
  - `GET /v1/admin/audit/logs` — expect 3 new failure entries with matching `status` / `error_code` / `operation`
  - Check `cycles_admin_audit_writes_total{path_class=failure, outcome=written}` increments

## Follow-up (tracked as v0.1.25.21)

Nightly CI coverage parity with cycles-server for the audit-write path:
- `nightly-audit-soak.yml` — 10min × sustained failure-flood load; assert TTL works, sweep reclaims memory, sampling ratio holds
- `nightly-property-tests.yml` — jqwik invariants: `written + sampled_out + error == N`; authenticated never sampled; TTL tier always matches tenant_id

Opening separately as a tracking issue.

## Cross-refs

- No spec dependency — `AuditLogEntry` schema already allowed the failure shape.
- No cycles-server impact — admin-plane change only.