### PR TITLE
fix(soak-test): AS4 — baseline-subtract setup-phase audit writes

### DIFF
--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/integration/AuditFailureSoakIntegrationTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/integration/AuditFailureSoakIntegrationTest.java
@@ -119,6 +119,26 @@ class AuditFailureSoakIntegrationTest extends BaseIntegrationTest {
                 "permissions", java.util.List.of("balances:read")));
         String tenantKey = (String) keyResp.getBody().get("key_secret");
 
+        // ---- AS4 baseline ----
+        // Setup calls above (createTenant + createApiKey) are SUCCESS paths
+        // that write audit entries via their respective per-controller
+        // AuditRepository.log() calls. Those ZADD to audit:logs:_all + per-
+        // tenant indexes but do NOT increment cycles_admin_audit_writes_total
+        // — that counter is failure-side only. Capture the index baseline
+        // after setup so AS4 can compare the load-phase delta against the
+        // failure counter without the setup entries polluting the math.
+        //
+        // Any deviation (v0.1.25.21 initial soak run: 14602 vs 14600) was
+        // entirely setup-side. The invariant we actually want to check is
+        // "every failure write that lands in Redis also increments the
+        // counter" — which needs the baseline subtraction.
+        long indexBaselineGlobal;
+        long indexBaselineTenant;
+        try (Jedis jedis = jedisPool.getResource()) {
+            indexBaselineGlobal = jedis.zcard("audit:logs:_all");
+            indexBaselineTenant = jedis.zcard("audit:logs:tenant-soak");
+        }
+
         ExecutorService pool = Executors.newFixedThreadPool(WORKER_THREADS);
         CountDownLatch start = new CountDownLatch(1);
         CountDownLatch done = new CountDownLatch(WORKER_THREADS);
@@ -261,23 +281,37 @@ class AuditFailureSoakIntegrationTest extends BaseIntegrationTest {
                         counterTotal, written, error, sampledOut, totalRequests)
                 .isEqualTo((double) totalRequests);
 
-        // ---- AS4: audit index cardinality ≤ written count ----
+        // ---- AS4: failure-phase index writes match written counter ----
+        // Subtract the baseline captured after setup so the assertion
+        // measures only the load phase. An orphan ZADD in the v0.1.25.20
+        // failure path (Lua racing with the counter increment) would show
+        // up as delta > written. Matching delta == written (at default
+        // rate=1, no sampling) is the strong invariant.
         try (Jedis jedis = jedisPool.getResource()) {
-            long globalIndex = jedis.zcard("audit:logs:_all");
-            assertThat(globalIndex)
-                    .as("AS4: audit:logs:_all cardinality %d must be ≤ written %f — "
+            long globalIndexAfter = jedis.zcard("audit:logs:_all");
+            long globalDelta = globalIndexAfter - indexBaselineGlobal;
+            assertThat(globalDelta)
+                    .as("AS4: audit:logs:_all load-phase delta %d must equal written %f — "
                             + "if greater, something is ZADDing without a corresponding "
-                            + "counter increment",
-                            globalIndex, written)
-                    .isLessThanOrEqualTo((long) written);
+                            + "counter increment (orphan-ZADD bug); if smaller, a write "
+                            + "incremented the counter but failed to index (sweep racing "
+                            + "writes, or script divergence)",
+                            globalDelta, written)
+                    .isEqualTo((long) written);
 
-            // Also confirm every sentinel + real-tenant index exists
-            // and has bounded cardinality.
+            // Per-tier delta sanity: every failure write lands in exactly
+            // one tier index (sentinel OR real tenant). Their delta sum
+            // must equal the global delta — guards against a ZADD going
+            // into only one of the two index families.
             long sentinelIndex = jedis.zcard("audit:logs:<unauthenticated>");
             long tenantSoakIndex = jedis.zcard("audit:logs:tenant-soak");
-            assertThat(sentinelIndex + tenantSoakIndex)
-                    .as("AS4: sum of tier indexes should equal global index")
-                    .isLessThanOrEqualTo(globalIndex);
+            long tenantSoakDelta = tenantSoakIndex - indexBaselineTenant;
+            assertThat(sentinelIndex + tenantSoakDelta)
+                    .as("AS4: sentinel + (tenant-soak - baseline) must equal "
+                            + "load-phase global delta — ensures every write lands in "
+                            + "both its tier index AND the global index",
+                            sentinelIndex, tenantSoakDelta, globalDelta)
+                    .isEqualTo(globalDelta);
         }
 
         // ---- AS5: network error rate < 1% ----


### PR DESCRIPTION
## Summary

First manual run of `nightly-audit-soak.yml` ([run #24523814247](https://github.com/runcycles/cycles-server-admin/actions/runs/24523814247)) failed on **AS4** only. **Root cause is a test bug, not a real regression** — the v0.1.25.20 audit code behaved correctly under sustained contention.

## Diagnosis

```
AS4: audit:logs:_all cardinality 14602 must be ≤ written 14600.000000
```

Off by **exactly 2**. The setup phase provisions a tenant + API key:

```java
adminPost("/v1/admin/tenants", ...);     // 201 → SUCCESS audit write (1 entry)
adminPost("/v1/admin/api-keys", ...);    // 201 → SUCCESS audit write (1 entry)
```

Success-path audits go through per-controller `AuditRepository.log()` — that ZADDs to `audit:logs:_all` but does **not** increment `cycles_admin_audit_writes_total` (that counter is failure-side only, in `AuditFailureService.recordWrite`).

So: 2 setup success writes + 14,600 failure writes = 14,602 index entries; counter = 14,600 (failures only). The original assertion conflated the two sets.

## Fix

Capture the index baseline **after setup, before load**. Assert the load-phase delta matches the failure counter exactly.

```diff
+ long indexBaselineGlobal = jedis.zcard("audit:logs:_all");
+ long indexBaselineTenant = jedis.zcard("audit:logs:tenant-soak");
...
- assertThat(globalIndex).isLessThanOrEqualTo((long) written);
+ long globalDelta = globalIndexAfter - indexBaselineGlobal;
+ assertThat(globalDelta).isEqualTo((long) written);
```

Strict equality is stronger than the previous `<=` — catches orphan-ZADD (index grew without counter) **and** orphan-counter (counter incremented without index, e.g. sweep racing writes) in both directions.

Per-tier decomposition check also strengthened: `sentinel + (tenant-soak - baseline) == globalDelta`. Guards against a ZADD that drops either the tier-specific index OR the global index.

## What passed (good news)

The v0.1.25.20 code is correct under load:

- **AS1** (heap stability) ✓
- **AS2** (latency stability) ✓
- **AS3** (counter-sum completeness: 14600 exact, no lost increments under 16-thread × 10-min contention) ✓ — this is the important one
- **AS5** (0% network errors) ✓

Only AS4's test arithmetic was wrong.

## Side observation (not addressed)

Achieved throughput was ~24 ops/s, not the targeted 500. Per-request latency (~40ms for a full-stack 401 with Testcontainers Redis) dominates the nanosecond pacing — `LockSupport.parkNanos` never actually sleeps because each HTTP call takes longer than `perThreadNanosPerOp`. The `soak.target.rps` knob is aspirational for integration-stack tests. Not in scope for this fix; the soak still exercises the invariants under contention.

## Release

No version bump — v0.1.25.21 hasn't been tagged yet; this ships in the same release.

## Test plan

- [x] Compile verified (`mvn test-compile`)
- [ ] Manual `workflow_dispatch` run of `nightly-audit-soak.yml` after merge — verify all 5 invariants pass
- [ ] First scheduled nightly run at 06:30 UTC — green