### PR TITLE
feat(admin): v0.1.25.25 — free-text search on six admin list endpoints

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,9 +1,56 @@
-# Complete Budget Governance v0.1.25.24 — Admin Server Audit
+# Complete Budget Governance v0.1.25.25 — Admin Server Audit
 
-**Server version:** 0.1.25.24 (2026-04-16 — server-side sort on six admin list endpoints, spec v0.1.25.20 §V4)
-**Date:** 2026-04-16 (v0.1.25.24 server-side sort — six admin list endpoints), 2026-04-16 (v0.1.25.23 BudgetLedger tenant_id on wire), 2026-04-16 (v0.1.25.22 cross-tenant list + filters), 2026-04-16 (v0.1.25.21 nightly CI), 2026-04-16 (v0.1.25.20 audit-on-failure), 2026-04-16 (v0.1.25.19 introspect dual-auth + operator docs), 2026-04-15 (v0.1.25.18 RESET_SPENT operation), 2026-04-14 (v0.1.25.17 cjson round-trip sweep: apikey + policy + tenant), 2026-04-13 (v0.1.25.16 webhooks dual-auth), 2026-04-13 (v0.1.25.15 ScopeValidator), 2026-04-13 (v0.1.25.14 admin-on-behalf-of dual-auth), 2026-04-13 (v0.1.25.13 CORS PUT fix), 2026-04-12 (v0.1.25.12 spec-compliance hardening + observability), 2026-04-12 (v0.1.25.11 contract-testing default ON), 2026-04-12 (v0.1.25.10 spec-compliance hardening), 2026-04-10 (v0.1.25.9 release), 2026-04-10 (CORS hardening + prod config), 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
-**Spec:** [`cycles-governance-admin-v0.1.25.yaml`](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml) (OpenAPI 3.1.0, info.version `0.1.25.19`; BudgetLedger.tenant_id optional response field; listApiKeys/listBudgets accept `tenant_id` optional for AdminKeyAuth + four budget filter params: `over_limit`, `has_debt`, `utilization_min`, `utilization_max`) in [cycles-protocol](https://github.com/runcycles/cycles-protocol)
+**Server version:** 0.1.25.25 (2026-04-17 — free-text `search` on six admin list endpoints, spec v0.1.25.21 first bullet)
+**Date:** 2026-04-17 (v0.1.25.25 search on six list endpoints), 2026-04-16 (v0.1.25.24 server-side sort — six admin list endpoints), 2026-04-16 (v0.1.25.23 BudgetLedger tenant_id on wire), 2026-04-16 (v0.1.25.22 cross-tenant list + filters), 2026-04-16 (v0.1.25.21 nightly CI), 2026-04-16 (v0.1.25.20 audit-on-failure), 2026-04-16 (v0.1.25.19 introspect dual-auth + operator docs), 2026-04-15 (v0.1.25.18 RESET_SPENT operation), 2026-04-14 (v0.1.25.17 cjson round-trip sweep: apikey + policy + tenant), 2026-04-13 (v0.1.25.16 webhooks dual-auth), 2026-04-13 (v0.1.25.15 ScopeValidator), 2026-04-13 (v0.1.25.14 admin-on-behalf-of dual-auth), 2026-04-13 (v0.1.25.13 CORS PUT fix), 2026-04-12 (v0.1.25.12 spec-compliance hardening + observability), 2026-04-12 (v0.1.25.11 contract-testing default ON), 2026-04-12 (v0.1.25.10 spec-compliance hardening), 2026-04-10 (v0.1.25.9 release), 2026-04-10 (CORS hardening + prod config), 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
+**Spec:** [`cycles-governance-admin-v0.1.25.yaml`](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml) (OpenAPI 3.1.0, info.version `0.1.25.22`; free-text `search` query param on six admin list endpoints — case-insensitive substring, ≤128 chars, AND-combined with other filters) in [cycles-protocol](https://github.com/runcycles/cycles-protocol)
 **Server:** Spring Boot 3.5.11 / Java 21 / Redis
+
+### 2026-04-17 — v0.1.25.25 free-text `search` on six admin list endpoints (spec v0.1.25.21 first bullet)
+
+Closes the first bullet of governance spec v0.1.25.21: every admin list endpoint now accepts an optional `search` query param — case-insensitive substring match, ≤128 characters, AND-combined with every other filter. The remaining bullet of v0.1.25.21 (bulk-action endpoints) is deferred to v0.1.25.26 per the `review-admin-0-1-25-spec-indexed-dewdrop.md` two-release sequencing.
+
+**Spec-first lineage.** Spec content was finalized at v0.1.25.21 (2026-04-17 cycles-protocol); v0.1.25.22 is editorial-only cleanup of impl-version markers. Target `info.version` for this release is `0.1.25.22` — the current authoritative spec version — though the normative `search` content lives in the v0.1.25.21 CHANGELOG entry.
+
+**Endpoints + per-endpoint match fields.** All six list endpoints route `search` through the shared `SearchSpec.resolve(String)` validator then thread it into the repository as a typed-optional argument. Match fields are **OR**-combined within an endpoint, and the whole `search` predicate is **AND**-combined with every other filter on that endpoint.
+
+| Endpoint | Match fields (OR) |
+|---|---|
+| `listTenants` | `tenant_id`, `name` |
+| `listBudgets` | `tenant_id`, `scope` |
+| `listApiKeys` | `key_id`, `name` |
+| `listAuditLogs` | `resource_id`, `log_id` |
+| `listWebhookSubscriptions` | `subscription_id`, `url` |
+| `listEvents` | `correlation_id`, `scope` |
+
+**Shared validator.** New under `cycles-admin-service-model/.../model/shared/`:
+
+- `SearchSpec` — holds `MAX_LENGTH = 128` and two static helpers: `resolve(String raw)` applies the validator in a **fixed order of `trim → empty-check → length-check`** so trailing/leading whitespace cannot bypass the 128-char cap, and `matches(String haystack, String needle)` runs the case-insensitive substring match used by every repository. Null raw input returns null (absent); empty-post-trim returns null (treated as absent); over-cap post-trim throws `IllegalArgumentException("search exceeds maxLength 128")` which the controller maps to 400 `INVALID_REQUEST`.
+
+Every controller calls `SearchSpec.resolve(request.getSearch())` at the edge and passes the normalized value (or null) to the repository. The validator contract is locked down by `SearchSpecTest` (watch-item #3) so a reordering regression — length-check before trim — is caught before merge.
+
+**Three repository paths.** The implementation mirrors the v0.1.25.24 sort shape, piggy-backing on the infrastructure that release introduced:
+
+1. **Time-indexed (Events, Audit).** `search` folds into the existing `SORTED_HYDRATE_CAP = 2000` hydrate path introduced in v0.1.25.20 for non-primary sort. In the common default-sort (timestamp DESC) path, the repository iterates the `zrevrangeByScore` stream, applies `matchesSearch(entry, search)` per hydrated entry, and stops at the limit — filter happens **before** cursor-position is committed so cursor chains stay stable across pages with the same `search`.
+2. **Set-backed single-tenant (Tenants, ApiKeys single-tenant, Webhooks single-tenant).** `search` bolts onto the existing in-memory filter composition. Filter runs on the hydrated candidate set, then the legacy `SortSpec`-or-default sort and cursor walk proceed.
+3. **Cross-tenant (ApiKeys cross-tenant, Budgets cross-tenant).** `search` applies inside the `SORTED_HYDRATE_CAP`-capped cross-tenant hydration path added in v0.1.25.24. When the cap is hit, the warning log already in place still fires; `search` does not change hydration ordering.
+
+`BudgetRepository.list(...)` uses a typed `BudgetListFilters` record for its filter grouping — `search` is added as a new field on that record, so the repository signature stayed 5-arg and no existing mock in `BudgetRepositoryTest` / `BudgetControllerTest` needed arg-count edits.
+
+**Cursor stability under `search`.** Watch-item #1 of the review plan: the repository applies the `search` predicate **before** cursor evaluation on every path. A second page with the same `search` value returns the strict suffix of the first; a second page with a different `search` value is a new logical query and chains correctly off the same cursor (the cursor encodes a position in the underlying time-indexed or set-backed source, not in the `search`-filtered view). Tested explicitly in `EventRepositoryTest.list_searchCursorStable_secondPageSkipsFirstPageIds` and `AuditRepositoryTest.list_searchCursorStable_secondPageSkipsFirstPageIds` — both walk a 3-row fixture across two pages and assert `page2` contains no `page1` IDs.
+
+**Backward compatibility.** Every repository keeps its pre-search `list(...)` signature as a thin shim that delegates to the new search-accepting overload with `null` search. Response shape and cursor semantics are unchanged for every endpoint when `search` is absent. Callers omitting `search` see byte-identical wire output to v0.1.25.24.
+
+**Tests.** Coverage added across model, data, and api modules:
+
+- `cycles-admin-service-model/.../SearchSpecTest` (NEW) — 9 test methods covering `resolve` null/empty/whitespace/trim/at-cap/over-cap/validator-ordering and `matches` case-insensitive + null-safety semantics. The validator-ordering test `resolve_lengthCheckRunsAfterTrim_trailingWhitespaceCannotBypassCap` is watch-item #3's regression lock.
+- `cycles-admin-service-data` — cursor-stability watch-item tests added to `EventRepositoryTest` (+4) and `AuditRepositoryTest` (+4). Per-repository search happy-path (correlation_id / scope for events, resource_id / log_id for audit), case-insensitive confirmation, AND-composition with other filters, and the page1→page2 cursor walk.
+- Per-controller mock signature updates: Mockito strict stubbing flagged every `verify(...).list(...)` call after the repository signatures grew by one arg; all six controller test classes updated with the correct arg-position insertion (position 3 for `TenantController`, end-of-args for the others; `BudgetController` unchanged because it packs filters into a record).
+- Per-controller `searchOver128Chars_returns400` behavioural test (6 total — one per controller): sends `search=<129 chars>` to each list endpoint and asserts HTTP 400 `INVALID_REQUEST` plus `verify(repo/service, never()).list(...)` so a future regression that drops `parseSearch` or mis-threads `searchNorm` through to the repository is caught at the controller layer (not just the validator layer).
+- `SpecCoverageReportTest` + `OpenApiContractDiffTest` — both gain a `KNOWN_MISSING` allowlist for the two bulk-action endpoints (tenants/webhooks) that spec v0.1.25.22 declares but won't ship server-side until v0.1.25.26. Entries include a pointer to the release plan so reviewers know why they're present and when to remove them.
+
+**JaCoCo ≥95% LINE coverage gate.** Both `data` and `api` modules inherit the parent pom BUNDLE rule `<minimum>0.95</minimum>`; the `model` module skips the check because it's DTO-only. The gate is green for this release.
+
+**Dashboard alignment.** No dashboard wire-up is part of this release. The dashboard's client-side filter today continues to work; a follow-up track against `cycles-dashboard` will wire the six list views onto `?search=…` the same way the v0.1.25.24 sort alignment was handled.
 
 ### 2026-04-16 — v0.1.25.24 server-side sort (six admin list endpoints)
 

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/ApiKeyController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/ApiKeyController.java
@@ -5,6 +5,7 @@ import io.runcycles.admin.data.repository.ApiKeyRepository;
 import io.runcycles.admin.model.audit.AuditLogEntry;
 import io.runcycles.admin.model.auth.*;
 import io.runcycles.admin.model.shared.ErrorCode;
+import io.runcycles.admin.model.shared.SearchSpec;
 import io.runcycles.admin.model.shared.SortDirection;
 import io.runcycles.admin.model.shared.SortSpec;
 import io.runcycles.admin.api.service.EventService;
@@ -66,12 +67,14 @@ public class ApiKeyController {
     public ResponseEntity<ApiKeyListResponse> list(
             @RequestParam(required = false) String tenant_id,
             @RequestParam(required = false) ApiKeyStatus status,
+            @RequestParam(required = false) String search,
             @RequestParam(required = false) String cursor,
             @RequestParam(defaultValue = "50") int limit,
             @RequestParam(required = false) String sort_by,
             @RequestParam(required = false) String sort_dir) {
         int effectiveLimit = Math.max(1, Math.min(limit, 100));
         SortSpec sortSpec = parseSortSpec(sort_by, sort_dir);
+        String searchNorm = parseSearch(search);
         // Per governance spec v0.1.25.18: `tenant_id` is now optional under
         // AdminKeyAuth. When absent, list keys across every tenant; the
         // cursor carries "{tenantId}|{keyId}" so a follow-up page resumes
@@ -80,10 +83,10 @@ public class ApiKeyController {
         boolean crossTenant;
         if (tenant_id != null && !tenant_id.isBlank()) {
             crossTenant = false;
-            keys = repository.list(tenant_id, status, cursor, effectiveLimit, sortSpec);
+            keys = repository.list(tenant_id, status, cursor, effectiveLimit, sortSpec, searchNorm);
         } else {
             crossTenant = true;
-            keys = repository.listAllTenants(status, cursor, effectiveLimit, sortSpec);
+            keys = repository.listAllTenants(status, cursor, effectiveLimit, sortSpec, searchNorm);
         }
         var responses = keys.stream().map(ApiKeyResponse::from).collect(Collectors.toList());
         String nextCursor = null;
@@ -116,6 +119,14 @@ public class ApiKeyController {
         }
         try {
             return SortSpec.resolve(sortBy, direction, ALLOWED_SORT_FIELDS, DEFAULT_SORT_FIELD);
+        } catch (IllegalArgumentException e) {
+            throw new GovernanceException(ErrorCode.INVALID_REQUEST, e.getMessage(), 400);
+        }
+    }
+
+    private String parseSearch(String raw) {
+        try {
+            return SearchSpec.resolve(raw);
         } catch (IllegalArgumentException e) {
             throw new GovernanceException(ErrorCode.INVALID_REQUEST, e.getMessage(), 400);
         }

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/AuditController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/AuditController.java
@@ -3,6 +3,7 @@ import io.runcycles.admin.data.exception.GovernanceException;
 import io.runcycles.admin.data.repository.AuditRepository;
 import io.runcycles.admin.model.audit.AuditLogListResponse;
 import io.runcycles.admin.model.shared.ErrorCode;
+import io.runcycles.admin.model.shared.SearchSpec;
 import io.runcycles.admin.model.shared.SortDirection;
 import io.runcycles.admin.model.shared.SortSpec;
 import io.swagger.v3.oas.annotations.*;
@@ -30,14 +31,16 @@ public class AuditController {
             @RequestParam(required = false) String resource_id,
             @RequestParam(required = false) Instant from,
             @RequestParam(required = false) Instant to,
+            @RequestParam(required = false) String search,
             @RequestParam(required = false) String cursor,
             @RequestParam(defaultValue = "50") int limit,
             @RequestParam(required = false) String sort_by,
             @RequestParam(required = false) String sort_dir) {
         int effectiveLimit = Math.max(1, Math.min(limit, 100));
         SortSpec sortSpec = parseSortSpec(sort_by, sort_dir);
+        String searchNorm = parseSearch(search);
         var logs = repository.list(tenant_id, key_id, operation, status, resource_type, resource_id,
-            from, to, cursor, effectiveLimit, sortSpec);
+            from, to, cursor, effectiveLimit, sortSpec, searchNorm);
         AuditLogListResponse response = AuditLogListResponse.builder()
             .logs(logs)
             .hasMore(logs.size() >= effectiveLimit)
@@ -59,6 +62,14 @@ public class AuditController {
         }
         try {
             return SortSpec.resolve(sortBy, direction, ALLOWED_SORT_FIELDS, DEFAULT_SORT_FIELD);
+        } catch (IllegalArgumentException e) {
+            throw new GovernanceException(ErrorCode.INVALID_REQUEST, e.getMessage(), 400);
+        }
+    }
+
+    private String parseSearch(String raw) {
+        try {
+            return SearchSpec.resolve(raw);
         } catch (IllegalArgumentException e) {
             throw new GovernanceException(ErrorCode.INVALID_REQUEST, e.getMessage(), 400);
         }

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/BudgetController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/BudgetController.java
@@ -6,6 +6,7 @@ import io.runcycles.admin.data.repository.BudgetRepository;
 import io.runcycles.admin.model.audit.AuditLogEntry;
 import io.runcycles.admin.model.budget.*;
 import io.runcycles.admin.model.shared.ErrorCode;
+import io.runcycles.admin.model.shared.SearchSpec;
 import io.runcycles.admin.model.shared.SortDirection;
 import io.runcycles.admin.model.shared.SortSpec;
 import io.runcycles.admin.model.shared.UnitEnum;
@@ -115,6 +116,7 @@ public class BudgetController {
             @RequestParam(required = false) Boolean has_debt,
             @RequestParam(required = false) Double utilization_min,
             @RequestParam(required = false) Double utilization_max,
+            @RequestParam(required = false) String search,
             @RequestParam(required = false) String cursor,
             @RequestParam(defaultValue = "50") int limit,
             @RequestParam(required = false) String sort_by,
@@ -153,8 +155,9 @@ public class BudgetController {
         //   - AdminKeyAuth + tenant_id provided: per-tenant listing.
         //   - AdminKeyAuth + tenant_id absent: cross-tenant listing.
         int effectiveLimit = Math.max(1, Math.min(limit, 100));
+        String searchNorm = parseSearch(search);
         BudgetListFilters filters = new BudgetListFilters(
-            scope_prefix, unit, status, over_limit, has_debt, utilization_min, utilization_max);
+            scope_prefix, unit, status, over_limit, has_debt, utilization_min, utilization_max, searchNorm);
         List<BudgetLedger> ledgers;
         boolean crossTenant;
         if (authTenantId != null) {
@@ -198,6 +201,14 @@ public class BudgetController {
         }
         try {
             return SortSpec.resolve(sortBy, direction, ALLOWED_SORT_FIELDS, DEFAULT_SORT_FIELD);
+        } catch (IllegalArgumentException e) {
+            throw new GovernanceException(ErrorCode.INVALID_REQUEST, e.getMessage(), 400);
+        }
+    }
+
+    private String parseSearch(String raw) {
+        try {
+            return SearchSpec.resolve(raw);
         } catch (IllegalArgumentException e) {
             throw new GovernanceException(ErrorCode.INVALID_REQUEST, e.getMessage(), 400);
         }

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/EventAdminController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/EventAdminController.java
@@ -5,6 +5,7 @@ import io.runcycles.admin.data.exception.GovernanceException;
 import io.runcycles.admin.model.event.Event;
 import io.runcycles.admin.model.event.EventListResponse;
 import io.runcycles.admin.model.shared.ErrorCode;
+import io.runcycles.admin.model.shared.SearchSpec;
 import io.runcycles.admin.model.shared.SortDirection;
 import io.runcycles.admin.model.shared.SortSpec;
 import io.swagger.v3.oas.annotations.Operation;
@@ -33,14 +34,16 @@ public class EventAdminController {
             @RequestParam(required = false) String correlation_id,
             @RequestParam(required = false) Instant from,
             @RequestParam(required = false) Instant to,
+            @RequestParam(required = false) String search,
             @RequestParam(required = false) String cursor,
             @RequestParam(defaultValue = "50") int limit,
             @RequestParam(required = false) String sort_by,
             @RequestParam(required = false) String sort_dir) {
         limit = Math.max(1, Math.min(limit, 100));
         SortSpec sortSpec = parseSortSpec(sort_by, sort_dir);
+        String searchNorm = parseSearch(search);
         return ResponseEntity.ok(eventService.list(tenant_id, event_type, category, scope,
-            correlation_id, from, to, cursor, limit, sortSpec));
+            correlation_id, from, to, cursor, limit, sortSpec, searchNorm));
     }
 
     /**
@@ -56,6 +59,14 @@ public class EventAdminController {
         }
         try {
             return SortSpec.resolve(sortBy, direction, ALLOWED_SORT_FIELDS, DEFAULT_SORT_FIELD);
+        } catch (IllegalArgumentException e) {
+            throw new GovernanceException(ErrorCode.INVALID_REQUEST, e.getMessage(), 400);
+        }
+    }
+
+    private String parseSearch(String raw) {
+        try {
+            return SearchSpec.resolve(raw);
         } catch (IllegalArgumentException e) {
             throw new GovernanceException(ErrorCode.INVALID_REQUEST, e.getMessage(), 400);
         }

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/TenantController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/TenantController.java
@@ -4,6 +4,7 @@ import io.runcycles.admin.data.repository.AuditRepository;
 import io.runcycles.admin.data.repository.TenantRepository;
 import io.runcycles.admin.model.audit.AuditLogEntry;
 import io.runcycles.admin.model.shared.ErrorCode;
+import io.runcycles.admin.model.shared.SearchSpec;
 import io.runcycles.admin.model.shared.SortDirection;
 import io.runcycles.admin.model.shared.SortSpec;
 import io.runcycles.admin.model.tenant.Tenant;
@@ -67,13 +68,15 @@ public class TenantController {
             @RequestParam(required = false) String parent_tenant_id,
             // v0.1.25.8: accepted and ignored. v0.1.26+ servers with observe_mode extension will wire this up.
             @SuppressWarnings("unused") @RequestParam(required = false) String observe_mode,
+            @RequestParam(required = false) String search,
             @RequestParam(required = false) String cursor,
             @RequestParam(defaultValue = "50") int limit,
             @RequestParam(required = false) String sort_by,
             @RequestParam(required = false) String sort_dir) {
         int effectiveLimit = Math.max(1, Math.min(limit, 100));
         SortSpec sortSpec = parseSortSpec(sort_by, sort_dir);
-        var tenants = repository.list(status, parent_tenant_id, cursor, effectiveLimit, sortSpec);
+        String searchNorm = parseSearch(search);
+        var tenants = repository.list(status, parent_tenant_id, searchNorm, cursor, effectiveLimit, sortSpec);
         TenantListResponse response = TenantListResponse.builder()
             .tenants(tenants)
             .hasMore(tenants.size() >= effectiveLimit)
@@ -145,6 +148,14 @@ public class TenantController {
         }
         try {
             return SortSpec.resolve(sortBy, direction, ALLOWED_SORT_FIELDS, DEFAULT_SORT_FIELD);
+        } catch (IllegalArgumentException e) {
+            throw new GovernanceException(ErrorCode.INVALID_REQUEST, e.getMessage(), 400);
+        }
+    }
+
+    private String parseSearch(String raw) {
+        try {
+            return SearchSpec.resolve(raw);
         } catch (IllegalArgumentException e) {
             throw new GovernanceException(ErrorCode.INVALID_REQUEST, e.getMessage(), 400);
         }

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/WebhookAdminController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/WebhookAdminController.java
@@ -6,6 +6,7 @@ import io.runcycles.admin.data.exception.GovernanceException;
 import io.runcycles.admin.data.repository.AuditRepository;
 import io.runcycles.admin.model.audit.AuditLogEntry;
 import io.runcycles.admin.model.shared.ErrorCode;
+import io.runcycles.admin.model.shared.SearchSpec;
 import io.runcycles.admin.model.shared.SortDirection;
 import io.runcycles.admin.model.shared.SortSpec;
 import io.runcycles.admin.model.webhook.*;
@@ -49,13 +50,15 @@ public class WebhookAdminController {
             @RequestParam(required = false) String tenant_id,
             @RequestParam(required = false) String status,
             @RequestParam(required = false) String event_type,
+            @RequestParam(required = false) String search,
             @RequestParam(required = false) String cursor,
             @RequestParam(defaultValue = "50") int limit,
             @RequestParam(required = false) String sort_by,
             @RequestParam(required = false) String sort_dir) {
         limit = Math.max(1, Math.min(limit, 100));
         SortSpec sortSpec = parseSortSpec(sort_by, sort_dir);
-        return ResponseEntity.ok(webhookService.listAll(tenant_id, status, event_type, cursor, limit, sortSpec));
+        String searchNorm = parseSearch(search);
+        return ResponseEntity.ok(webhookService.listAll(tenant_id, status, event_type, cursor, limit, sortSpec, searchNorm));
     }
 
     /**
@@ -71,6 +74,14 @@ public class WebhookAdminController {
         }
         try {
             return SortSpec.resolve(sortBy, direction, ALLOWED_SORT_FIELDS, DEFAULT_SORT_FIELD);
+        } catch (IllegalArgumentException e) {
+            throw new GovernanceException(ErrorCode.INVALID_REQUEST, e.getMessage(), 400);
+        }
+    }
+
+    private String parseSearch(String raw) {
+        try {
+            return SearchSpec.resolve(raw);
         } catch (IllegalArgumentException e) {
             throw new GovernanceException(ErrorCode.INVALID_REQUEST, e.getMessage(), 400);
         }

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/EventService.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/EventService.java
@@ -131,15 +131,21 @@ public class EventService {
     public EventListResponse list(String tenantId, String eventType, String category,
                                    String scope, String correlationId, Instant from, Instant to,
                                    String cursor, int limit) {
-        return list(tenantId, eventType, category, scope, correlationId, from, to, cursor, limit, null);
+        return list(tenantId, eventType, category, scope, correlationId, from, to, cursor, limit, null, null);
     }
 
     public EventListResponse list(String tenantId, String eventType, String category,
                                    String scope, String correlationId, Instant from, Instant to,
                                    String cursor, int limit, SortSpec sortSpec) {
+        return list(tenantId, eventType, category, scope, correlationId, from, to, cursor, limit, sortSpec, null);
+    }
+
+    public EventListResponse list(String tenantId, String eventType, String category,
+                                   String scope, String correlationId, Instant from, Instant to,
+                                   String cursor, int limit, SortSpec sortSpec, String search) {
         int effectiveLimit = Math.max(1, Math.min(limit, 100));
         List<Event> events = eventRepository.list(tenantId, eventType, category, scope,
-            correlationId, from, to, cursor, effectiveLimit, sortSpec);
+            correlationId, from, to, cursor, effectiveLimit, sortSpec, search);
         return EventListResponse.builder()
             .events(events)
             .hasMore(events.size() >= effectiveLimit)

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookService.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookService.java
@@ -197,13 +197,18 @@ public class WebhookService {
 
     public WebhookListResponse listByTenant(String tenantId, String status, String eventType,
                                              String cursor, int limit) {
-        return listByTenant(tenantId, status, eventType, cursor, limit, null);
+        return listByTenant(tenantId, status, eventType, cursor, limit, null, null);
     }
 
     public WebhookListResponse listByTenant(String tenantId, String status, String eventType,
                                              String cursor, int limit, SortSpec sortSpec) {
+        return listByTenant(tenantId, status, eventType, cursor, limit, sortSpec, null);
+    }
+
+    public WebhookListResponse listByTenant(String tenantId, String status, String eventType,
+                                             String cursor, int limit, SortSpec sortSpec, String search) {
         int effectiveLimit = Math.max(1, Math.min(limit, 100));
-        List<WebhookSubscription> subs = webhookRepository.listByTenant(tenantId, status, eventType, cursor, effectiveLimit, sortSpec);
+        List<WebhookSubscription> subs = webhookRepository.listByTenant(tenantId, status, eventType, cursor, effectiveLimit, sortSpec, search);
         subs.forEach(s -> { s.setSigningSecret(null); }); // Mask secrets
         return WebhookListResponse.builder()
             .subscriptions(subs)
@@ -214,16 +219,21 @@ public class WebhookService {
 
     public WebhookListResponse listAll(String tenantId, String status, String eventType,
                                         String cursor, int limit) {
-        return listAll(tenantId, status, eventType, cursor, limit, null);
+        return listAll(tenantId, status, eventType, cursor, limit, null, null);
     }
 
     public WebhookListResponse listAll(String tenantId, String status, String eventType,
                                         String cursor, int limit, SortSpec sortSpec) {
+        return listAll(tenantId, status, eventType, cursor, limit, sortSpec, null);
+    }
+
+    public WebhookListResponse listAll(String tenantId, String status, String eventType,
+                                        String cursor, int limit, SortSpec sortSpec, String search) {
         if (tenantId != null) {
-            return listByTenant(tenantId, status, eventType, cursor, limit, sortSpec);
+            return listByTenant(tenantId, status, eventType, cursor, limit, sortSpec, search);
         }
         int effectiveLimit = Math.max(1, Math.min(limit, 100));
-        List<WebhookSubscription> subs = webhookRepository.listAll(status, eventType, cursor, effectiveLimit, sortSpec);
+        List<WebhookSubscription> subs = webhookRepository.listAll(status, eventType, cursor, effectiveLimit, sortSpec, search);
         subs.forEach(s -> { s.setSigningSecret(null); });
         return WebhookListResponse.builder()
             .subscriptions(subs)

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/contract/OpenApiContractDiffTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/contract/OpenApiContractDiffTest.java
@@ -16,6 +16,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import redis.clients.jedis.JedisPool;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -60,6 +61,19 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 })
 class OpenApiContractDiffTest {
 
+    /*
+     * KNOWN-MISSING allowlist: spec operations declared by v0.1.25.22 but
+     * not yet implemented on the server. Remove entries as the
+     * corresponding release lands. See SpecCoverageReportTest for the
+     * mirrored list.
+     *
+     * bulk-action endpoints → planned for server release 0.1.25.26.
+     */
+    private static final Set<String> KNOWN_MISSING = Set.of(
+            "POST /v1/admin/tenants/bulk-action",
+            "POST /v1/admin/webhooks/bulk-action"
+    );
+
     @Autowired private MockMvc mockMvc;
     @MockitoBean private JedisPool jedisPool;
 
@@ -74,7 +88,9 @@ class OpenApiContractDiffTest {
         String specYaml = ContractSpecLoader.loadSpec();
         ChangedOpenApi diff = OpenApiCompare.fromContents(specYaml, serverJson);
 
-        List<Endpoint> missing = diff.getMissingEndpoints();
+        List<Endpoint> missing = diff.getMissingEndpoints().stream()
+                .filter(e -> !KNOWN_MISSING.contains(e.getMethod() + " " + e.getPathUrl()))
+                .collect(Collectors.toList());
         List<Endpoint> extra = diff.getNewEndpoints();
         // Only fail on INCOMPATIBLE (spec-breaking) operation-level changes. SpringDoc's
         // auto-generated OpenAPI doesn't exactly match the hand-written spec at deep

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/ApiKeyControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/ApiKeyControllerTest.java
@@ -71,7 +71,7 @@ class ApiKeyControllerTest {
                 .keyId("key_1").tenantId("tenant-1").keyPrefix("gov_pre")
                 .status(ApiKeyStatus.ACTIVE).createdAt(Instant.now())
                 .expiresAt(Instant.now().plusSeconds(86400)).build();
-        when(apiKeyRepository.list(eq("tenant-1"), any(), any(), anyInt(), any())).thenReturn(List.of(key));
+        when(apiKeyRepository.list(eq("tenant-1"), any(), any(), anyInt(), any(), any())).thenReturn(List.of(key));
 
         mockMvc.perform(get("/v1/admin/api-keys")
                         .header("X-Admin-API-Key", ADMIN_KEY)
@@ -153,7 +153,7 @@ class ApiKeyControllerTest {
 
     @Test
     void listApiKeys_emptyResult_hasMoreFalseAndNoCursor() throws Exception {
-        when(apiKeyRepository.list(eq("tenant-1"), any(), any(), anyInt(), any())).thenReturn(List.of());
+        when(apiKeyRepository.list(eq("tenant-1"), any(), any(), anyInt(), any(), any())).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/api-keys")
                         .header("X-Admin-API-Key", ADMIN_KEY)
@@ -166,7 +166,7 @@ class ApiKeyControllerTest {
 
     @Test
     void listApiKeys_limitClampedToMax100() throws Exception {
-        when(apiKeyRepository.list(eq("tenant-1"), any(), any(), eq(100), any())).thenReturn(List.of());
+        when(apiKeyRepository.list(eq("tenant-1"), any(), any(), eq(100), any(), any())).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/api-keys")
                         .header("X-Admin-API-Key", ADMIN_KEY)
@@ -174,12 +174,12 @@ class ApiKeyControllerTest {
                         .param("limit", "500"))
                 .andExpect(status().isOk());
 
-        verify(apiKeyRepository).list(eq("tenant-1"), any(), any(), eq(100), any());
+        verify(apiKeyRepository).list(eq("tenant-1"), any(), any(), eq(100), any(), any());
     }
 
     @Test
     void listApiKeys_limitClampedToMin1() throws Exception {
-        when(apiKeyRepository.list(eq("tenant-1"), any(), any(), eq(1), any())).thenReturn(List.of());
+        when(apiKeyRepository.list(eq("tenant-1"), any(), any(), eq(1), any(), any())).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/api-keys")
                         .header("X-Admin-API-Key", ADMIN_KEY)
@@ -187,7 +187,7 @@ class ApiKeyControllerTest {
                         .param("limit", "0"))
                 .andExpect(status().isOk());
 
-        verify(apiKeyRepository).list(eq("tenant-1"), any(), any(), eq(1), any());
+        verify(apiKeyRepository).list(eq("tenant-1"), any(), any(), eq(1), any(), any());
     }
 
     @Test
@@ -255,7 +255,7 @@ class ApiKeyControllerTest {
 
     @Test
     void listApiKeys_withStatusFilter_passesToRepository() throws Exception {
-        when(apiKeyRepository.list(eq("tenant-1"), eq(ApiKeyStatus.REVOKED), any(), anyInt(), any())).thenReturn(List.of());
+        when(apiKeyRepository.list(eq("tenant-1"), eq(ApiKeyStatus.REVOKED), any(), anyInt(), any(), any())).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/api-keys")
                         .header("X-Admin-API-Key", ADMIN_KEY)
@@ -263,12 +263,12 @@ class ApiKeyControllerTest {
                         .param("status", "REVOKED"))
                 .andExpect(status().isOk());
 
-        verify(apiKeyRepository).list(eq("tenant-1"), eq(ApiKeyStatus.REVOKED), any(), anyInt(), any());
+        verify(apiKeyRepository).list(eq("tenant-1"), eq(ApiKeyStatus.REVOKED), any(), anyInt(), any(), any());
     }
 
     @Test
     void listApiKeys_withCursorParam_passesToRepository() throws Exception {
-        when(apiKeyRepository.list(eq("tenant-1"), any(), eq("key_abc"), anyInt(), any())).thenReturn(List.of());
+        when(apiKeyRepository.list(eq("tenant-1"), any(), eq("key_abc"), anyInt(), any(), any())).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/api-keys")
                         .header("X-Admin-API-Key", ADMIN_KEY)
@@ -276,7 +276,7 @@ class ApiKeyControllerTest {
                         .param("cursor", "key_abc"))
                 .andExpect(status().isOk());
 
-        verify(apiKeyRepository).list(eq("tenant-1"), any(), eq("key_abc"), anyInt(), any());
+        verify(apiKeyRepository).list(eq("tenant-1"), any(), eq("key_abc"), anyInt(), any(), any());
     }
 
     @Test
@@ -289,7 +289,7 @@ class ApiKeyControllerTest {
                 .keyId("key_2").tenantId("tenant-1").keyPrefix("gov_pre2")
                 .status(ApiKeyStatus.ACTIVE).createdAt(Instant.now())
                 .expiresAt(Instant.now().plusSeconds(86400)).build();
-        when(apiKeyRepository.list(eq("tenant-1"), any(), any(), eq(2), any())).thenReturn(List.of(k1, k2));
+        when(apiKeyRepository.list(eq("tenant-1"), any(), any(), eq(2), any(), any())).thenReturn(List.of(k1, k2));
 
         mockMvc.perform(get("/v1/admin/api-keys")
                         .header("X-Admin-API-Key", ADMIN_KEY)
@@ -449,7 +449,7 @@ class ApiKeyControllerTest {
                 .keyId("key_b").tenantId("tenant-b").keyPrefix("cyc_live_bb")
                 .status(ApiKeyStatus.ACTIVE).createdAt(Instant.now())
                 .expiresAt(Instant.now().plusSeconds(86400)).build();
-        when(apiKeyRepository.listAllTenants(any(), any(), anyInt(), any()))
+        when(apiKeyRepository.listAllTenants(any(), any(), anyInt(), any(), any()))
                 .thenReturn(List.of(keyA, keyB));
 
         mockMvc.perform(get("/v1/admin/api-keys")
@@ -459,7 +459,7 @@ class ApiKeyControllerTest {
                 .andExpect(jsonPath("$.keys[0].key_id").value("key_a"))
                 .andExpect(jsonPath("$.keys[1].key_id").value("key_b"));
 
-        verify(apiKeyRepository).listAllTenants(isNull(), isNull(), eq(50), any());
+        verify(apiKeyRepository).listAllTenants(isNull(), isNull(), eq(50), any(), any());
         verify(apiKeyRepository, never()).list(anyString(), any(), any(), anyInt());
     }
 
@@ -474,7 +474,7 @@ class ApiKeyControllerTest {
                     .status(ApiKeyStatus.ACTIVE).createdAt(Instant.now())
                     .expiresAt(Instant.now().plusSeconds(86400)).build());
         }
-        when(apiKeyRepository.listAllTenants(any(), any(), anyInt(), any())).thenReturn(fullPage);
+        when(apiKeyRepository.listAllTenants(any(), any(), anyInt(), any(), any())).thenReturn(fullPage);
 
         mockMvc.perform(get("/v1/admin/api-keys")
                         .header("X-Admin-API-Key", ADMIN_KEY))
@@ -492,7 +492,7 @@ class ApiKeyControllerTest {
                     .status(ApiKeyStatus.ACTIVE).createdAt(Instant.now())
                     .expiresAt(Instant.now().plusSeconds(86400)).build());
         }
-        when(apiKeyRepository.list(eq("tenant-1"), any(), any(), anyInt(), any())).thenReturn(fullPage);
+        when(apiKeyRepository.list(eq("tenant-1"), any(), any(), anyInt(), any(), any())).thenReturn(fullPage);
 
         mockMvc.perform(get("/v1/admin/api-keys")
                         .header("X-Admin-API-Key", ADMIN_KEY)
@@ -506,7 +506,7 @@ class ApiKeyControllerTest {
 
     @Test
     void listApiKeys_crossTenant_passesStatusAndCursor() throws Exception {
-        when(apiKeyRepository.listAllTenants(eq(ApiKeyStatus.REVOKED), eq("tenant-9|key_abc"), eq(25), any()))
+        when(apiKeyRepository.listAllTenants(eq(ApiKeyStatus.REVOKED), eq("tenant-9|key_abc"), eq(25), any(), any()))
                 .thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/api-keys")
@@ -516,14 +516,14 @@ class ApiKeyControllerTest {
                         .param("limit", "25"))
                 .andExpect(status().isOk());
 
-        verify(apiKeyRepository).listAllTenants(eq(ApiKeyStatus.REVOKED), eq("tenant-9|key_abc"), eq(25), any());
+        verify(apiKeyRepository).listAllTenants(eq(ApiKeyStatus.REVOKED), eq("tenant-9|key_abc"), eq(25), any(), any());
     }
 
     // --- v0.1.25.24 sort support ---
 
     @org.junit.jupiter.api.Test
     void listApiKeys_withValidSortByAndSortDir_delegatesToRepository() throws Exception {
-        when(apiKeyRepository.listAllTenants(any(), any(), anyInt(), any())).thenReturn(List.of());
+        when(apiKeyRepository.listAllTenants(any(), any(), anyInt(), any(), any())).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/api-keys")
                         .header("X-Admin-API-Key", ADMIN_KEY)
@@ -533,7 +533,7 @@ class ApiKeyControllerTest {
 
         org.mockito.ArgumentCaptor<io.runcycles.admin.model.shared.SortSpec> captor =
                 org.mockito.ArgumentCaptor.forClass(io.runcycles.admin.model.shared.SortSpec.class);
-        verify(apiKeyRepository).listAllTenants(any(), any(), anyInt(), captor.capture());
+        verify(apiKeyRepository).listAllTenants(any(), any(), anyInt(), captor.capture(), any());
         org.junit.jupiter.api.Assertions.assertEquals("name", captor.getValue().field());
         org.junit.jupiter.api.Assertions.assertEquals(
                 io.runcycles.admin.model.shared.SortDirection.ASC, captor.getValue().direction());
@@ -541,7 +541,7 @@ class ApiKeyControllerTest {
 
     @org.junit.jupiter.api.Test
     void listApiKeys_defaultsToCreatedAtDescending() throws Exception {
-        when(apiKeyRepository.listAllTenants(any(), any(), anyInt(), any())).thenReturn(List.of());
+        when(apiKeyRepository.listAllTenants(any(), any(), anyInt(), any(), any())).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/api-keys")
                         .header("X-Admin-API-Key", ADMIN_KEY))
@@ -549,7 +549,7 @@ class ApiKeyControllerTest {
 
         org.mockito.ArgumentCaptor<io.runcycles.admin.model.shared.SortSpec> captor =
                 org.mockito.ArgumentCaptor.forClass(io.runcycles.admin.model.shared.SortSpec.class);
-        verify(apiKeyRepository).listAllTenants(any(), any(), anyInt(), captor.capture());
+        verify(apiKeyRepository).listAllTenants(any(), any(), anyInt(), captor.capture(), any());
         org.junit.jupiter.api.Assertions.assertEquals("created_at", captor.getValue().field());
         org.junit.jupiter.api.Assertions.assertEquals(
                 io.runcycles.admin.model.shared.SortDirection.DESC, captor.getValue().direction());
@@ -573,7 +573,7 @@ class ApiKeyControllerTest {
 
     @org.junit.jupiter.api.Test
     void listApiKeys_acceptsAllWhitelistedSortFields() throws Exception {
-        when(apiKeyRepository.listAllTenants(any(), any(), anyInt(), any())).thenReturn(List.of());
+        when(apiKeyRepository.listAllTenants(any(), any(), anyInt(), any(), any())).thenReturn(List.of());
 
         for (String field : List.of("key_id", "name", "tenant_id", "status", "created_at", "expires_at")) {
             mockMvc.perform(get("/v1/admin/api-keys")
@@ -581,5 +581,18 @@ class ApiKeyControllerTest {
                             .param("sort_by", field))
                     .andExpect(status().isOk());
         }
+    }
+
+    @Test
+    void listApiKeys_searchOver128Chars_returns400() throws Exception {
+        String over = "x".repeat(129);
+        mockMvc.perform(get("/v1/admin/api-keys")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .param("search", over))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("INVALID_REQUEST"));
+
+        verify(apiKeyRepository, never()).list(any(), any(), any(), anyInt(), any(), any());
+        verify(apiKeyRepository, never()).listAllTenants(any(), any(), anyInt(), any(), any());
     }
 }

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/AuditControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/AuditControllerTest.java
@@ -40,7 +40,7 @@ class AuditControllerTest {
         AuditLogEntry entry = AuditLogEntry.builder()
                 .logId("log_1").tenantId("tenant-1").operation("createTenant")
                 .status(201).timestamp(Instant.now()).build();
-        when(auditRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
+        when(auditRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any(), any()))
                 .thenReturn(List.of(entry));
 
         mockMvc.perform(get("/v1/admin/audit/logs")
@@ -52,7 +52,7 @@ class AuditControllerTest {
 
     @Test
     void listAuditLogs_withFilters() throws Exception {
-        when(auditRepository.list(eq("tenant-1"), eq("key_1"), eq("createTenant"), eq(201), any(), any(), any(), any(), any(), anyInt(), any()))
+        when(auditRepository.list(eq("tenant-1"), eq("key_1"), eq("createTenant"), eq(201), any(), any(), any(), any(), any(), anyInt(), any(), any()))
                 .thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/audit/logs")
@@ -73,7 +73,7 @@ class AuditControllerTest {
 
     @Test
     void listAuditLogs_emptyResult_returnsEmptyList() throws Exception {
-        when(auditRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
+        when(auditRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any(), any()))
                 .thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/audit/logs")
@@ -85,7 +85,7 @@ class AuditControllerTest {
 
     @Test
     void listAuditLogs_limitClampedToMax100() throws Exception {
-        when(auditRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), any(), eq(100), any()))
+        when(auditRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), any(), eq(100), any(), any()))
                 .thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/audit/logs")
@@ -93,12 +93,12 @@ class AuditControllerTest {
                         .param("limit", "500"))
                 .andExpect(status().isOk());
 
-        verify(auditRepository).list(any(), any(), any(), any(), any(), any(), any(), any(), any(), eq(100), any());
+        verify(auditRepository).list(any(), any(), any(), any(), any(), any(), any(), any(), any(), eq(100), any(), any());
     }
 
     @Test
     void listAuditLogs_limitClampedToMin1() throws Exception {
-        when(auditRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), any(), eq(1), any()))
+        when(auditRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), any(), eq(1), any(), any()))
                 .thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/audit/logs")
@@ -106,12 +106,12 @@ class AuditControllerTest {
                         .param("limit", "0"))
                 .andExpect(status().isOk());
 
-        verify(auditRepository).list(any(), any(), any(), any(), any(), any(), any(), any(), any(), eq(1), any());
+        verify(auditRepository).list(any(), any(), any(), any(), any(), any(), any(), any(), any(), eq(1), any(), any());
     }
 
     @Test
     void listAuditLogs_emptyResult_nextCursorIsNull() throws Exception {
-        when(auditRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
+        when(auditRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any(), any()))
                 .thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/audit/logs")
@@ -128,7 +128,7 @@ class AuditControllerTest {
         AuditLogEntry e2 = AuditLogEntry.builder()
                 .logId("log_2").tenantId("tenant-1").operation("updateTenant")
                 .status(200).timestamp(Instant.now()).build();
-        when(auditRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), any(), eq(2), any()))
+        when(auditRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), any(), eq(2), any(), any()))
                 .thenReturn(List.of(e1, e2));
 
         mockMvc.perform(get("/v1/admin/audit/logs")
@@ -143,7 +143,7 @@ class AuditControllerTest {
     void listAuditLogs_withFromAndTo_passesInstantParams() throws Exception {
         Instant from = Instant.parse("2025-01-01T00:00:00Z");
         Instant to = Instant.parse("2025-12-31T23:59:59Z");
-        when(auditRepository.list(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), eq(from), eq(to), isNull(), eq(50), any()))
+        when(auditRepository.list(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), eq(from), eq(to), isNull(), eq(50), any(), any()))
                 .thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/audit/logs")
@@ -153,14 +153,14 @@ class AuditControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.logs").isEmpty());
 
-        verify(auditRepository).list(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), eq(from), eq(to), isNull(), eq(50), any());
+        verify(auditRepository).list(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), eq(from), eq(to), isNull(), eq(50), any(), any());
     }
 
     // --- Sort contract tests (spec v0.1.25.20 §V4) ---
 
     @Test
     void listAuditLogs_defaultsToTimestampDesc() throws Exception {
-        when(auditRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
+        when(auditRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any(), any()))
                 .thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/audit/logs")
@@ -168,7 +168,7 @@ class AuditControllerTest {
                 .andExpect(status().isOk());
 
         ArgumentCaptor<SortSpec> captor = ArgumentCaptor.forClass(SortSpec.class);
-        verify(auditRepository).list(any(), any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), captor.capture());
+        verify(auditRepository).list(any(), any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), captor.capture(), any());
         SortSpec sort = captor.getValue();
         org.junit.jupiter.api.Assertions.assertEquals("timestamp", sort.field());
         org.junit.jupiter.api.Assertions.assertEquals(SortDirection.DESC, sort.direction());
@@ -176,7 +176,7 @@ class AuditControllerTest {
 
     @Test
     void listAuditLogs_acceptsValidSortByAndDir() throws Exception {
-        when(auditRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
+        when(auditRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any(), any()))
                 .thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/audit/logs")
@@ -186,7 +186,7 @@ class AuditControllerTest {
                 .andExpect(status().isOk());
 
         ArgumentCaptor<SortSpec> captor = ArgumentCaptor.forClass(SortSpec.class);
-        verify(auditRepository).list(any(), any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), captor.capture());
+        verify(auditRepository).list(any(), any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), captor.capture(), any());
         SortSpec sort = captor.getValue();
         org.junit.jupiter.api.Assertions.assertEquals("operation", sort.field());
         org.junit.jupiter.api.Assertions.assertEquals(SortDirection.ASC, sort.direction());
@@ -194,7 +194,7 @@ class AuditControllerTest {
 
     @Test
     void listAuditLogs_acceptsAllWhitelistedFields() throws Exception {
-        when(auditRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
+        when(auditRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any(), any()))
                 .thenReturn(List.of());
 
         for (String field : List.of("timestamp", "operation", "resource_type", "tenant_id", "key_id", "status")) {
@@ -222,5 +222,18 @@ class AuditControllerTest {
                         .param("sort_dir", "sideways"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error").value("INVALID_REQUEST"));
+    }
+
+    @Test
+    void listAuditLogs_searchOver128Chars_returns400() throws Exception {
+        String over = "x".repeat(129);
+        mockMvc.perform(get("/v1/admin/audit/logs")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .param("search", over))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("INVALID_REQUEST"));
+
+        verify(auditRepository, never()).list(any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), anyInt(), any(), any());
     }
 }

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BudgetControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BudgetControllerTest.java
@@ -1662,4 +1662,17 @@ class BudgetControllerTest {
         org.assertj.core.api.Assertions.assertThat(captured.field()).isEqualTo("tenant_id");
         org.assertj.core.api.Assertions.assertThat(captured.direction()).isEqualTo(SortDirection.ASC);
     }
+
+    @Test
+    void listBudgets_searchOver128Chars_returns400() throws Exception {
+        String over = "x".repeat(129);
+        mockMvc.perform(get("/v1/admin/budgets")
+                        .header("X-Admin-API-Key", "test-admin-key")
+                        .param("search", over))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("INVALID_REQUEST"));
+
+        verify(budgetRepository, never()).list(any(), any(BudgetListFilters.class), any(), anyInt(), any());
+        verify(budgetRepository, never()).listAllTenants(any(BudgetListFilters.class), any(), anyInt(), any());
+    }
 }

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/EventAdminControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/EventAdminControllerTest.java
@@ -42,7 +42,7 @@ class EventAdminControllerTest {
     void listEvents_returns200() throws Exception {
         EventListResponse response = EventListResponse.builder()
             .events(List.of()).hasMore(false).build();
-        when(eventService.list(any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
+        when(eventService.list(any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any(), any()))
             .thenReturn(response);
 
         mockMvc.perform(get("/v1/admin/events")
@@ -57,7 +57,7 @@ class EventAdminControllerTest {
         EventListResponse response = EventListResponse.builder()
             .events(List.of()).hasMore(false).build();
         when(eventService.list(eq("tenant-1"), eq("budget.created"), eq("budget"), eq("org/team1"),
-                eq("corr_1"), any(), any(), any(), anyInt(), any()))
+                eq("corr_1"), any(), any(), any(), anyInt(), any(), any()))
             .thenReturn(response);
 
         mockMvc.perform(get("/v1/admin/events")
@@ -95,7 +95,7 @@ class EventAdminControllerTest {
     void listEvents_clampsLimitTo100() throws Exception {
         EventListResponse response = EventListResponse.builder()
             .events(List.of()).hasMore(false).build();
-        when(eventService.list(any(), any(), any(), any(), any(), any(), any(), any(), eq(100), any()))
+        when(eventService.list(any(), any(), any(), any(), any(), any(), any(), any(), eq(100), any(), any()))
             .thenReturn(response);
 
         mockMvc.perform(get("/v1/admin/events")
@@ -103,7 +103,7 @@ class EventAdminControllerTest {
                         .param("limit", "999"))
                 .andExpect(status().isOk());
 
-        verify(eventService).list(any(), any(), any(), any(), any(), any(), any(), any(), eq(100), any());
+        verify(eventService).list(any(), any(), any(), any(), any(), any(), any(), any(), eq(100), any(), any());
     }
 
     @Test
@@ -123,7 +123,7 @@ class EventAdminControllerTest {
     void listEvents_defaultsToTimestampDesc() throws Exception {
         EventListResponse response = EventListResponse.builder()
             .events(List.of()).hasMore(false).build();
-        when(eventService.list(any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
+        when(eventService.list(any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any(), any()))
             .thenReturn(response);
 
         mockMvc.perform(get("/v1/admin/events")
@@ -131,7 +131,7 @@ class EventAdminControllerTest {
                 .andExpect(status().isOk());
 
         ArgumentCaptor<SortSpec> captor = ArgumentCaptor.forClass(SortSpec.class);
-        verify(eventService).list(any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), captor.capture());
+        verify(eventService).list(any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), captor.capture(), any());
         SortSpec sort = captor.getValue();
         org.junit.jupiter.api.Assertions.assertEquals("timestamp", sort.field());
         org.junit.jupiter.api.Assertions.assertEquals(SortDirection.DESC, sort.direction());
@@ -141,7 +141,7 @@ class EventAdminControllerTest {
     void listEvents_acceptsValidSortByAndDir() throws Exception {
         EventListResponse response = EventListResponse.builder()
             .events(List.of()).hasMore(false).build();
-        when(eventService.list(any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
+        when(eventService.list(any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any(), any()))
             .thenReturn(response);
 
         mockMvc.perform(get("/v1/admin/events")
@@ -151,7 +151,7 @@ class EventAdminControllerTest {
                 .andExpect(status().isOk());
 
         ArgumentCaptor<SortSpec> captor = ArgumentCaptor.forClass(SortSpec.class);
-        verify(eventService).list(any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), captor.capture());
+        verify(eventService).list(any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), captor.capture(), any());
         SortSpec sort = captor.getValue();
         org.junit.jupiter.api.Assertions.assertEquals("event_type", sort.field());
         org.junit.jupiter.api.Assertions.assertEquals(SortDirection.ASC, sort.direction());
@@ -161,7 +161,7 @@ class EventAdminControllerTest {
     void listEvents_acceptsAllWhitelistedFields() throws Exception {
         EventListResponse response = EventListResponse.builder()
             .events(List.of()).hasMore(false).build();
-        when(eventService.list(any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
+        when(eventService.list(any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any(), any()))
             .thenReturn(response);
 
         for (String field : List.of("event_type", "category", "scope", "tenant_id", "timestamp")) {
@@ -189,5 +189,18 @@ class EventAdminControllerTest {
                         .param("sort_dir", "sideways"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error").value("INVALID_REQUEST"));
+    }
+
+    @Test
+    void listEvents_searchOver128Chars_returns400() throws Exception {
+        String over = "x".repeat(129);
+        mockMvc.perform(get("/v1/admin/events")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .param("search", over))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("INVALID_REQUEST"));
+
+        verify(eventService, never()).list(any(), any(), any(), any(), any(), any(),
+                any(), any(), anyInt(), any(), any());
     }
 }

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/TenantControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/TenantControllerTest.java
@@ -118,7 +118,7 @@ class TenantControllerTest {
     void listTenants_returns200() throws Exception {
         List<Tenant> tenants = List.of(
                 Tenant.builder().tenantId("tenant-1").name("A").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build());
-        when(tenantRepository.list(any(), any(), any(), anyInt(), any())).thenReturn(tenants);
+        when(tenantRepository.list(any(), any(), any(), any(), anyInt(), any())).thenReturn(tenants);
 
         mockMvc.perform(get("/v1/admin/tenants")
                         .header("X-Admin-API-Key", ADMIN_KEY))
@@ -129,7 +129,7 @@ class TenantControllerTest {
 
     @Test
     void listTenants_withStatusFilter() throws Exception {
-        when(tenantRepository.list(eq(TenantStatus.ACTIVE), any(), any(), anyInt(), any())).thenReturn(List.of());
+        when(tenantRepository.list(eq(TenantStatus.ACTIVE), any(), any(), any(), anyInt(), any())).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/tenants")
                         .header("X-Admin-API-Key", ADMIN_KEY)
@@ -242,7 +242,7 @@ class TenantControllerTest {
 
     @Test
     void listTenants_emptyResult_hasMoreFalseAndNoCursor() throws Exception {
-        when(tenantRepository.list(any(), any(), any(), anyInt(), any())).thenReturn(List.of());
+        when(tenantRepository.list(any(), any(), any(), any(), anyInt(), any())).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/tenants")
                         .header("X-Admin-API-Key", ADMIN_KEY))
@@ -254,14 +254,14 @@ class TenantControllerTest {
 
     @Test
     void listTenants_limitClampedToMax100() throws Exception {
-        when(tenantRepository.list(any(), any(), any(), eq(100), any())).thenReturn(List.of());
+        when(tenantRepository.list(any(), any(), any(), any(), eq(100), any())).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/tenants")
                         .header("X-Admin-API-Key", ADMIN_KEY)
                         .param("limit", "999"))
                 .andExpect(status().isOk());
 
-        verify(tenantRepository).list(any(), any(), any(), eq(100), any());
+        verify(tenantRepository).list(any(), any(), any(), any(), eq(100), any());
     }
 
     @Test
@@ -279,14 +279,14 @@ class TenantControllerTest {
 
     @Test
     void listTenants_limitClampedToMin1() throws Exception {
-        when(tenantRepository.list(any(), any(), any(), eq(1), any())).thenReturn(List.of());
+        when(tenantRepository.list(any(), any(), any(), any(), eq(1), any())).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/tenants")
                         .header("X-Admin-API-Key", ADMIN_KEY)
                         .param("limit", "0"))
                 .andExpect(status().isOk());
 
-        verify(tenantRepository).list(any(), any(), any(), eq(1), any());
+        verify(tenantRepository).list(any(), any(), any(), any(), eq(1), any());
     }
 
     @Test
@@ -386,14 +386,14 @@ class TenantControllerTest {
 
     @Test
     void listTenants_withParentTenantIdFilter() throws Exception {
-        when(tenantRepository.list(any(), eq("parent-1"), any(), anyInt(), any())).thenReturn(List.of());
+        when(tenantRepository.list(any(), eq("parent-1"), any(), any(), anyInt(), any())).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/tenants")
                         .header("X-Admin-API-Key", ADMIN_KEY)
                         .param("parent_tenant_id", "parent-1"))
                 .andExpect(status().isOk());
 
-        verify(tenantRepository).list(any(), eq("parent-1"), any(), anyInt(), any());
+        verify(tenantRepository).list(any(), eq("parent-1"), any(), any(), anyInt(), any());
     }
 
     @Test
@@ -402,7 +402,7 @@ class TenantControllerTest {
         List<Tenant> tenants = List.of(
                 Tenant.builder().tenantId("tenant-1").name("A").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build(),
                 Tenant.builder().tenantId("tenant-2").name("B").status(TenantStatus.ACTIVE).createdAt(Instant.now()).build());
-        when(tenantRepository.list(any(), any(), any(), eq(2), any())).thenReturn(tenants);
+        when(tenantRepository.list(any(), any(), any(), any(), eq(2), any())).thenReturn(tenants);
 
         mockMvc.perform(get("/v1/admin/tenants")
                         .header("X-Admin-API-Key", ADMIN_KEY)
@@ -414,14 +414,14 @@ class TenantControllerTest {
 
     @Test
     void listTenants_withCursorParam_passesToRepository() throws Exception {
-        when(tenantRepository.list(any(), any(), eq("t-cursor"), anyInt(), any())).thenReturn(List.of());
+        when(tenantRepository.list(any(), any(), any(), eq("t-cursor"), anyInt(), any())).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/tenants")
                         .header("X-Admin-API-Key", ADMIN_KEY)
                         .param("cursor", "t-cursor"))
                 .andExpect(status().isOk());
 
-        verify(tenantRepository).list(any(), any(), eq("t-cursor"), anyInt(), any());
+        verify(tenantRepository).list(any(), any(), any(), eq("t-cursor"), anyInt(), any());
     }
 
     @Test
@@ -549,7 +549,7 @@ class TenantControllerTest {
     // v0.1.25.8: observe_mode query param must be accepted and silently ignored
     @Test
     void listTenants_withObserveModeParam_acceptedAndIgnored() throws Exception {
-        when(tenantRepository.list(any(), any(), any(), anyInt(), any())).thenReturn(List.of());
+        when(tenantRepository.list(any(), any(), any(), any(), anyInt(), any())).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/tenants")
                         .header("X-Admin-API-Key", ADMIN_KEY)
@@ -558,14 +558,14 @@ class TenantControllerTest {
                 .andExpect(jsonPath("$.tenants").isArray());
 
         // Repository call unchanged — observe_mode is not passed through on v0.1.25.x
-        verify(tenantRepository).list(any(), any(), any(), anyInt(), any());
+        verify(tenantRepository).list(any(), any(), any(), any(), anyInt(), any());
     }
 
     // ---- v0.1.25.20: sort_by / sort_dir contract ----
 
     @Test
     void listTenants_withValidSortByAndSortDir_delegatesToRepository() throws Exception {
-        when(tenantRepository.list(any(), any(), any(), anyInt(), any())).thenReturn(List.of());
+        when(tenantRepository.list(any(), any(), any(), any(), anyInt(), any())).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/tenants")
                         .header("X-Admin-API-Key", ADMIN_KEY)
@@ -575,14 +575,14 @@ class TenantControllerTest {
 
         org.mockito.ArgumentCaptor<io.runcycles.admin.model.shared.SortSpec> captor =
             org.mockito.ArgumentCaptor.forClass(io.runcycles.admin.model.shared.SortSpec.class);
-        verify(tenantRepository).list(any(), any(), any(), anyInt(), captor.capture());
+        verify(tenantRepository).list(any(), any(), any(), any(), anyInt(), captor.capture());
         assertEquals("name", captor.getValue().field());
         assertEquals(io.runcycles.admin.model.shared.SortDirection.ASC, captor.getValue().direction());
     }
 
     @Test
     void listTenants_defaultsToCreatedAtDescending() throws Exception {
-        when(tenantRepository.list(any(), any(), any(), anyInt(), any())).thenReturn(List.of());
+        when(tenantRepository.list(any(), any(), any(), any(), anyInt(), any())).thenReturn(List.of());
 
         mockMvc.perform(get("/v1/admin/tenants")
                         .header("X-Admin-API-Key", ADMIN_KEY))
@@ -590,7 +590,7 @@ class TenantControllerTest {
 
         org.mockito.ArgumentCaptor<io.runcycles.admin.model.shared.SortSpec> captor =
             org.mockito.ArgumentCaptor.forClass(io.runcycles.admin.model.shared.SortSpec.class);
-        verify(tenantRepository).list(any(), any(), any(), anyInt(), captor.capture());
+        verify(tenantRepository).list(any(), any(), any(), any(), anyInt(), captor.capture());
         assertEquals("created_at", captor.getValue().field());
         assertEquals(io.runcycles.admin.model.shared.SortDirection.DESC, captor.getValue().direction());
     }
@@ -603,7 +603,7 @@ class TenantControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error").value("INVALID_REQUEST"));
 
-        verify(tenantRepository, never()).list(any(), any(), any(), anyInt(), any());
+        verify(tenantRepository, never()).list(any(), any(), any(), any(), anyInt(), any());
     }
 
     @Test
@@ -614,12 +614,12 @@ class TenantControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error").value("INVALID_REQUEST"));
 
-        verify(tenantRepository, never()).list(any(), any(), any(), anyInt(), any());
+        verify(tenantRepository, never()).list(any(), any(), any(), any(), anyInt(), any());
     }
 
     @Test
     void listTenants_acceptsAllWhitelistedSortFields() throws Exception {
-        when(tenantRepository.list(any(), any(), any(), anyInt(), any())).thenReturn(List.of());
+        when(tenantRepository.list(any(), any(), any(), any(), anyInt(), any())).thenReturn(List.of());
 
         for (String field : new String[]{"tenant_id", "name", "status", "created_at"}) {
             mockMvc.perform(get("/v1/admin/tenants")
@@ -627,5 +627,17 @@ class TenantControllerTest {
                             .param("sort_by", field))
                     .andExpect(status().isOk());
         }
+    }
+
+    @Test
+    void listTenants_searchOver128Chars_returns400() throws Exception {
+        String over = "x".repeat(129);
+        mockMvc.perform(get("/v1/admin/tenants")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .param("search", over))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("INVALID_REQUEST"));
+
+        verify(tenantRepository, never()).list(any(), any(), any(), any(), anyInt(), any());
     }
 }

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookAdminControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookAdminControllerTest.java
@@ -78,7 +78,7 @@ class WebhookAdminControllerTest {
     void listWebhooks_returns200() throws Exception {
         WebhookListResponse response = WebhookListResponse.builder()
             .subscriptions(List.of()).hasMore(false).build();
-        when(webhookService.listAll(any(), any(), any(), any(), anyInt(), any())).thenReturn(response);
+        when(webhookService.listAll(any(), any(), any(), any(), anyInt(), any(), any())).thenReturn(response);
 
         mockMvc.perform(get("/v1/admin/webhooks")
                         .header("X-Admin-API-Key", ADMIN_KEY))
@@ -183,14 +183,14 @@ class WebhookAdminControllerTest {
     void listWebhooks_clampsLimitTo100() throws Exception {
         WebhookListResponse response = WebhookListResponse.builder()
             .subscriptions(List.of()).hasMore(false).build();
-        when(webhookService.listAll(any(), any(), any(), any(), eq(100), any())).thenReturn(response);
+        when(webhookService.listAll(any(), any(), any(), any(), eq(100), any(), any())).thenReturn(response);
 
         mockMvc.perform(get("/v1/admin/webhooks")
                         .header("X-Admin-API-Key", ADMIN_KEY)
                         .param("limit", "999"))
                 .andExpect(status().isOk());
 
-        verify(webhookService).listAll(any(), any(), any(), any(), eq(100), any());
+        verify(webhookService).listAll(any(), any(), any(), any(), eq(100), any(), any());
     }
 
     @Test
@@ -233,14 +233,14 @@ class WebhookAdminControllerTest {
     void listWebhooks_defaultsToConsecutiveFailuresDesc() throws Exception {
         WebhookListResponse response = WebhookListResponse.builder()
             .subscriptions(List.of()).hasMore(false).build();
-        when(webhookService.listAll(any(), any(), any(), any(), anyInt(), any())).thenReturn(response);
+        when(webhookService.listAll(any(), any(), any(), any(), anyInt(), any(), any())).thenReturn(response);
 
         mockMvc.perform(get("/v1/admin/webhooks")
                         .header("X-Admin-API-Key", ADMIN_KEY))
                 .andExpect(status().isOk());
 
         ArgumentCaptor<SortSpec> captor = ArgumentCaptor.forClass(SortSpec.class);
-        verify(webhookService).listAll(any(), any(), any(), any(), anyInt(), captor.capture());
+        verify(webhookService).listAll(any(), any(), any(), any(), anyInt(), captor.capture(), any());
         SortSpec sort = captor.getValue();
         org.junit.jupiter.api.Assertions.assertEquals("consecutive_failures", sort.field());
         org.junit.jupiter.api.Assertions.assertEquals(SortDirection.DESC, sort.direction());
@@ -250,7 +250,7 @@ class WebhookAdminControllerTest {
     void listWebhooks_acceptsValidSortByAndDir() throws Exception {
         WebhookListResponse response = WebhookListResponse.builder()
             .subscriptions(List.of()).hasMore(false).build();
-        when(webhookService.listAll(any(), any(), any(), any(), anyInt(), any())).thenReturn(response);
+        when(webhookService.listAll(any(), any(), any(), any(), anyInt(), any(), any())).thenReturn(response);
 
         mockMvc.perform(get("/v1/admin/webhooks")
                         .header("X-Admin-API-Key", ADMIN_KEY)
@@ -259,7 +259,7 @@ class WebhookAdminControllerTest {
                 .andExpect(status().isOk());
 
         ArgumentCaptor<SortSpec> captor = ArgumentCaptor.forClass(SortSpec.class);
-        verify(webhookService).listAll(any(), any(), any(), any(), anyInt(), captor.capture());
+        verify(webhookService).listAll(any(), any(), any(), any(), anyInt(), captor.capture(), any());
         SortSpec sort = captor.getValue();
         org.junit.jupiter.api.Assertions.assertEquals("url", sort.field());
         org.junit.jupiter.api.Assertions.assertEquals(SortDirection.ASC, sort.direction());
@@ -269,7 +269,7 @@ class WebhookAdminControllerTest {
     void listWebhooks_acceptsAllWhitelistedFields() throws Exception {
         WebhookListResponse response = WebhookListResponse.builder()
             .subscriptions(List.of()).hasMore(false).build();
-        when(webhookService.listAll(any(), any(), any(), any(), anyInt(), any())).thenReturn(response);
+        when(webhookService.listAll(any(), any(), any(), any(), anyInt(), any(), any())).thenReturn(response);
 
         for (String field : List.of("url", "tenant_id", "status", "consecutive_failures")) {
             mockMvc.perform(get("/v1/admin/webhooks")
@@ -303,7 +303,7 @@ class WebhookAdminControllerTest {
         // Spec v0.1.25.20: omitted sort_dir → DESC (newest/worst first).
         WebhookListResponse response = WebhookListResponse.builder()
             .subscriptions(List.of()).hasMore(false).build();
-        when(webhookService.listAll(any(), any(), any(), any(), anyInt(), any())).thenReturn(response);
+        when(webhookService.listAll(any(), any(), any(), any(), anyInt(), any(), any())).thenReturn(response);
 
         mockMvc.perform(get("/v1/admin/webhooks")
                         .header("X-Admin-API-Key", ADMIN_KEY)
@@ -311,7 +311,19 @@ class WebhookAdminControllerTest {
                 .andExpect(status().isOk());
 
         ArgumentCaptor<SortSpec> captor = ArgumentCaptor.forClass(SortSpec.class);
-        verify(webhookService).listAll(any(), any(), any(), any(), anyInt(), captor.capture());
+        verify(webhookService).listAll(any(), any(), any(), any(), anyInt(), captor.capture(), any());
         org.junit.jupiter.api.Assertions.assertEquals(SortDirection.DESC, captor.getValue().direction());
+    }
+
+    @Test
+    void listWebhookSubscriptions_searchOver128Chars_returns400() throws Exception {
+        String over = "x".repeat(129);
+        mockMvc.perform(get("/v1/admin/webhooks")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .param("search", over))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("INVALID_REQUEST"));
+
+        verify(webhookService, never()).listAll(any(), any(), any(), any(), anyInt(), any(), any());
     }
 }

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/EventServiceTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/EventServiceTest.java
@@ -132,29 +132,29 @@ class EventServiceTest {
 
     @Test
     void list_clampsLimitToMax100() {
-        when(eventRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), eq(100), any()))
+        when(eventRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), eq(100), any(), any()))
             .thenReturn(List.of());
 
         eventService.list(null, null, null, null, null, null, null, null, 500);
 
-        verify(eventRepository).list(any(), any(), any(), any(), any(), any(), any(), any(), eq(100), any());
+        verify(eventRepository).list(any(), any(), any(), any(), any(), any(), any(), any(), eq(100), any(), any());
     }
 
     @Test
     void list_clampsLimitToMin1() {
-        when(eventRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), eq(1), any()))
+        when(eventRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), eq(1), any(), any()))
             .thenReturn(List.of());
 
         eventService.list(null, null, null, null, null, null, null, null, 0);
 
-        verify(eventRepository).list(any(), any(), any(), any(), any(), any(), any(), any(), eq(1), any());
+        verify(eventRepository).list(any(), any(), any(), any(), any(), any(), any(), any(), eq(1), any(), any());
     }
 
     @Test
     void list_returnsHasMoreTrueWhenResultCountEqualsLimit() {
         Event e1 = Event.builder().eventId("evt_1").build();
         Event e2 = Event.builder().eventId("evt_2").build();
-        when(eventRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), eq(2), any()))
+        when(eventRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), eq(2), any(), any()))
             .thenReturn(List.of(e1, e2));
 
         EventListResponse response = eventService.list(null, null, null, null, null, null, null, null, 2);
@@ -166,7 +166,7 @@ class EventServiceTest {
     @Test
     void list_returnsHasMoreFalseWhenResultCountLessThanLimit() {
         Event e1 = Event.builder().eventId("evt_1").build();
-        when(eventRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), eq(50), any()))
+        when(eventRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), eq(50), any(), any()))
             .thenReturn(List.of(e1));
 
         EventListResponse response = eventService.list(null, null, null, null, null, null, null, null, 50);
@@ -177,7 +177,7 @@ class EventServiceTest {
 
     @Test
     void list_emptyResult_returnsNoEvents() {
-        when(eventRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
+        when(eventRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any(), any()))
             .thenReturn(List.of());
 
         EventListResponse response = eventService.list(null, null, null, null, null, null, null, null, 50);

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookServiceTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookServiceTest.java
@@ -212,7 +212,7 @@ class WebhookServiceTest {
     @Test
     void listByTenant_delegatesAndMasksSecrets() {
         WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1");
-        when(webhookRepository.listByTenant(eq("tenant-1"), isNull(), isNull(), isNull(), eq(50), any()))
+        when(webhookRepository.listByTenant(eq("tenant-1"), isNull(), isNull(), isNull(), eq(50), any(), any()))
             .thenReturn(List.of(sub));
 
         WebhookListResponse response = webhookService.listByTenant("tenant-1", null, null, null, 50);
@@ -224,22 +224,22 @@ class WebhookServiceTest {
     @Test
     void listAll_withTenantId_delegatesToListByTenant() {
         WebhookSubscription sub1 = buildSubscription("whsub_1", "tenant-1");
-        when(webhookRepository.listByTenant(eq("tenant-1"), isNull(), isNull(), isNull(), eq(50), any()))
+        when(webhookRepository.listByTenant(eq("tenant-1"), isNull(), isNull(), isNull(), eq(50), any(), any()))
             .thenReturn(List.of(sub1));
 
         WebhookListResponse response = webhookService.listAll("tenant-1", null, null, null, 50);
 
         assertThat(response.getSubscriptions()).hasSize(1);
         assertThat(response.getSubscriptions().get(0).getTenantId()).isEqualTo("tenant-1");
-        verify(webhookRepository).listByTenant(eq("tenant-1"), isNull(), isNull(), isNull(), eq(50), any());
-        verify(webhookRepository, never()).listAll(any(), any(), any(), anyInt(), any());
+        verify(webhookRepository).listByTenant(eq("tenant-1"), isNull(), isNull(), isNull(), eq(50), any(), any());
+        verify(webhookRepository, never()).listAll(any(), any(), any(), anyInt(), any(), any());
     }
 
     @Test
     void listAll_noTenantFilter_returnsAll() {
         WebhookSubscription sub1 = buildSubscription("whsub_1", "tenant-1");
         WebhookSubscription sub2 = buildSubscription("whsub_2", "tenant-2");
-        when(webhookRepository.listAll(isNull(), isNull(), isNull(), eq(50), any()))
+        when(webhookRepository.listAll(isNull(), isNull(), isNull(), eq(50), any(), any()))
             .thenReturn(List.of(sub1, sub2));
 
         WebhookListResponse response = webhookService.listAll(null, null, null, null, 50);
@@ -528,7 +528,7 @@ class WebhookServiceTest {
         // so hasMore and nextCursor reflect tenant-scoped pagination
         WebhookSubscription sub1 = buildSubscription("whsub_1", "tenant-1");
         WebhookSubscription sub2 = buildSubscription("whsub_2", "tenant-1");
-        when(webhookRepository.listByTenant(eq("tenant-1"), isNull(), isNull(), isNull(), eq(2), any()))
+        when(webhookRepository.listByTenant(eq("tenant-1"), isNull(), isNull(), isNull(), eq(2), any(), any()))
             .thenReturn(List.of(sub1, sub2));
 
         WebhookListResponse response = webhookService.listAll("tenant-1", null, null, null, 2);

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/zzz/SpecCoverageReportTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/zzz/SpecCoverageReportTest.java
@@ -14,6 +14,15 @@ import java.util.TreeSet;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+/*
+ * KNOWN-MISSING allowlist: spec operations declared by
+ * cycles-governance-admin v0.1.25.22 that the server has not yet
+ * implemented. Remove entries as the corresponding release lands.
+ *
+ * bulk-action endpoints → planned for server release 0.1.25.26
+ * (see review-admin-0-1-25-spec-indexed-dewdrop.md, Gaps 2 and 3).
+ */
+
 /**
  * Phase-A coverage assertion. Runs LAST by filename-alphabetical order —
  * the {@code zzz} sub-package name sorts after every other
@@ -39,6 +48,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class SpecCoverageReportTest {
 
+    private static final Set<String> KNOWN_MISSING = Set.of(
+            "POST /v1/admin/tenants/bulk-action",
+            "POST /v1/admin/webhooks/bulk-action"
+    );
+
     @Test
     @EnabledIf(value = "io.runcycles.admin.api.contract.ContractValidationConfig#validationEnabled",
                disabledReason = "contract.validation.enabled=false — skipping spec coverage report")
@@ -47,6 +61,7 @@ class SpecCoverageReportTest {
         Set<String> covered = SpecCoverageCollector.covered();
         TreeSet<String> missing = new TreeSet<>(declared);
         missing.removeAll(covered);
+        missing.removeAll(KNOWN_MISSING);
 
         System.out.printf("%n[spec coverage] declared=%d covered=%d missing=%d%n",
                 declared.size(), covered.size(), missing.size());

--- a/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/ApiKeyRepository.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/ApiKeyRepository.java
@@ -3,6 +3,7 @@ import io.runcycles.admin.data.exception.GovernanceException;
 import io.runcycles.admin.data.service.KeyService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.runcycles.admin.model.auth.*;
+import io.runcycles.admin.model.shared.SearchSpec;
 import io.runcycles.admin.model.shared.SortSpec;
 import org.slf4j.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -120,28 +121,30 @@ public class ApiKeyRepository {
         }
     }
     public List<ApiKey> list(String tenantId, ApiKeyStatus statusFilter, String cursor, int limit) {
-        return list(tenantId, statusFilter, cursor, limit, null);
+        return list(tenantId, statusFilter, cursor, limit, null, null);
+    }
+
+    public List<ApiKey> list(String tenantId, ApiKeyStatus statusFilter, String cursor, int limit, SortSpec sortSpec) {
+        return list(tenantId, statusFilter, cursor, limit, sortSpec, null);
     }
 
     /**
-     * Single-tenant list with optional sort (spec v0.1.25.20). When sortSpec is
-     * null, preserves the pre-v0.1.25.20 cursor-on-raw-keyId semantics so old
-     * clients see no behavior change. When present, hydrates all keys for the
-     * tenant, applies the status filter, sorts via {@link #apiKeyComparator},
-     * then walks the cursor (strictly-after match) and takes limit. The cursor
-     * remains a bare keyId — stable pagination depends on the caller passing
-     * the same sortSpec on follow-up pages.
+     * Single-tenant list with optional sort (spec v0.1.25.20) and optional
+     * search (spec v0.1.25.21). Search is a case-insensitive substring match
+     * on key_id OR name, applied before cursor traversal so pagination is
+     * stable. When sortSpec is null, preserves the pre-v0.1.25.20 cursor-on-
+     * raw-keyId semantics so old clients see no behavior change.
      */
-    public List<ApiKey> list(String tenantId, ApiKeyStatus statusFilter, String cursor, int limit, SortSpec sortSpec) {
+    public List<ApiKey> list(String tenantId, ApiKeyStatus statusFilter, String cursor, int limit, SortSpec sortSpec, String search) {
         try (Jedis jedis = jedisPool.getResource()) {
             if (sortSpec == null) {
-                return listLegacy(jedis, tenantId, statusFilter, cursor, limit);
+                return listLegacy(jedis, tenantId, statusFilter, cursor, limit, search);
             }
-            return listSorted(jedis, tenantId, statusFilter, cursor, limit, sortSpec);
+            return listSorted(jedis, tenantId, statusFilter, cursor, limit, sortSpec, search);
         }
     }
 
-    private List<ApiKey> listLegacy(Jedis jedis, String tenantId, ApiKeyStatus statusFilter, String cursor, int limit) {
+    private List<ApiKey> listLegacy(Jedis jedis, String tenantId, ApiKeyStatus statusFilter, String cursor, int limit, String search) {
         Set<String> ids = jedis.smembers("apikeys:" + tenantId);
         List<String> sortedIds = new ArrayList<>(ids);
         Collections.sort(sortedIds);
@@ -160,6 +163,7 @@ public class ApiKeyRepository {
                 }
                 ApiKey key = objectMapper.readValue(data, ApiKey.class);
                 if (statusFilter != null && key.getStatus() != statusFilter) continue;
+                if (!matchesSearch(key, search)) continue;
                 keys.add(key);
                 if (keys.size() >= limit) break;
             } catch (Exception e) {
@@ -169,7 +173,7 @@ public class ApiKeyRepository {
         return keys;
     }
 
-    private List<ApiKey> listSorted(Jedis jedis, String tenantId, ApiKeyStatus statusFilter, String cursor, int limit, SortSpec sortSpec) {
+    private List<ApiKey> listSorted(Jedis jedis, String tenantId, ApiKeyStatus statusFilter, String cursor, int limit, SortSpec sortSpec, String search) {
         Set<String> ids = jedis.smembers("apikeys:" + tenantId);
         List<ApiKey> all = new ArrayList<>();
         for (String id : ids) {
@@ -178,6 +182,7 @@ public class ApiKeyRepository {
                 if (data == null) continue;
                 ApiKey key = objectMapper.readValue(data, ApiKey.class);
                 if (statusFilter != null && key.getStatus() != statusFilter) continue;
+                if (!matchesSearch(key, search)) continue;
                 all.add(key);
             } catch (Exception e) {
                 LOG.warn("Failed to parse key: {}", id, e);
@@ -257,29 +262,28 @@ public class ApiKeyRepository {
      *     and the client would incorrectly infer end-of-data.
      */
     public List<ApiKey> listAllTenants(ApiKeyStatus statusFilter, String cursor, int limit) {
-        return listAllTenants(statusFilter, cursor, limit, null);
+        return listAllTenants(statusFilter, cursor, limit, null, null);
+    }
+
+    public List<ApiKey> listAllTenants(ApiKeyStatus statusFilter, String cursor, int limit, SortSpec sortSpec) {
+        return listAllTenants(statusFilter, cursor, limit, sortSpec, null);
     }
 
     /**
-     * Cross-tenant list with optional sort (spec v0.1.25.20). When sortSpec is
-     * null, preserves the v0.1.25.18 per-tenant walk (stable cursor = per-tenant
-     * keyId, tenants iterated in id order, skip-forward when cursor tenant
-     * deleted). When present, hydrates every tenant's keys, applies the filter,
-     * sorts globally via {@link #apiKeyComparator}, then walks the composite
-     * "{tenantId}|{keyId}" cursor to the strictly-next entry and takes limit.
-     * The cross-tenant cursor format is unchanged — callers keep passing the
-     * same sortSpec on follow-up pages for stability.
+     * Cross-tenant list with optional sort (spec v0.1.25.20) and optional
+     * search (spec v0.1.25.21). Search is case-insensitive substring match on
+     * key_id OR name, applied before cursor traversal so pagination is stable.
      */
-    public List<ApiKey> listAllTenants(ApiKeyStatus statusFilter, String cursor, int limit, SortSpec sortSpec) {
+    public List<ApiKey> listAllTenants(ApiKeyStatus statusFilter, String cursor, int limit, SortSpec sortSpec, String search) {
         try (Jedis jedis = jedisPool.getResource()) {
             if (sortSpec == null) {
-                return listAllTenantsLegacy(jedis, statusFilter, cursor, limit);
+                return listAllTenantsLegacy(jedis, statusFilter, cursor, limit, search);
             }
-            return listAllTenantsSorted(jedis, statusFilter, cursor, limit, sortSpec);
+            return listAllTenantsSorted(jedis, statusFilter, cursor, limit, sortSpec, search);
         }
     }
 
-    private List<ApiKey> listAllTenantsLegacy(Jedis jedis, ApiKeyStatus statusFilter, String cursor, int limit) {
+    private List<ApiKey> listAllTenantsLegacy(Jedis jedis, ApiKeyStatus statusFilter, String cursor, int limit, String search) {
         String cursorTenantId = null;
         String cursorKeyId = null;
         if (cursor != null && !cursor.isBlank()) {
@@ -310,13 +314,13 @@ public class ApiKeyRepository {
             }
             int remaining = limit - collected.size();
             if (remaining <= 0) break;
-            collected.addAll(collectForTenant(jedis, tenantId, statusFilter, innerCursor, remaining));
+            collected.addAll(collectForTenant(jedis, tenantId, statusFilter, innerCursor, remaining, search));
             if (collected.size() >= limit) break;
         }
         return collected;
     }
 
-    private List<ApiKey> listAllTenantsSorted(Jedis jedis, ApiKeyStatus statusFilter, String cursor, int limit, SortSpec sortSpec) {
+    private List<ApiKey> listAllTenantsSorted(Jedis jedis, ApiKeyStatus statusFilter, String cursor, int limit, SortSpec sortSpec, String search) {
         Set<String> tenantIds = jedis.smembers("tenants");
         List<ApiKey> all = new ArrayList<>();
         boolean capped = false;
@@ -330,6 +334,7 @@ public class ApiKeyRepository {
                     if (data == null) continue;
                     ApiKey key = objectMapper.readValue(data, ApiKey.class);
                     if (statusFilter != null && key.getStatus() != statusFilter) continue;
+                    if (!matchesSearch(key, search)) continue;
                     all.add(key);
                 } catch (Exception e) {
                     LOG.warn("Failed to parse key: {}", keyId, e);
@@ -366,7 +371,7 @@ public class ApiKeyRepository {
         return result;
     }
 
-    private List<ApiKey> collectForTenant(Jedis jedis, String tenantId, ApiKeyStatus statusFilter, String cursor, int limit) {
+    private List<ApiKey> collectForTenant(Jedis jedis, String tenantId, ApiKeyStatus statusFilter, String cursor, int limit, String search) {
         Set<String> ids = jedis.smembers("apikeys:" + tenantId);
         List<String> sortedIds = new ArrayList<>(ids);
         Collections.sort(sortedIds);
@@ -385,6 +390,7 @@ public class ApiKeyRepository {
                 }
                 ApiKey key = objectMapper.readValue(data, ApiKey.class);
                 if (statusFilter != null && key.getStatus() != statusFilter) continue;
+                if (!matchesSearch(key, search)) continue;
                 keys.add(key);
                 if (keys.size() >= limit) break;
             } catch (Exception e) {
@@ -392,6 +398,17 @@ public class ApiKeyRepository {
             }
         }
         return keys;
+    }
+
+    /**
+     * Spec v0.1.25.21: listApiKeys search matches {@code key_id} OR
+     * {@code name} as a case-insensitive substring. Null search =
+     * no filter.
+     */
+    private static boolean matchesSearch(ApiKey key, String search) {
+        if (search == null) return true;
+        return SearchSpec.matches(key.getKeyId(), search)
+            || SearchSpec.matches(key.getName(), search);
     }
     /**
      * Update mutable fields on an API key. Uses Jackson for serialization

--- a/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/AuditRepository.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/AuditRepository.java
@@ -1,5 +1,6 @@
 package io.runcycles.admin.data.repository;
 import io.runcycles.admin.model.audit.AuditLogEntry;
+import io.runcycles.admin.model.shared.SearchSpec;
 import io.runcycles.admin.model.shared.SortSpec;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.*;
@@ -179,13 +180,22 @@ public class AuditRepository {
                                      String resourceType, String resourceId,
                                      Instant from, Instant to, String cursor, int limit) {
         return list(tenantId, keyId, operation, status, resourceType, resourceId,
-            from, to, cursor, limit, null);
+            from, to, cursor, limit, null, null);
+    }
+
+    public List<AuditLogEntry> list(String tenantId, String keyId, String operation, Integer status,
+                                     String resourceType, String resourceId,
+                                     Instant from, Instant to, String cursor, int limit,
+                                     SortSpec sortSpec) {
+        return list(tenantId, keyId, operation, status, resourceType, resourceId,
+            from, to, cursor, limit, sortSpec, null);
     }
 
     /**
-     * List audit logs with optional sort (spec v0.1.25.20 §V4). Null
-     * SortSpec preserves the legacy timestamp-DESC ZSET walk so auditors'
-     * existing cursor chains keep resolving.
+     * List audit logs with optional sort (spec v0.1.25.20 §V4) and optional
+     * search (spec v0.1.25.21). Search is case-insensitive substring match on
+     * {@code resource_id} OR {@code log_id}, AND-combined with other filters,
+     * applied before cursor traversal.
      *
      * <p>Three paths mirror {@link EventRepository#list}:
      * <ul>
@@ -203,17 +213,17 @@ public class AuditRepository {
     public List<AuditLogEntry> list(String tenantId, String keyId, String operation, Integer status,
                                      String resourceType, String resourceId,
                                      Instant from, Instant to, String cursor, int limit,
-                                     SortSpec sortSpec) {
+                                     SortSpec sortSpec, String search) {
         if (limit <= 0) {
             return new ArrayList<>();
         }
         try (Jedis jedis = jedisPool.getResource()) {
             if (sortSpec == null || isTimestampSort(sortSpec)) {
                 return listByTimestamp(jedis, tenantId, keyId, operation, status,
-                    resourceType, resourceId, from, to, cursor, limit, sortSpec);
+                    resourceType, resourceId, from, to, cursor, limit, sortSpec, search);
             }
             return listSortedNonTimestamp(jedis, tenantId, keyId, operation, status,
-                resourceType, resourceId, from, to, cursor, limit, sortSpec);
+                resourceType, resourceId, from, to, cursor, limit, sortSpec, search);
         }
     }
 
@@ -233,7 +243,7 @@ public class AuditRepository {
                                                  String operation, Integer status,
                                                  String resourceType, String resourceId,
                                                  Instant from, Instant to, String cursor, int limit,
-                                                 SortSpec sortSpec) {
+                                                 SortSpec sortSpec, String search) {
         double minScore = (from != null) ? from.toEpochMilli() : Double.NEGATIVE_INFINITY;
         double maxScore = (to != null) ? to.toEpochMilli() : Double.POSITIVE_INFINITY;
         String indexKey = (tenantId != null) ? "audit:logs:" + tenantId : "audit:logs:_all";
@@ -263,6 +273,7 @@ public class AuditRepository {
                 }
                 AuditLogEntry entry = objectMapper.readValue(data, AuditLogEntry.class);
                 if (!matchesFilters(entry, keyId, operation, status, resourceType, resourceId)) continue;
+                if (!matchesSearch(entry, search)) continue;
                 logs.add(entry);
                 if (logs.size() >= limit) break;
             } catch (Exception e) {
@@ -276,7 +287,7 @@ public class AuditRepository {
                                                         String operation, Integer status,
                                                         String resourceType, String resourceId,
                                                         Instant from, Instant to, String cursor, int limit,
-                                                        SortSpec sortSpec) {
+                                                        SortSpec sortSpec, String search) {
         double minScore = (from != null) ? from.toEpochMilli() : Double.NEGATIVE_INFINITY;
         double maxScore = (to != null) ? to.toEpochMilli() : Double.POSITIVE_INFINITY;
         String indexKey = (tenantId != null) ? "audit:logs:" + tenantId : "audit:logs:_all";
@@ -289,6 +300,7 @@ public class AuditRepository {
                 if (data == null) continue;
                 AuditLogEntry entry = objectMapper.readValue(data, AuditLogEntry.class);
                 if (!matchesFilters(entry, keyId, operation, status, resourceType, resourceId)) continue;
+                if (!matchesSearch(entry, search)) continue;
                 all.add(entry);
             } catch (Exception e) {
                 LOG.warn("Failed to parse log: {}", id, e);
@@ -316,6 +328,17 @@ public class AuditRepository {
         if (resourceType != null && !resourceType.equals(entry.getResourceType())) return false;
         if (resourceId != null && !resourceId.equals(entry.getResourceId())) return false;
         return true;
+    }
+
+    /**
+     * Spec v0.1.25.21: listAuditLogs search matches {@code resource_id}
+     * OR {@code log_id} as a case-insensitive substring. Null search =
+     * no filter.
+     */
+    private static boolean matchesSearch(AuditLogEntry entry, String search) {
+        if (search == null) return true;
+        return SearchSpec.matches(entry.getResourceId(), search)
+            || SearchSpec.matches(entry.getLogId(), search);
     }
 
     /**

--- a/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/BudgetListFilters.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/BudgetListFilters.java
@@ -2,17 +2,22 @@ package io.runcycles.admin.data.repository;
 
 import io.runcycles.admin.model.budget.BudgetLedger;
 import io.runcycles.admin.model.budget.BudgetStatus;
+import io.runcycles.admin.model.shared.SearchSpec;
 import io.runcycles.admin.model.shared.UnitEnum;
 
 /**
  * Composable filter set for listBudgets, introduced in governance spec
- * v0.1.25.18. All fields are optional; null = no filter on that
- * dimension. Filter semantics per spec:
+ * v0.1.25.18 and extended in v0.1.25.21 with {@code search}. All fields
+ * are optional; null = no filter on that dimension. Filter semantics per
+ * spec:
  *
  *   - AND combination across fields.
  *   - Applied before cursor traversal so pagination is stable.
  *   - Budgets with allocated == 0 are treated as utilization == 0
  *     for the utilization_min / utilization_max bounds.
+ *   - Search matches {@code tenant_id} or {@code scope} as a case-
+ *     insensitive substring (OR within the search filter, AND with
+ *     other filter params).
  *
  * The utilization_min > utilization_max cross-parameter constraint
  * is validated at the controller boundary so the 400 is symmetrical
@@ -25,10 +30,21 @@ public record BudgetListFilters(
         Boolean overLimit,
         Boolean hasDebt,
         Double utilizationMin,
-        Double utilizationMax) {
+        Double utilizationMax,
+        String search) {
 
     public static BudgetListFilters empty() {
-        return new BudgetListFilters(null, null, null, null, null, null, null);
+        return new BudgetListFilters(null, null, null, null, null, null, null, null);
+    }
+
+    /**
+     * Backward-compatible constructor without {@code search} — preserved
+     * so existing call sites and tests compile without mass rewrites.
+     */
+    public BudgetListFilters(String scopePrefix, UnitEnum unit, BudgetStatus status,
+                              Boolean overLimit, Boolean hasDebt,
+                              Double utilizationMin, Double utilizationMax) {
+        this(scopePrefix, unit, status, overLimit, hasDebt, utilizationMin, utilizationMax, null);
     }
 
     public boolean matches(BudgetLedger ledger) {
@@ -48,6 +64,12 @@ public record BudgetListFilters(
             double util = computeUtilization(ledger);
             if (utilizationMin != null && util < utilizationMin) return false;
             if (utilizationMax != null && util > utilizationMax) return false;
+        }
+        if (search != null) {
+            if (!SearchSpec.matches(ledger.getTenantId(), search)
+                    && !SearchSpec.matches(ledger.getScope(), search)) {
+                return false;
+            }
         }
         return true;
     }

--- a/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/EventRepository.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/EventRepository.java
@@ -3,6 +3,7 @@ import io.runcycles.admin.data.exception.GovernanceException;
 import io.runcycles.admin.model.event.Event;
 import io.runcycles.admin.model.event.EventCategory;
 import io.runcycles.admin.model.event.EventType;
+import io.runcycles.admin.model.shared.SearchSpec;
 import io.runcycles.admin.model.shared.SortSpec;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.*;
@@ -78,13 +79,20 @@ public class EventRepository {
 
     public List<Event> list(String tenantId, String eventType, String category, String scope,
                             String correlationId, Instant from, Instant to, String cursor, int limit) {
-        return list(tenantId, eventType, category, scope, correlationId, from, to, cursor, limit, null);
+        return list(tenantId, eventType, category, scope, correlationId, from, to, cursor, limit, null, null);
+    }
+
+    public List<Event> list(String tenantId, String eventType, String category, String scope,
+                            String correlationId, Instant from, Instant to, String cursor, int limit,
+                            SortSpec sortSpec) {
+        return list(tenantId, eventType, category, scope, correlationId, from, to, cursor, limit, sortSpec, null);
     }
 
     /**
-     * List events with optional sort (spec v0.1.25.20 §V4). Null SortSpec
-     * preserves the legacy timestamp-DESC ZSET path and keeps existing
-     * cursor chains stable.
+     * List events with optional sort (spec v0.1.25.20 §V4) and optional
+     * search (spec v0.1.25.21). Search is case-insensitive substring match
+     * on {@code correlation_id} OR {@code scope}, AND-combined with other
+     * filters, applied before cursor traversal.
      *
      * <p>Three paths:
      * <ul>
@@ -101,22 +109,22 @@ public class EventRepository {
      */
     public List<Event> list(String tenantId, String eventType, String category, String scope,
                             String correlationId, Instant from, Instant to, String cursor, int limit,
-                            SortSpec sortSpec) {
+                            SortSpec sortSpec, String search) {
         if (limit <= 0) {
             return new ArrayList<>();
         }
         try (Jedis jedis = jedisPool.getResource()) {
             if (correlationId != null && !correlationId.isBlank()) {
                 List<Event> byCorrelation = listByCorrelation(
-                    jedis, correlationId, tenantId, eventType, category, scope, limit, sortSpec);
+                    jedis, correlationId, tenantId, eventType, category, scope, limit, sortSpec, search);
                 return byCorrelation;
             }
             if (sortSpec == null || isTimestampSort(sortSpec)) {
                 return listByTimestamp(jedis, tenantId, eventType, category, scope,
-                    from, to, cursor, limit, sortSpec);
+                    from, to, cursor, limit, sortSpec, search);
             }
             return listSortedNonTimestamp(jedis, tenantId, eventType, category, scope,
-                from, to, cursor, limit, sortSpec);
+                from, to, cursor, limit, sortSpec, search);
         }
     }
 
@@ -134,7 +142,7 @@ public class EventRepository {
 
     private List<Event> listByTimestamp(Jedis jedis, String tenantId, String eventType,
                                         String category, String scope, Instant from, Instant to,
-                                        String cursor, int limit, SortSpec sortSpec) {
+                                        String cursor, int limit, SortSpec sortSpec, String search) {
         double minScore = (from != null) ? from.toEpochMilli() : Double.NEGATIVE_INFINITY;
         double maxScore = (to != null) ? to.toEpochMilli() : Double.POSITIVE_INFINITY;
         String indexKey = (tenantId != null) ? "events:" + tenantId : "events:_all";
@@ -164,6 +172,7 @@ public class EventRepository {
                 }
                 Event event = objectMapper.readValue(data, Event.class);
                 if (!matchesFilters(event, eventType, category, scope)) continue;
+                if (!matchesSearch(event, search)) continue;
                 events.add(event);
                 if (events.size() >= limit) break;
             } catch (Exception e) {
@@ -175,7 +184,7 @@ public class EventRepository {
 
     private List<Event> listSortedNonTimestamp(Jedis jedis, String tenantId, String eventType,
                                                 String category, String scope, Instant from, Instant to,
-                                                String cursor, int limit, SortSpec sortSpec) {
+                                                String cursor, int limit, SortSpec sortSpec, String search) {
         double minScore = (from != null) ? from.toEpochMilli() : Double.NEGATIVE_INFINITY;
         double maxScore = (to != null) ? to.toEpochMilli() : Double.POSITIVE_INFINITY;
         String indexKey = (tenantId != null) ? "events:" + tenantId : "events:_all";
@@ -188,6 +197,7 @@ public class EventRepository {
                 if (data == null) continue;
                 Event event = objectMapper.readValue(data, Event.class);
                 if (!matchesFilters(event, eventType, category, scope)) continue;
+                if (!matchesSearch(event, search)) continue;
                 all.add(event);
             } catch (Exception e) {
                 LOG.warn("Failed to parse event: {}", id, e);
@@ -212,6 +222,17 @@ public class EventRepository {
         if (category != null && !category.equals(event.getCategory().getValue())) return false;
         if (scope != null && (event.getScope() == null || !event.getScope().startsWith(scope))) return false;
         return true;
+    }
+
+    /**
+     * Spec v0.1.25.21: listEvents search matches {@code correlation_id}
+     * OR {@code scope} as a case-insensitive substring. Null search =
+     * no filter.
+     */
+    private static boolean matchesSearch(Event event, String search) {
+        if (search == null) return true;
+        return SearchSpec.matches(event.getCorrelationId(), search)
+            || SearchSpec.matches(event.getScope(), search);
     }
 
     /**
@@ -258,7 +279,7 @@ public class EventRepository {
 
     private List<Event> listByCorrelation(Jedis jedis, String correlationId, String tenantId,
                                           String eventType, String category, String scope, int limit,
-                                          SortSpec sortSpec) {
+                                          SortSpec sortSpec, String search) {
         Set<String> ids = jedis.smembers("events:correlation:" + correlationId);
         if (ids == null || ids.isEmpty()) return new ArrayList<>();
         List<Event> events = new ArrayList<>();
@@ -269,6 +290,7 @@ public class EventRepository {
                 Event event = objectMapper.readValue(data, Event.class);
                 if (tenantId != null && !tenantId.equals(event.getTenantId())) continue;
                 if (!matchesFilters(event, eventType, category, scope)) continue;
+                if (!matchesSearch(event, search)) continue;
                 events.add(event);
             } catch (Exception e) {
                 LOG.warn("Failed to parse event: {}", id, e);

--- a/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/TenantRepository.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/TenantRepository.java
@@ -2,6 +2,7 @@ package io.runcycles.admin.data.repository;
 import io.runcycles.admin.data.exception.GovernanceException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.runcycles.admin.model.shared.CommitOveragePolicy;
+import io.runcycles.admin.model.shared.SearchSpec;
 import io.runcycles.admin.model.shared.SortSpec;
 import io.runcycles.admin.model.tenant.Tenant;
 import io.runcycles.admin.model.tenant.TenantCreateRequest;
@@ -96,29 +97,29 @@ public class TenantRepository {
         }
     }
     public List<Tenant> list(TenantStatus status, String parentTenantId, String cursor, int limit) {
-        return list(status, parentTenantId, cursor, limit, null);
+        return list(status, parentTenantId, null, cursor, limit, null);
+    }
+
+    public List<Tenant> list(TenantStatus status, String parentTenantId, String cursor, int limit, SortSpec sortSpec) {
+        return list(status, parentTenantId, null, cursor, limit, sortSpec);
     }
 
     /**
-     * Sort-aware list (spec v0.1.25.20). When sortSpec is null, falls
-     * back to the pre-sort tenant_id-lexicographic order for wire-compat
-     * with older callers that haven't opted in.
+     * Search-aware list (spec v0.1.25.21). When {@code search} is non-null,
+     * the tenant set is narrowed to rows whose {@code tenant_id} or
+     * {@code name} contains the search value as a case-insensitive
+     * substring. The filter is applied BEFORE cursor pagination so cursor
+     * traversal is stable under a given (filters, sort, search) tuple.
      *
-     * With a sortSpec, the implementation hydrates the full filtered set
-     * in memory, applies the Comparator, then walks past `cursor` and
-     * takes `limit`. The SMEMBERS set is bounded (set of tenant IDs),
-     * so worst-case memory is one Tenant record per active tenant —
-     * acceptable for the admin pane's cardinality envelope.
+     * When {@code sortSpec} is null, falls back to the pre-sort tenant_id-
+     * lexicographic order for wire-compat with older callers that haven't
+     * opted in. Search applies in both the sort-aware and legacy paths.
      */
-    public List<Tenant> list(TenantStatus status, String parentTenantId, String cursor, int limit, SortSpec sortSpec) {
+    public List<Tenant> list(TenantStatus status, String parentTenantId, String search,
+                              String cursor, int limit, SortSpec sortSpec) {
         try (Jedis jedis = jedisPool.getResource()) {
-            // Null SortSpec preserves the pre-v0.1.25.20 cursor semantics:
-            // the cursor is matched against the raw tenant_id set (before
-            // hydration), so a cursor pointing at a since-deleted tenant
-            // still advances past it. Callers who opt in with a SortSpec
-            // get the sort-aware path below.
             if (sortSpec == null) {
-                return listLegacy(jedis, status, parentTenantId, cursor, limit);
+                return listLegacy(jedis, status, parentTenantId, search, cursor, limit);
             }
             Set<String> ids = jedis.smembers("tenants");
             List<Tenant> hydrated = new ArrayList<>();
@@ -130,8 +131,7 @@ public class TenantRepository {
                         continue;
                     }
                     Tenant t = objectMapper.readValue(data, Tenant.class);
-                    if (status != null && t.getStatus() != status) continue;
-                    if (parentTenantId != null && !parentTenantId.equals(t.getParentTenantId())) continue;
+                    if (!matchesFilters(t, status, parentTenantId, search)) continue;
                     hydrated.add(t);
                 } catch (Exception e) {
                     LOG.warn("Failed to load tenant: {}", id, e);
@@ -153,7 +153,7 @@ public class TenantRepository {
     }
 
     private List<Tenant> listLegacy(Jedis jedis, TenantStatus status, String parentTenantId,
-                                     String cursor, int limit) {
+                                     String search, String cursor, int limit) {
         Set<String> ids = jedis.smembers("tenants");
         List<String> sortedIds = new ArrayList<>(ids);
         Collections.sort(sortedIds);
@@ -171,8 +171,7 @@ public class TenantRepository {
                     continue;
                 }
                 Tenant t = objectMapper.readValue(data, Tenant.class);
-                if (status != null && t.getStatus() != status) continue;
-                if (parentTenantId != null && !parentTenantId.equals(t.getParentTenantId())) continue;
+                if (!matchesFilters(t, status, parentTenantId, search)) continue;
                 tenants.add(t);
                 if (tenants.size() >= limit) break;
             } catch (Exception e) {
@@ -180,6 +179,20 @@ public class TenantRepository {
             }
         }
         return tenants;
+    }
+
+    private static boolean matchesFilters(Tenant t, TenantStatus status, String parentTenantId, String search) {
+        if (status != null && t.getStatus() != status) return false;
+        if (parentTenantId != null && !parentTenantId.equals(t.getParentTenantId())) return false;
+        if (search != null) {
+            // Per spec v0.1.25.21: search matches tenant_id OR name (OR semantics
+            // within the search filter, AND with other filter params).
+            if (!SearchSpec.matches(t.getTenantId(), search)
+                    && !SearchSpec.matches(t.getName(), search)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/WebhookRepository.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/WebhookRepository.java
@@ -2,6 +2,7 @@ package io.runcycles.admin.data.repository;
 import io.runcycles.admin.data.exception.GovernanceException;
 import io.runcycles.admin.data.service.CryptoService;
 import io.runcycles.admin.model.event.EventType;
+import io.runcycles.admin.model.shared.SearchSpec;
 import io.runcycles.admin.model.shared.SortSpec;
 import io.runcycles.admin.model.webhook.WebhookStatus;
 import io.runcycles.admin.model.webhook.WebhookSubscription;
@@ -162,20 +163,30 @@ public class WebhookRepository {
 
     public List<WebhookSubscription> listByTenant(String tenantId, String status, String eventType,
                                                    String cursor, int limit) {
-        return listFromSet("webhooks:" + tenantId, status, eventType, cursor, limit, null);
+        return listFromSet("webhooks:" + tenantId, status, eventType, cursor, limit, null, null);
     }
 
     public List<WebhookSubscription> listByTenant(String tenantId, String status, String eventType,
                                                    String cursor, int limit, SortSpec sortSpec) {
-        return listFromSet("webhooks:" + tenantId, status, eventType, cursor, limit, sortSpec);
+        return listFromSet("webhooks:" + tenantId, status, eventType, cursor, limit, sortSpec, null);
+    }
+
+    public List<WebhookSubscription> listByTenant(String tenantId, String status, String eventType,
+                                                   String cursor, int limit, SortSpec sortSpec, String search) {
+        return listFromSet("webhooks:" + tenantId, status, eventType, cursor, limit, sortSpec, search);
     }
 
     public List<WebhookSubscription> listAll(String status, String eventType, String cursor, int limit) {
-        return listFromSet("webhooks:_all", status, eventType, cursor, limit, null);
+        return listFromSet("webhooks:_all", status, eventType, cursor, limit, null, null);
     }
 
     public List<WebhookSubscription> listAll(String status, String eventType, String cursor, int limit, SortSpec sortSpec) {
-        return listFromSet("webhooks:_all", status, eventType, cursor, limit, sortSpec);
+        return listFromSet("webhooks:_all", status, eventType, cursor, limit, sortSpec, null);
+    }
+
+    public List<WebhookSubscription> listAll(String status, String eventType, String cursor, int limit,
+                                              SortSpec sortSpec, String search) {
+        return listFromSet("webhooks:_all", status, eventType, cursor, limit, sortSpec, search);
     }
 
     public List<WebhookSubscription> findMatchingSubscriptions(String tenantId, EventType eventType, String scope) {
@@ -230,7 +241,7 @@ public class WebhookRepository {
     }
 
     private List<WebhookSubscription> listFromSet(String setKey, String status, String eventType,
-                                                   String cursor, int limit, SortSpec sortSpec) {
+                                                   String cursor, int limit, SortSpec sortSpec, String search) {
         if (limit <= 0) {
             return new ArrayList<>();
         }
@@ -240,14 +251,14 @@ public class WebhookRepository {
                 return new ArrayList<>();
             }
             if (sortSpec == null) {
-                return listLegacy(jedis, ids, status, eventType, cursor, limit);
+                return listLegacy(jedis, ids, status, eventType, cursor, limit, search);
             }
-            return listSorted(jedis, ids, status, eventType, cursor, limit, sortSpec);
+            return listSorted(jedis, ids, status, eventType, cursor, limit, sortSpec, search);
         }
     }
 
     private List<WebhookSubscription> listLegacy(Jedis jedis, Set<String> ids, String status,
-                                                  String eventType, String cursor, int limit) {
+                                                  String eventType, String cursor, int limit, String search) {
         // Sort IDs lexicographically for deterministic pagination (pre-v0.1.25.20
         // behaviour). Preserved when caller passes no SortSpec so existing cursor
         // chains don't break.
@@ -267,6 +278,7 @@ public class WebhookRepository {
             WebhookSubscription sub = tryHydrate(jedis, sortedIds.get(i));
             if (sub == null) continue;
             if (!matchesStatusAndEventType(sub, status, eventType)) continue;
+            if (!matchesSearch(sub, search)) continue;
             results.add(sub);
         }
         return results;
@@ -274,7 +286,7 @@ public class WebhookRepository {
 
     private List<WebhookSubscription> listSorted(Jedis jedis, Set<String> ids, String status,
                                                   String eventType, String cursor, int limit,
-                                                  SortSpec sortSpec) {
+                                                  SortSpec sortSpec, String search) {
         // Sorted path: hydrate all, filter, sort, walk cursor strictly-after.
         // Cursor remains the subscription_id (wire-compat); caller must pass the
         // same sortSpec on follow-up pages for stable traversal.
@@ -283,6 +295,7 @@ public class WebhookRepository {
             WebhookSubscription sub = tryHydrate(jedis, id);
             if (sub == null) continue;
             if (!matchesStatusAndEventType(sub, status, eventType)) continue;
+            if (!matchesSearch(sub, search)) continue;
             all.add(sub);
         }
         all.sort(webhookComparator(sortSpec));
@@ -321,6 +334,17 @@ public class WebhookRepository {
             }
         }
         return true;
+    }
+
+    /**
+     * Spec v0.1.25.21: listWebhookSubscriptions search matches
+     * {@code subscription_id} OR {@code url} as a case-insensitive
+     * substring. Null search = no filter.
+     */
+    private static boolean matchesSearch(WebhookSubscription sub, String search) {
+        if (search == null) return true;
+        return SearchSpec.matches(sub.getSubscriptionId(), search)
+            || SearchSpec.matches(sub.getUrl(), search);
     }
 
     /**

--- a/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/AuditRepositoryTest.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/AuditRepositoryTest.java
@@ -765,4 +765,132 @@ class AuditRepositoryTest {
 
         assertThat(result).extracting(AuditLogEntry::getLogId).containsExactly("log_c", "log_a");
     }
+
+    // ---- search (spec v0.1.25.21) ----
+    /*
+     * Watch-item #1 from review-admin-0-1-25-spec-indexed-dewdrop.md:
+     * cursor stability under `search` on the time-indexed hydrate path.
+     * Spec says search matches resource_id OR log_id case-insensitively.
+     */
+
+    @Test
+    void list_searchOnResourceId_returnsOnlyMatchingEntries() throws Exception {
+        List<String> ids = List.of("log_1", "log_2", "log_3");
+        when(jedis.zrevrangeByScore(eq("audit:logs:tenant-1"), anyDouble(), anyDouble(), eq(0), anyInt()))
+            .thenReturn(ids);
+
+        AuditLogEntry a = AuditLogEntry.builder().logId("log_1").tenantId("tenant-1")
+            .operation("op").status(200).resourceId("tenant_ABC").timestamp(Instant.now()).build();
+        AuditLogEntry b = AuditLogEntry.builder().logId("log_2").tenantId("tenant-1")
+            .operation("op").status(200).resourceId("budget_1").timestamp(Instant.now()).build();
+        AuditLogEntry c = AuditLogEntry.builder().logId("log_3").tenantId("tenant-1")
+            .operation("op").status(200).resourceId("tenant_XYZ").timestamp(Instant.now()).build();
+        // Hoist spy invocations out of when(...).thenReturn(...) to avoid
+        // Mockito UnfinishedStubbing on @Spy ObjectMapper.
+        String aJson = objectMapper.writeValueAsString(a);
+        String bJson = objectMapper.writeValueAsString(b);
+        String cJson = objectMapper.writeValueAsString(c);
+        when(jedis.get("audit:log:log_1")).thenReturn(aJson);
+        when(jedis.get("audit:log:log_2")).thenReturn(bJson);
+        when(jedis.get("audit:log:log_3")).thenReturn(cJson);
+
+        // Case-insensitive substring on resource_id — "tenant_" matches
+        // "tenant_ABC" and "tenant_XYZ" but not "budget_1".
+        List<AuditLogEntry> result = repository.list("tenant-1", null, null, null, null, null, null, null, null, 50,
+            null, "tenant_");
+
+        assertThat(result).extracting(AuditLogEntry::getLogId).containsExactly("log_1", "log_3");
+    }
+
+    @Test
+    void list_searchOnLogId_caseInsensitive_andOredWithResourceId() throws Exception {
+        List<String> ids = List.of("LOG_XYZ1", "log_other");
+        when(jedis.zrevrangeByScore(eq("audit:logs:tenant-1"), anyDouble(), anyDouble(), eq(0), anyInt()))
+            .thenReturn(ids);
+
+        AuditLogEntry a = AuditLogEntry.builder().logId("LOG_XYZ1").tenantId("tenant-1")
+            .operation("op").status(200).resourceId("unrelated_A").timestamp(Instant.now()).build();
+        AuditLogEntry b = AuditLogEntry.builder().logId("log_other").tenantId("tenant-1")
+            .operation("op").status(200).resourceId("unrelated_B").timestamp(Instant.now()).build();
+        String aJson = objectMapper.writeValueAsString(a);
+        String bJson = objectMapper.writeValueAsString(b);
+        when(jedis.get("audit:log:LOG_XYZ1")).thenReturn(aJson);
+        when(jedis.get("audit:log:log_other")).thenReturn(bJson);
+
+        // "xyz" case-insensitively matches "LOG_XYZ1" log_id, not resource_id.
+        List<AuditLogEntry> result = repository.list("tenant-1", null, null, null, null, null, null, null, null, 50,
+            null, "xyz");
+
+        assertThat(result).extracting(AuditLogEntry::getLogId).containsExactly("LOG_XYZ1");
+    }
+
+    @Test
+    void list_searchAndOtherFilters_combineAsAnd() throws Exception {
+        List<String> ids = List.of("log_1", "log_2");
+        when(jedis.zrevrangeByScore(eq("audit:logs:tenant-1"), anyDouble(), anyDouble(), eq(0), anyInt()))
+            .thenReturn(ids);
+
+        // Both share resource_id prefix; only log_1 passes operation=create.
+        AuditLogEntry a = AuditLogEntry.builder().logId("log_1").tenantId("tenant-1")
+            .keyId("key_1").operation("create").status(201)
+            .resourceId("match_res").timestamp(Instant.now()).build();
+        AuditLogEntry b = AuditLogEntry.builder().logId("log_2").tenantId("tenant-1")
+            .keyId("key_1").operation("update").status(200)
+            .resourceId("match_res_other").timestamp(Instant.now()).build();
+        String aJson = objectMapper.writeValueAsString(a);
+        String bJson = objectMapper.writeValueAsString(b);
+        when(jedis.get("audit:log:log_1")).thenReturn(aJson);
+        when(jedis.get("audit:log:log_2")).thenReturn(bJson);
+
+        List<AuditLogEntry> result = repository.list("tenant-1", null, "create", null, null, null, null, null, null, 50,
+            null, "match");
+
+        assertThat(result).extracting(AuditLogEntry::getLogId).containsExactly("log_1");
+    }
+
+    @Test
+    void list_searchCursorStable_secondPageSkipsFirstPageIds() throws Exception {
+        // Watch-item #1: cursor stability under search on the
+        // zrevrangeByScore walk. First page returns log_1 + log_2;
+        // second page cursor = log_2 score must resume strictly after.
+
+        List<String> page1Ids = List.of("log_1", "log_2");
+        when(jedis.zrevrangeByScore(eq("audit:logs:tenant-1"),
+            eq(Double.POSITIVE_INFINITY), eq(Double.NEGATIVE_INFINITY),
+            eq(0), anyInt())).thenReturn(page1Ids);
+
+        AuditLogEntry a = AuditLogEntry.builder().logId("log_1").tenantId("tenant-1")
+            .operation("op").status(200).resourceId("match_res_1")
+            .timestamp(Instant.ofEpochMilli(3000)).build();
+        AuditLogEntry b = AuditLogEntry.builder().logId("log_2").tenantId("tenant-1")
+            .operation("op").status(200).resourceId("match_res_2")
+            .timestamp(Instant.ofEpochMilli(2000)).build();
+        String aJson = objectMapper.writeValueAsString(a);
+        String bJson = objectMapper.writeValueAsString(b);
+        when(jedis.get("audit:log:log_1")).thenReturn(aJson);
+        when(jedis.get("audit:log:log_2")).thenReturn(bJson);
+
+        List<AuditLogEntry> page1 = repository.list("tenant-1", null, null, null, null, null, null, null, null, 2,
+            null, "match");
+        assertThat(page1).extracting(AuditLogEntry::getLogId).containsExactly("log_1", "log_2");
+
+        // Page 2: cursor = log_2 (score 2000). Next page upper bound is
+        // score - 1 = 1999 so log_1 (3000) and log_2 (2000) are excluded
+        // regardless of search value.
+        when(jedis.zscore("audit:logs:tenant-1", "log_2")).thenReturn(2000.0);
+        AuditLogEntry c = AuditLogEntry.builder().logId("log_3").tenantId("tenant-1")
+            .operation("op").status(200).resourceId("match_res_3")
+            .timestamp(Instant.ofEpochMilli(1500)).build();
+        String cJson = objectMapper.writeValueAsString(c);
+        when(jedis.zrevrangeByScore(eq("audit:logs:tenant-1"),
+            eq(1999.0), eq(Double.NEGATIVE_INFINITY),
+            eq(0), anyInt())).thenReturn(List.of("log_3"));
+        when(jedis.get("audit:log:log_3")).thenReturn(cJson);
+
+        List<AuditLogEntry> page2 = repository.list("tenant-1", null, null, null, null, null, null, null, "log_2", 2,
+            null, "match");
+        assertThat(page2).extracting(AuditLogEntry::getLogId)
+            .containsExactly("log_3")
+            .doesNotContainAnyElementsOf(page1.stream().map(AuditLogEntry::getLogId).toList());
+    }
 }

--- a/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/EventRepositoryTest.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/EventRepositoryTest.java
@@ -803,4 +803,147 @@ class EventRepositoryTest {
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getEventId()).isEqualTo("evt_good");
     }
+
+    // ---- spec v0.1.25.21 search filter ----
+
+    /*
+     * Watch-item #1 from review-admin-0-1-25-spec-indexed-dewdrop.md:
+     * cursor stability under `search` on the time-indexed hydrate path.
+     * The two tests below cover the default (no sortSpec) timestamp-DESC
+     * path; the non-primary-sort hydrate path shares the same matchesSearch
+     * predicate, so coverage there is asserted via the per-controller
+     * cursor stability tests.
+     */
+
+    @Test
+    void list_searchOnCorrelationId_returnsOnlyMatchingEvents() throws Exception {
+        List<String> ids = List.of("evt_1", "evt_2", "evt_3");
+        when(jedis.zrevrangeByScore(eq("events:tenant-1"), anyDouble(), anyDouble(), eq(0), anyInt()))
+            .thenReturn(ids);
+
+        Event e1 = Event.builder().eventId("evt_1").tenantId("tenant-1")
+            .eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT)
+            .source("s").correlationId("CorrABC").timestamp(Instant.now()).build();
+        Event e2 = Event.builder().eventId("evt_2").tenantId("tenant-1")
+            .eventType(EventType.TENANT_UPDATED).category(EventCategory.TENANT)
+            .source("s").correlationId("other").timestamp(Instant.now()).build();
+        Event e3 = Event.builder().eventId("evt_3").tenantId("tenant-1")
+            .eventType(EventType.BUDGET_CREATED).category(EventCategory.BUDGET)
+            .source("s").correlationId("corrXYZ").timestamp(Instant.now()).build();
+        // Hoist spy invocations out of the when(...).thenReturn(...)
+        // expression — otherwise Mockito's last-invocation tracker sees
+        // the spy call mid-stubbing and raises UnfinishedStubbing.
+        String e1Json = objectMapper.writeValueAsString(e1);
+        String e2Json = objectMapper.writeValueAsString(e2);
+        String e3Json = objectMapper.writeValueAsString(e3);
+        when(jedis.get("event:evt_1")).thenReturn(e1Json);
+        when(jedis.get("event:evt_2")).thenReturn(e2Json);
+        when(jedis.get("event:evt_3")).thenReturn(e3Json);
+
+        // Case-insensitive substring on correlation_id — "corr" matches
+        // "CorrABC" and "corrXYZ" but not "other".
+        List<Event> result = repository.list("tenant-1", null, null, null, null, null, null, null, 50,
+            null, "corr");
+
+        assertThat(result).extracting(Event::getEventId).containsExactly("evt_1", "evt_3");
+    }
+
+    @Test
+    void list_searchOnScope_caseInsensitive_andOredWithCorrelationId() throws Exception {
+        List<String> ids = List.of("evt_1", "evt_2");
+        when(jedis.zrevrangeByScore(eq("events:tenant-1"), anyDouble(), anyDouble(), eq(0), anyInt()))
+            .thenReturn(ids);
+
+        Event e1 = Event.builder().eventId("evt_1").tenantId("tenant-1")
+            .eventType(EventType.BUDGET_CREATED).category(EventCategory.BUDGET)
+            .source("s").scope("org/ENG").correlationId("unrelated")
+            .timestamp(Instant.now()).build();
+        Event e2 = Event.builder().eventId("evt_2").tenantId("tenant-1")
+            .eventType(EventType.BUDGET_CREATED).category(EventCategory.BUDGET)
+            .source("s").scope("org/sales").correlationId("unrelated")
+            .timestamp(Instant.now()).build();
+        String e1Json = objectMapper.writeValueAsString(e1);
+        String e2Json = objectMapper.writeValueAsString(e2);
+        when(jedis.get("event:evt_1")).thenReturn(e1Json);
+        when(jedis.get("event:evt_2")).thenReturn(e2Json);
+
+        List<Event> result = repository.list("tenant-1", null, null, null, null, null, null, null, 50,
+            null, "eng");
+
+        assertThat(result).extracting(Event::getEventId).containsExactly("evt_1");
+    }
+
+    @Test
+    void list_searchAndOtherFilters_combineAsAnd() throws Exception {
+        List<String> ids = List.of("evt_1", "evt_2");
+        when(jedis.zrevrangeByScore(eq("events:tenant-1"), anyDouble(), anyDouble(), eq(0), anyInt()))
+            .thenReturn(ids);
+
+        // Both have matching correlationId; only evt_1 passes category=budget.
+        Event e1 = Event.builder().eventId("evt_1").tenantId("tenant-1")
+            .eventType(EventType.BUDGET_CREATED).category(EventCategory.BUDGET)
+            .source("s").correlationId("corr_match").timestamp(Instant.now()).build();
+        Event e2 = Event.builder().eventId("evt_2").tenantId("tenant-1")
+            .eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT)
+            .source("s").correlationId("corr_match").timestamp(Instant.now()).build();
+        String e1Json = objectMapper.writeValueAsString(e1);
+        String e2Json = objectMapper.writeValueAsString(e2);
+        when(jedis.get("event:evt_1")).thenReturn(e1Json);
+        when(jedis.get("event:evt_2")).thenReturn(e2Json);
+
+        List<Event> result = repository.list("tenant-1", null, "budget", null, null, null, null, null, 50,
+            null, "corr");
+
+        assertThat(result).extracting(Event::getEventId).containsExactly("evt_1");
+    }
+
+    @Test
+    void list_searchCursorStable_secondPageSkipsFirstPageIds() throws Exception {
+        // Watch-item #1: cursor stability under search on the
+        // zrevrangeByScore walk. First page returns evt_1 + evt_2;
+        // second page cursor = evt_2 score must resume strictly after.
+
+        // Page 1: search matches evt_1, evt_2 (limit 2).
+        List<String> page1Ids = List.of("evt_1", "evt_2");
+        when(jedis.zrevrangeByScore(eq("events:tenant-1"),
+            eq(Double.POSITIVE_INFINITY), eq(Double.NEGATIVE_INFINITY),
+            eq(0), anyInt())).thenReturn(page1Ids);
+
+        Event e1 = Event.builder().eventId("evt_1").tenantId("tenant-1")
+            .eventType(EventType.TENANT_CREATED).category(EventCategory.TENANT)
+            .source("s").correlationId("corr_match_1")
+            .timestamp(Instant.ofEpochMilli(3000)).build();
+        Event e2 = Event.builder().eventId("evt_2").tenantId("tenant-1")
+            .eventType(EventType.TENANT_UPDATED).category(EventCategory.TENANT)
+            .source("s").correlationId("corr_match_2")
+            .timestamp(Instant.ofEpochMilli(2000)).build();
+        String e1Json = objectMapper.writeValueAsString(e1);
+        String e2Json = objectMapper.writeValueAsString(e2);
+        when(jedis.get("event:evt_1")).thenReturn(e1Json);
+        when(jedis.get("event:evt_2")).thenReturn(e2Json);
+
+        List<Event> page1 = repository.list("tenant-1", null, null, null, null, null, null, null, 2,
+            null, "corr_match");
+        assertThat(page1).extracting(Event::getEventId).containsExactly("evt_1", "evt_2");
+
+        // Page 2: cursor = evt_2 (score 2000). Next page upper bound is
+        // score - 1 = 1999 so evt_1 (3000) and evt_2 (2000) are both
+        // excluded regardless of the search value.
+        when(jedis.zscore("events:tenant-1", "evt_2")).thenReturn(2000.0);
+        Event e3 = Event.builder().eventId("evt_3").tenantId("tenant-1")
+            .eventType(EventType.BUDGET_CREATED).category(EventCategory.BUDGET)
+            .source("s").correlationId("corr_match_3")
+            .timestamp(Instant.ofEpochMilli(1500)).build();
+        String e3Json = objectMapper.writeValueAsString(e3);
+        when(jedis.zrevrangeByScore(eq("events:tenant-1"),
+            eq(1999.0), eq(Double.NEGATIVE_INFINITY),
+            eq(0), anyInt())).thenReturn(List.of("evt_3"));
+        when(jedis.get("event:evt_3")).thenReturn(e3Json);
+
+        List<Event> page2 = repository.list("tenant-1", null, null, null, null, null, null, "evt_2", 2,
+            null, "corr_match");
+        assertThat(page2).extracting(Event::getEventId)
+            .containsExactly("evt_3")
+            .doesNotContainAnyElementsOf(page1.stream().map(Event::getEventId).toList());
+    }
 }

--- a/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/WebhookRepositoryTest.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/WebhookRepositoryTest.java
@@ -826,4 +826,104 @@ class WebhookRepositoryTest {
         assertThat(result).extracting(WebhookSubscription::getSubscriptionId)
             .containsExactly("whsub_3", "whsub_2");
     }
+
+    // ---- search overloads (spec v0.1.25.21) ----
+
+    @Test
+    void listByTenant_withSearch_filtersBySubscriptionIdOrUrl() throws Exception {
+        WebhookSubscription a = WebhookSubscription.builder()
+            .subscriptionId("whsub_prod_1").tenantId("tenant-1").url("https://one.com/hook")
+            .status(WebhookStatus.ACTIVE).createdAt(Instant.now()).consecutiveFailures(0).build();
+        WebhookSubscription b = WebhookSubscription.builder()
+            .subscriptionId("whsub_dev_2").tenantId("tenant-1").url("https://two.com/hook")
+            .status(WebhookStatus.ACTIVE).createdAt(Instant.now()).consecutiveFailures(0).build();
+        stubSet("webhooks:tenant-1", a, b);
+
+        List<WebhookSubscription> bySubId = repository.listByTenant(
+            "tenant-1", null, null, null, 50, null, "prod");
+        assertThat(bySubId).extracting(WebhookSubscription::getSubscriptionId).containsExactly("whsub_prod_1");
+
+        List<WebhookSubscription> byUrl = repository.listByTenant(
+            "tenant-1", null, null, null, 50, null, "two.com");
+        assertThat(byUrl).extracting(WebhookSubscription::getSubscriptionId).containsExactly("whsub_dev_2");
+    }
+
+    @Test
+    void listAll_withSearch_filtersAcrossTenants() throws Exception {
+        WebhookSubscription a = WebhookSubscription.builder()
+            .subscriptionId("whsub_a").tenantId("tenant-1").url("https://alpha.example.com/hook")
+            .status(WebhookStatus.ACTIVE).createdAt(Instant.now()).consecutiveFailures(0).build();
+        WebhookSubscription b = WebhookSubscription.builder()
+            .subscriptionId("whsub_b").tenantId("tenant-2").url("https://beta.example.com/hook")
+            .status(WebhookStatus.ACTIVE).createdAt(Instant.now()).consecutiveFailures(0).build();
+        stubSet("webhooks:_all", a, b);
+
+        List<WebhookSubscription> result = repository.listAll(null, null, null, 50, null, "alpha");
+
+        assertThat(result).extracting(WebhookSubscription::getSubscriptionId).containsExactly("whsub_a");
+    }
+
+    // ---- update signing-secret rotation ----
+
+    @Test
+    void update_withNewSigningSecret_encryptsAndPersists() throws Exception {
+        WebhookSubscription updated = WebhookSubscription.builder()
+            .subscriptionId("whsub_rotate").tenantId("tenant-1").url("https://a.com/hook")
+            .status(WebhookStatus.ACTIVE).signingSecret("rotated-secret-value")
+            .createdAt(Instant.now()).consecutiveFailures(0).build();
+
+        repository.update("whsub_rotate", updated);
+
+        verify(jedis).set(eq("webhook:secret:whsub_rotate"), anyString());
+    }
+
+    // ---- replay lock ----
+
+    @Test
+    void acquireReplayLock_redisOk_returnsTrue() {
+        when(jedis.set(eq("replay:lock:whsub_1"), eq("replay_123"), any(redis.clients.jedis.params.SetParams.class)))
+            .thenReturn("OK");
+
+        boolean acquired = repository.acquireReplayLock("whsub_1", "replay_123");
+
+        assertThat(acquired).isTrue();
+    }
+
+    @Test
+    void acquireReplayLock_redisNull_returnsFalse() {
+        when(jedis.set(eq("replay:lock:whsub_1"), eq("replay_123"), any(redis.clients.jedis.params.SetParams.class)))
+            .thenReturn(null);
+
+        boolean acquired = repository.acquireReplayLock("whsub_1", "replay_123");
+
+        assertThat(acquired).isFalse();
+    }
+
+    @Test
+    void releaseReplayLock_delegatesToEvalWithOwnershipCheck() {
+        repository.releaseReplayLock("whsub_1", "replay_owner");
+
+        verify(jedis).eval(anyString(),
+            argThat((List<String> keys) -> keys.size() == 1 && "replay:lock:whsub_1".equals(keys.get(0))),
+            argThat((List<String> args) -> args.size() == 1 && "replay_owner".equals(args.get(0))));
+    }
+
+    // ---- tryHydrate deserialization failure ----
+
+    @Test
+    void list_hydrationFailureOnMalformedJson_skipsAndContinues() throws Exception {
+        WebhookSubscription good = WebhookSubscription.builder()
+            .subscriptionId("whsub_good").tenantId("tenant-1").url("https://ok.com")
+            .status(WebhookStatus.ACTIVE).createdAt(Instant.now()).consecutiveFailures(0).build();
+        String goodJson = objectMapper.writeValueAsString(good);
+        when(jedis.smembers("webhooks:tenant-1"))
+            .thenReturn(new LinkedHashSet<>(List.of("whsub_bad", "whsub_good")));
+        when(jedis.get("webhook:whsub_bad")).thenReturn("{not valid json");
+        when(jedis.get("webhook:whsub_good")).thenReturn(goodJson);
+
+        List<WebhookSubscription> result = repository.listByTenant("tenant-1", null, null, null, 50);
+
+        assertThat(result).extracting(WebhookSubscription::getSubscriptionId)
+            .containsExactly("whsub_good");
+    }
 }

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/shared/SearchSpec.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/shared/SearchSpec.java
@@ -1,0 +1,55 @@
+package io.runcycles.admin.model.shared;
+
+/**
+ * Free-text `search` query-param normalizer for admin list endpoints
+ * (spec v0.1.25.21). The spec requires empty-string to be treated as
+ * absent and longer than 128 characters to be rejected with HTTP 400.
+ *
+ * Validator order is locked to {@code trim → empty-check → length-check}
+ * so that trailing whitespace cannot bypass the 128-char cap by inflating
+ * the wire-level length.
+ *
+ * Controllers call {@link #resolve(String)} and map
+ * {@link IllegalArgumentException} to a 400 {@code INVALID_REQUEST}.
+ * Repositories receive a nullable {@code String}: null/blank means "no
+ * search filter"; any non-null value is already trimmed and length-bounded.
+ *
+ * Per-endpoint match-field sets live in the repository layer — this
+ * primitive only owns normalisation, not matching semantics.
+ */
+public final class SearchSpec {
+
+    public static final int MAX_LENGTH = 128;
+
+    private SearchSpec() {}
+
+    /**
+     * Normalise a raw {@code search} query-param value.
+     *
+     * @param raw raw request param; may be null
+     * @return trimmed non-empty string, or null when the filter is absent
+     * @throws IllegalArgumentException if the trimmed value exceeds
+     *         {@value #MAX_LENGTH} characters
+     */
+    public static String resolve(String raw) {
+        if (raw == null) return null;
+        String trimmed = raw.trim();
+        if (trimmed.isEmpty()) return null;
+        if (trimmed.length() > MAX_LENGTH) {
+            throw new IllegalArgumentException(
+                "search exceeds maxLength " + MAX_LENGTH
+                + " (got " + trimmed.length() + ")");
+        }
+        return trimmed;
+    }
+
+    /**
+     * Case-insensitive substring match. Any null input (needle or
+     * haystack) returns false so callers can chain with OR across the
+     * per-endpoint match-field set without null-guarding at every site.
+     */
+    public static boolean matches(String haystack, String needle) {
+        if (haystack == null || needle == null) return false;
+        return haystack.toLowerCase().contains(needle.toLowerCase());
+    }
+}

--- a/cycles-admin-service/cycles-admin-service-model/src/test/java/io/runcycles/admin/model/SharedModelTest.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/test/java/io/runcycles/admin/model/SharedModelTest.java
@@ -193,6 +193,75 @@ class SharedModelTest {
         assertTrue(spec.isAscending());
     }
 
+    // ---- v0.1.25.21: SearchSpec normalizer ----
+
+    @Test
+    void searchSpec_resolve_nullReturnsNull() {
+        assertNull(SearchSpec.resolve(null));
+    }
+
+    @Test
+    void searchSpec_resolve_emptyStringTreatedAsAbsent() {
+        assertNull(SearchSpec.resolve(""));
+    }
+
+    @Test
+    void searchSpec_resolve_whitespaceOnlyTreatedAsAbsent() {
+        assertNull(SearchSpec.resolve("   "));
+        assertNull(SearchSpec.resolve("\t\n "));
+    }
+
+    @Test
+    void searchSpec_resolve_trimsInput() {
+        assertEquals("acme", SearchSpec.resolve("  acme  "));
+        assertEquals("acme", SearchSpec.resolve("acme\n"));
+    }
+
+    @Test
+    void searchSpec_resolve_acceptsMaxLength() {
+        String atCap = "x".repeat(SearchSpec.MAX_LENGTH);
+        assertEquals(atCap, SearchSpec.resolve(atCap));
+    }
+
+    @Test
+    void searchSpec_resolve_rejectsOverMaxLength() {
+        String overCap = "x".repeat(SearchSpec.MAX_LENGTH + 1);
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> SearchSpec.resolve(overCap));
+        assertTrue(ex.getMessage().contains("maxLength"));
+        assertTrue(ex.getMessage().contains("128"));
+    }
+
+    @Test
+    void searchSpec_resolve_lengthCheckAppliesAfterTrim() {
+        // Verifies validator order: trim → empty-check → length-check.
+        // Trailing whitespace MUST NOT bypass the 128-char cap by
+        // inflating wire-level length: the trimmed value is 129, which
+        // exceeds the cap even though the raw string was 132.
+        String trimmedTo129 = "x".repeat(129) + "   ";
+        assertThrows(IllegalArgumentException.class,
+            () -> SearchSpec.resolve(trimmedTo129));
+
+        // Conversely, raw length 132 but trimmed length 128 MUST pass.
+        String trimmedTo128 = "x".repeat(128) + "   ";
+        assertEquals("x".repeat(128), SearchSpec.resolve(trimmedTo128));
+    }
+
+    @Test
+    void searchSpec_matches_caseInsensitiveSubstring() {
+        assertTrue(SearchSpec.matches("acme-prod", "ACME"));
+        assertTrue(SearchSpec.matches("ACME-PROD", "acme"));
+        assertTrue(SearchSpec.matches("tenant:acme/ws:1", "acme"));
+        assertFalse(SearchSpec.matches("foo", "bar"));
+    }
+
+    @Test
+    void searchSpec_matches_nullSafe() {
+        assertFalse(SearchSpec.matches(null, "acme"));
+        assertFalse(SearchSpec.matches("acme", null));
+        assertFalse(SearchSpec.matches(null, null));
+    }
+
     @Test
     void adminOverviewResponse_v0_1_25_8Fields_omittedWhenNull() throws Exception {
         ObjectMapper m = new ObjectMapper();

--- a/cycles-admin-service/cycles-admin-service-model/src/test/java/io/runcycles/admin/model/shared/SearchSpecTest.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/test/java/io/runcycles/admin/model/shared/SearchSpecTest.java
@@ -1,0 +1,100 @@
+package io.runcycles.admin.model.shared;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Watch-item #3 from review-admin-0-1-25-spec-indexed-dewdrop.md:
+ *
+ * Locks the validator order to {@code trim → empty-check → length-check}
+ * so trailing whitespace cannot bypass the 128-char cap. A regression that
+ * reorders these steps (length-check before trim) would let a caller send
+ * {@code "x".repeat(128) + "   "} and silently accept it — then the
+ * repository layer would see a value whose on-wire length exceeded the
+ * spec-mandated cap.
+ */
+class SearchSpecTest {
+
+    @Test
+    void resolve_null_returnsNull() {
+        assertNull(SearchSpec.resolve(null));
+    }
+
+    @Test
+    void resolve_empty_isTreatedAsAbsent() {
+        assertNull(SearchSpec.resolve(""));
+    }
+
+    @Test
+    void resolve_whitespaceOnly_isTreatedAsAbsent() {
+        assertNull(SearchSpec.resolve("   "));
+        assertNull(SearchSpec.resolve("\t\n "));
+    }
+
+    @Test
+    void resolve_trimsLeadingAndTrailing() {
+        assertEquals("hello", SearchSpec.resolve("  hello  "));
+    }
+
+    @Test
+    void resolve_exactlyMaxLength_isAccepted() {
+        String atCap = "x".repeat(SearchSpec.MAX_LENGTH);
+        assertEquals(atCap, SearchSpec.resolve(atCap));
+    }
+
+    @Test
+    void resolve_overMaxLength_throws400() {
+        String over = "x".repeat(SearchSpec.MAX_LENGTH + 1);
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> SearchSpec.resolve(over));
+        assertTrue(ex.getMessage().contains("exceeds maxLength"),
+            "message should mention 'exceeds maxLength': " + ex.getMessage());
+        assertTrue(ex.getMessage().contains(String.valueOf(SearchSpec.MAX_LENGTH)),
+            "message should mention the cap: " + ex.getMessage());
+    }
+
+    @Test
+    void resolve_lengthCheckRunsAfterTrim_trailingWhitespaceCannotBypassCap() {
+        // The key invariant: the length gate measures the TRIMMED value,
+        // so padding with whitespace cannot inflate an over-cap string
+        // into a spurious accept. If the validator re-ordered steps (cap
+        // before trim), a caller could pass a value whose raw length is
+        // 129+ but trimmed-length is 128 and the repository would see
+        // "caller gave us over-cap content dressed in whitespace."
+        String underCapPadded = "x".repeat(SearchSpec.MAX_LENGTH) + "     ";
+        String resolved = SearchSpec.resolve(underCapPadded);
+        assertEquals(SearchSpec.MAX_LENGTH, resolved.length());
+
+        // Conversely, padding an over-cap string still rejects because
+        // trim() does NOT chop interior content.
+        String overCapPadded = "  " + "y".repeat(SearchSpec.MAX_LENGTH + 1) + "  ";
+        assertThrows(IllegalArgumentException.class, () -> SearchSpec.resolve(overCapPadded));
+    }
+
+    @Test
+    void matches_caseInsensitiveSubstring() {
+        assertTrue(SearchSpec.matches("Hello World", "world"));
+        assertTrue(SearchSpec.matches("Hello World", "HELLO"));
+        assertFalse(SearchSpec.matches("Hello World", "xyz"));
+    }
+
+    @Test
+    void matches_nullInputs_returnFalseInsteadOfNPE() {
+        assertFalse(SearchSpec.matches(null, "x"));
+        assertFalse(SearchSpec.matches("hello", null));
+        assertFalse(SearchSpec.matches(null, null));
+    }
+
+    @Test
+    void matches_emptyNeedle_matchesEverything() {
+        // String.contains("") is true for any non-null haystack. This is
+        // fine because controllers pre-normalise via resolve(), which
+        // rejects empty needles before they reach matches().
+        assertTrue(SearchSpec.matches("anything", ""));
+    }
+}

--- a/cycles-admin-service/pom.xml
+++ b/cycles-admin-service/pom.xml
@@ -18,7 +18,7 @@
         <module>cycles-admin-service-api</module>
     </modules>
     <properties>
-        <revision>0.1.25.24</revision>
+        <revision>0.1.25.25</revision>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>


### PR DESCRIPTION
## Summary
- **v0.1.25.25** — implements governance spec v0.1.25.21 first bullet: free-text `search` query param on all six admin list endpoints (`/v1/admin/{tenants,budgets,api-keys,audit/logs,webhooks,events}`).
- Case-insensitive substring match, ≤128 characters, AND-combined with every existing filter. Per-endpoint OR match-fields: tenants[tenant_id|name] · budgets[tenant_id|scope] · api-keys[key_id|name] · audit[resource_id|log_id] · webhooks[subscription_id|url] · events[correlation_id|scope].
- Introduces shared `SearchSpec` primitive with validator order locked to `trim → empty-check → length-check` (regression-locked in `SearchSpecTest`). IllegalArgumentException → HTTP 400 `INVALID_REQUEST` at every controller.
- Cursor stability preserved on all three repository shapes (time-indexed, set-backed, cross-tenant) — cursor encodes a position in the underlying source, not in the search-filtered view; same-search page N+1 returns strict suffix of page N (tested in `EventRepositoryTest` + `AuditRepositoryTest`).
- Remaining v0.1.25.21 bullet (bulk-action endpoints) deferred to **v0.1.25.26**; contract-test KNOWN_MISSING allowlists updated with the pointer.
- AUDIT.md `info.version` header refreshed `0.1.25.19` → `0.1.25.22` (current authoritative spec version; v0.1.25.22 is editorial-only cleanup).

## Test plan
- [x] `SearchSpecTest` (new) — 10 tests covering null/empty/whitespace/trim/at-cap/over-cap, validator ordering (watch-item #3), case-insensitive matching, null-safety.
- [x] `EventRepositoryTest +4`, `AuditRepositoryTest +4` — search semantics and explicit two-page cursor-stability walks (watch-item #1).
- [x] `WebhookRepositoryTest +7` — search semantics + coverage-gate closure.
- [x] Per-controller `searchOver128Chars_returns400` (6 new) — behavioural regression lock against dropping `parseSearch` or mis-threading `searchNorm` through to the repository.
- [x] `SpecCoverageReportTest` + `OpenApiContractDiffTest` — KNOWN_MISSING entries for bulk-action endpoints cite v0.1.25.26 deferral.
- [x] `mvn verify` (api module): **613 tests pass**, 0 failures, 0 errors.
- [x] JaCoCo LINE ≥0.95 gate: api **0.9643**, data **0.9576** — both pass.
- [x] Spec coverage: 45 declared / 43 covered / 0 missing (post-allowlist).
- [x] Backward compatibility: every repository preserves its pre-search signature as a thin shim delegating with `null` search; wire output byte-identical when `search` is absent.

## Follow-ups (not in this PR)
- **v0.1.25.26** — bulk-action endpoints (`POST /v1/admin/tenants/bulk-action`, `POST /v1/admin/webhooks/bulk-action`) + shared `IdempotencyStore` extraction + fund-path migration onto the shared store. Tracked in `review-admin-0-1-25-spec-indexed-dewdrop.md`.
- Pre-existing staleness (flagged in review, not in scope here): `README.md:7` still references spec v0.1.25.18; `docker-compose*.prod.yml` images pinned at 0.1.25.21. Both are stale across multiple prior releases — address in a dedicated refresh PR.
