### PR TITLE
feat(v0.1.25.29): budget bulk-action endpoint (spec v0.1.25.26)

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,9 +1,81 @@
-# Complete Budget Governance v0.1.25.28 — Admin Server Audit
+# Complete Budget Governance v0.1.25.29 — Admin Server Audit
 
-**Server version:** 0.1.25.28 (2026-04-17 — audit tenant_id sentinel split: `__admin__` for admin-plane auth, `__unauth__` for pre-auth failures, spec v0.1.25.25)
-**Date:** 2026-04-17 (v0.1.25.28 audit sentinel split), 2026-04-17 (v0.1.25.27 audit filter DSL upgrade), 2026-04-17 (v0.1.25.26 bulk-action endpoints), 2026-04-17 (v0.1.25.25 search on six list endpoints), 2026-04-16 (v0.1.25.24 server-side sort — six admin list endpoints), 2026-04-16 (v0.1.25.23 BudgetLedger tenant_id on wire), 2026-04-16 (v0.1.25.22 cross-tenant list + filters), 2026-04-16 (v0.1.25.21 nightly CI), 2026-04-16 (v0.1.25.20 audit-on-failure), 2026-04-16 (v0.1.25.19 introspect dual-auth + operator docs), 2026-04-15 (v0.1.25.18 RESET_SPENT operation), 2026-04-14 (v0.1.25.17 cjson round-trip sweep: apikey + policy + tenant), 2026-04-13 (v0.1.25.16 webhooks dual-auth), 2026-04-13 (v0.1.25.15 ScopeValidator), 2026-04-13 (v0.1.25.14 admin-on-behalf-of dual-auth), 2026-04-13 (v0.1.25.13 CORS PUT fix), 2026-04-12 (v0.1.25.12 spec-compliance hardening + observability), 2026-04-12 (v0.1.25.11 contract-testing default ON), 2026-04-12 (v0.1.25.10 spec-compliance hardening), 2026-04-10 (v0.1.25.9 release), 2026-04-10 (CORS hardening + prod config), 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
-**Spec:** [`cycles-governance-admin-v0.1.25.yaml`](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml) (OpenAPI 3.1.0, info.version `0.1.25.25`; `listAuditLogs` gains `error_code` / `error_code_exclude` IN/NOT-IN arrays, `status_min` / `status_max` numeric range; `operation` / `resource_type` promoted scalar → array, all maxItems 25) in [cycles-protocol](https://github.com/runcycles/cycles-protocol)
+**Server version:** 0.1.25.29 (2026-04-18 — budget bulk-action endpoint, spec v0.1.25.26)
+**Date:** 2026-04-18 (v0.1.25.29 budget bulk-action), 2026-04-17 (v0.1.25.28 audit sentinel split), 2026-04-17 (v0.1.25.27 audit filter DSL upgrade), 2026-04-17 (v0.1.25.26 bulk-action endpoints), 2026-04-17 (v0.1.25.25 search on six list endpoints), 2026-04-16 (v0.1.25.24 server-side sort — six admin list endpoints), 2026-04-16 (v0.1.25.23 BudgetLedger tenant_id on wire), 2026-04-16 (v0.1.25.22 cross-tenant list + filters), 2026-04-16 (v0.1.25.21 nightly CI), 2026-04-16 (v0.1.25.20 audit-on-failure), 2026-04-16 (v0.1.25.19 introspect dual-auth + operator docs), 2026-04-15 (v0.1.25.18 RESET_SPENT operation), 2026-04-14 (v0.1.25.17 cjson round-trip sweep: apikey + policy + tenant), 2026-04-13 (v0.1.25.16 webhooks dual-auth), 2026-04-13 (v0.1.25.15 ScopeValidator), 2026-04-13 (v0.1.25.14 admin-on-behalf-of dual-auth), 2026-04-13 (v0.1.25.13 CORS PUT fix), 2026-04-12 (v0.1.25.12 spec-compliance hardening + observability), 2026-04-12 (v0.1.25.11 contract-testing default ON), 2026-04-12 (v0.1.25.10 spec-compliance hardening), 2026-04-10 (v0.1.25.9 release), 2026-04-10 (CORS hardening + prod config), 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
+**Spec:** [`cycles-governance-admin-v0.1.25.yaml`](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml) (OpenAPI 3.1.0, info.version `0.1.25.26`; adds `POST /v1/admin/budgets/bulk-action` — fifth bulk-action endpoint, mirrors the tenant/webhook envelope) in [cycles-protocol](https://github.com/runcycles/cycles-protocol)
 **Server:** Spring Boot 3.5.11 / Java 21 / Redis
+
+### 2026-04-18 — v0.1.25.29 budget bulk-action endpoint (spec v0.1.25.26)
+
+Closes [cycles-server-admin issue #99](https://github.com/runcycles/cycles-server-admin/issues/99) ("Bulk Budget Reset at Tenant or Parent-Scope Level"). Operators rolling over a billing period previously had to iterate `listBudgets` + per-row `fundBudget` — painful for a tenant with dozens or hundreds of ledgers, and no atomic count-gate to catch drift between preview and apply. The new endpoint lets them issue one filtered bulk request. Spec v0.1.25.26 (merged to cycles-protocol `main` via PR #55) had already shipped the analogous endpoints for tenants and webhooks in server v0.1.25.26; budgets were the last gap.
+
+**Endpoint:** `POST /v1/admin/budgets/bulk-action` — AdminKeyAuth only. Body `BudgetBulkActionRequest`, success 200 `BudgetBulkActionResponse`. Errors: 400 (`INVALID_REQUEST` on validation, `LIMIT_EXCEEDED` when matched > 500), 409 (`COUNT_MISMATCH` when `expected_count` differs from server-counted matches).
+
+**Request shape:**
+
+| Field | Required | Notes |
+|---|---|---|
+| `filter.tenant_id` | yes | Cross-tenant bulk is explicitly out of scope per spec; `@NotBlank` at the DTO boundary. |
+| `filter.scope_prefix` / `unit` / `status` / `over_limit` / `has_debt` / `utilization_min` / `utilization_max` / `search` | no | Mirrors the `listBudgets` query params one-for-one. A preview via `listBudgets` and a bulk apply share the same match semantics — see "zero-drift matcher" below. |
+| `action` | yes | `FundingOperation` enum reused — values match spec exactly: `CREDIT`, `DEBIT`, `RESET`, `REPAY_DEBT`, `RESET_SPENT`. |
+| `amount` | yes, all 5 actions | Validation runs before the match phase so malformed combos never touch Redis. |
+| `spent` | only `RESET_SPENT` | 400 if present for any other action; 400 if negative. |
+| `reason` | no | Free-form, ≤512 chars. |
+| `expected_count` | no | Count-gate — if present and differs from matched size, 409 `COUNT_MISMATCH` with `details.total_matched`. |
+| `idempotency_key` | yes | 15-minute replay window via `IdempotencyStore` under the `budgets-bulk` namespace. |
+
+**Per-row outcome mapping** (spec row-level known codes, returned inside `failed[]` / `skipped[]`):
+
+| Row condition | Bucket | Outcome |
+|---|---|---|
+| `amount.unit != ledger.unit` — pre-check, no Lua round-trip | `failed` | `error_code=INVALID_TRANSITION`, `message="unit mismatch: expected <X>, got <Y>"` |
+| `action == REPAY_DEBT && ledger.debt == 0` — pre-check | `skipped` | `reason=ALREADY_IN_TARGET_STATE` |
+| `fund()` returns normally | `succeeded` | `id = ledger.ledger_id` (per spec `BudgetBulkActionResponse.succeeded` description) |
+| `fund()` throws `BUDGET_EXCEEDED` (DEBIT would take remaining negative) | `failed` | `error_code=BUDGET_EXCEEDED` |
+| `fund()` throws `BUDGET_FROZEN` / `BUDGET_CLOSED` / `INVALID_REQUEST` | `failed` | `error_code=INVALID_TRANSITION` |
+| `fund()` throws `BUDGET_NOT_FOUND` / `NOT_FOUND` (race) | `failed` | `error_code=NOT_FOUND` |
+| `fund()` throws `FORBIDDEN` / `INSUFFICIENT_PERMISSIONS` | `failed` | `error_code=PERMISSION_DENIED` |
+| Any other `GovernanceException` / `RuntimeException` | `failed` | `error_code=INTERNAL_ERROR` |
+
+**Safety semantics (identical to tenant/webhook bulk-action):**
+
+- **500-row hard cap.** `BudgetRepository.matchForBulk(tenantId, filters, cap)` fetches up to `cap + 1` ledgers; the +1 is the "this filter is too wide" sentinel that triggers `GovernanceException(LIMIT_EXCEEDED, 400, {total_matched})`. No writes on overflow.
+- **Idempotency, two layers.** The outer envelope is cached under `budgets-bulk:<key>` for 15 minutes — any replay within the window returns the cached envelope verbatim, no repo work. Each row also gets a **derived** key `<outerKey>:<scope>:<unit>` passed to `BudgetFundingRequest.idempotencyKey` so that if the filter is narrowed to the failed set after the envelope TTL expires, the Lua fund-idempotency cache short-circuits the already-applied rows.
+- **No cross-row rollback.** Partial completion is observable via the three-array envelope and is intentionally idempotent-retryable; Redis has no multi-key transaction across ledgers. HTTP status is **200 even when `failed[]` is non-empty** — envelope-level failure (4xx/5xx) is reserved for `LIMIT_EXCEEDED` / `COUNT_MISMATCH` / auth / infrastructure.
+- **Audit.** One `AuditLogEntry` per bulk-op, `operation="bulkActionBudgets"`, `resource_type="budget"`, `resource_id="bulk-action"`, `tenant_id=filter.tenant_id`. Metadata carries `action`, `total_matched`, `succeeded`, `failed`, `skipped`, `idempotency_key`. The synchronous response envelope remains the record-of-truth for per-row outcomes.
+
+**Zero-drift matcher.** The new `BudgetListFilters.fromBulkFilter(BudgetBulkFilter)` static factory drops the request-level `tenant_id` (that's applied as a tenant-scoped Redis walk, not a per-ledger predicate) and forwards every remaining dimension verbatim into the existing `BudgetListFilters.matches(BudgetLedger)` — the same matcher `listBudgets` uses. An operator's preview → bulk workflow therefore can never disagree on "what matches": whatever the listBudgets page shows is exactly what bulk-action will try to mutate (modulo races between the two calls, which the count-gate covers).
+
+**Per-file changes:**
+
+| File | Change |
+|---|---|
+| `cycles-admin-service/pom.xml` | `<revision>0.1.25.28</revision>` → `<revision>0.1.25.29</revision>` |
+| `docker-compose.prod.yml`, `docker-compose.full-stack.prod.yml` | Image tag `0.1.25.28` → `0.1.25.29` |
+| `.../model/budget/BudgetBulkFilter.java` | New DTO mirroring spec `BudgetBulkFilter` schema. `@NotBlank tenantId` + eight optional filter dimensions. `@JsonIgnoreProperties(ignoreUnknown = false)` enforces spec `additionalProperties: false`. |
+| `.../model/budget/BudgetBulkActionRequest.java` | New DTO. `action` reuses `FundingOperation` (no divergent enum). `@Valid` cascades into `filter` and `amount` / `spent`. |
+| `.../model/budget/BudgetBulkActionResponse.java` | New DTO. Three `BulkActionRowOutcome` lists + total_matched + echoed action & idempotency_key. |
+| `.../data/repository/BudgetListFilters.java` | `fromBulkFilter(BudgetBulkFilter)` static factory added. The adapter lives in the data module (not the model module) to avoid a model → data dependency inversion — `BudgetListFilters` already lives here and knows how to `matches(BudgetLedger)`. |
+| `.../data/repository/BudgetRepository.java` | `matchForBulk(String tenantId, BudgetListFilters filters, int cap)` walks `SMEMBERS budgets:<tenantId>`, hydrates each ledger, applies the filter, stops once `matched.size() > cap` (the +1 sentinel). Stale-index cleanup and parse-failure tolerance mirror the existing `list(...)` path. |
+| `.../api/controller/BudgetController.java` | New `@PostMapping("/bulk-action") @Operation(operationId = "bulkActionBudgets")` handler. Flow: `validateBulkActionPayload` → `parseSearch` → idempotency lookup → `matchForBulk(cap+1)` → LIMIT_EXCEEDED check → expected_count gate → per-row apply via `applyBudgetAction` → idempotency store → audit log. `classifyBudgetFailureCode` maps request-level `ErrorCode` to the row-level known-codes set. Constants: `BULK_ACTION_LIMIT = 500`, `BULK_IDEMPOTENCY_ENDPOINT = "budgets-bulk"`. |
+| `.../api/config/AuthInterceptor.java` | `requiresAdminKey` gains a branch for `POST /v1/admin/budgets/bulk-action`. Without this, the path would match the `/v1/admin/budgets` `requiresApiKey` prefix and a tenant API key would grant access — spec v0.1.25.26 makes this endpoint AdminKeyAuth only. The test `bulkAction_tenantKeyRejected_returns401` asserts this guard holds. |
+
+**Test coverage delta:**
+
+- `BudgetControllerBulkActionTest` (new, 27 tests) covers: happy path per action (CREDIT/DEBIT/RESET/REPAY_DEBT/RESET_SPENT), derived per-row idempotency key captured into `BudgetFundingRequest`, all per-row classifier branches (BUDGET_EXCEEDED / INVALID_TRANSITION for frozen and closed / NOT_FOUND / PERMISSION_DENIED / INTERNAL_ERROR for both `RuntimeException` and unknown `ErrorCode`), unit-mismatch pre-check, REPAY_DEBT-on-zero-debt skipped, envelope gates (LIMIT_EXCEEDED with 501-row mock, COUNT_MISMATCH with drift), validation 400s (missing amount, spent on non-RESET_SPENT, negative spent, missing tenant_id, utilization_min > utilization_max, missing idempotency_key, search > 128 chars), idempotency replay (cached envelope returned verbatim, zero repo work, zero audit writes), audit metadata assertions on all six keys, and auth (missing admin key → 401, tenant key → 401).
+- `BudgetRepositoryBulkMatchTest` (new, 14 tests) covers each filter dimension end-to-end against mocked Jedis (`scope_prefix`, `unit`, `status`, `over_limit`, `has_debt`, utilization range, `search`, empty filter, null filter), the cap+1 sentinel behavior, tenant isolation (the walk only reads `budgets:<requested-tenant>`), stale-index cleanup (empty hash → `SREM` then skip), and parse-failure tolerance (bad unit value → swallowed, next row still returned).
+- `OpenApiContractDiffTest` + `SpecCoverageReportTest` — both auto-detect `bulkActionBudgets` against spec v0.1.25.26 now that the implementation exists; no allowlist entry needed.
+
+**Verification:** `mvn -B -o test -pl cycles-admin-service-api -am -Dtest=BudgetControllerBulkActionTest` → 27/27 pass. `mvn -B -o test -pl cycles-admin-service-data -am -Dtest=BudgetRepositoryBulkMatchTest` → 14/14 pass. Full verify excluding IntegrationTest, plus contract tests, gate the PR.
+
+**Design decisions worth flagging:**
+
+- **Reused `FundingOperation` instead of introducing a `BudgetBulkAction` enum.** Spec says explicitly "mirrors BudgetFundingRequest.operation"; divergent enums would require a translator and rot on future spec changes.
+- **No new `ErrorCode` enum values.** The spec v0.1.25.26 review-round distinguishes row-level known-codes (free-form string returned inside `BulkActionRowOutcome.error_code`, never surfaced as envelope-level `ErrorCode`) from request-level `ErrorCode` (already has `COUNT_MISMATCH`, `LIMIT_EXCEEDED`, `BUDGET_EXCEEDED`).
+- **Adapter lives in the data module.** `BudgetListFilters.fromBulkFilter(BudgetBulkFilter)` was placed in `BudgetListFilters` (data module) rather than as `BudgetBulkFilter.toListFilters()` (model module) to preserve the one-way model → data dependency; the model layer does not know about the matcher.
+- **Out of scope (per spec + plan).** Cross-tenant bulk (tenant_id is `@NotBlank`), async / long-running bulk (500-row synchronous cap suffices for rollover workloads), CSV export of per-row outcomes (JSON envelope covers the need; revisit if compliance asks), bulk-action for non-`FundingOperation` actions.
+
+---
 
 ### 2026-04-17 — v0.1.25.28 audit tenant_id sentinel split (spec v0.1.25.25)
 

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/config/AuthInterceptor.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/config/AuthInterceptor.java
@@ -206,6 +206,10 @@ public class AuthInterceptor implements HandlerInterceptor {
                                        path.startsWith("/v1/admin/budgets/unfreeze"))) {
             return true;
         }
+        // POST /v1/admin/budgets/bulk-action requires AdminKeyAuth per spec v0.1.25.26
+        if ("POST".equals(method) && path.startsWith("/v1/admin/budgets/bulk-action")) {
+            return true;
+        }
         return false;
     }
 

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/BudgetController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/BudgetController.java
@@ -1,10 +1,12 @@
 package io.runcycles.admin.api.controller;
 import io.runcycles.admin.data.exception.GovernanceException;
+import io.runcycles.admin.data.idempotency.IdempotencyStore;
 import io.runcycles.admin.data.repository.AuditRepository;
 import io.runcycles.admin.data.repository.BudgetListFilters;
 import io.runcycles.admin.data.repository.BudgetRepository;
 import io.runcycles.admin.model.audit.AuditLogEntry;
 import io.runcycles.admin.model.budget.*;
+import io.runcycles.admin.model.shared.BulkActionRowOutcome;
 import io.runcycles.admin.model.shared.ErrorCode;
 import io.runcycles.admin.model.shared.SearchSpec;
 import io.runcycles.admin.model.shared.SortDirection;
@@ -24,6 +26,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -39,10 +42,18 @@ public class BudgetController {
         "tenant_id", "scope", "unit", "status", "commit_overage_policy",
         "utilization", "debt");
     private static final String DEFAULT_SORT_FIELD = "utilization";
+    // Bulk-action (spec v0.1.25.26): 500-row hard cap per invocation and
+    // 15-minute idempotency replay window. The idempotency endpoint tag
+    // "budgets-bulk" partitions this store from tenant / webhook bulk-ops
+    // so operator-supplied keys cannot collide across endpoints.
+    private static final int BULK_ACTION_LIMIT = 500;
+    private static final String BULK_IDEMPOTENCY_ENDPOINT = "budgets-bulk";
+
     @Autowired private BudgetRepository repository;
     @Autowired private AuditRepository auditRepository;
     @Autowired private EventService eventService;
     @Autowired private ObjectMapper objectMapper;
+    @Autowired private IdempotencyStore idempotencyStore;
     @PostMapping @Operation(operationId = "createBudget")
     public ResponseEntity<BudgetLedger> create(@Valid @RequestBody BudgetCreateRequest request, HttpServletRequest httpRequest) {
         validateCreateUnits(request);
@@ -412,6 +423,222 @@ public class BudgetController {
             LOG.warn("Failed to emit event: {}", e.getMessage());
         }
         return ResponseEntity.ok(ledger);
+    }
+
+    // ========== POST /v1/admin/budgets/bulk-action ==========
+
+    /**
+     * Apply one of the five {@link FundingOperation} actions to every
+     * budget ledger matching the filter, in a single synchronous request
+     * (spec v0.1.25.26). Resolves cycles-server-admin issue #99 — rolling
+     * over a billing period no longer requires the operator to iterate
+     * listBudgets + per-row fundBudget; they issue one filtered bulk
+     * request.
+     *
+     * <p>Body shape, envelope semantics, safety gates, and per-row outcome
+     * reporting mirror {@code bulkActionTenants} and {@code bulkActionWebhooks}:
+     * <ul>
+     *   <li>500-row hard cap → LIMIT_EXCEEDED (400).</li>
+     *   <li>{@code expected_count} mismatch → COUNT_MISMATCH (409), no writes.</li>
+     *   <li>15-minute {@code idempotency_key} replay window.</li>
+     *   <li>Overall HTTP 200 even when per-row failures land in {@code failed[]}.</li>
+     * </ul>
+     * AdminKeyAuth only (tenants cannot bulk-mutate their own budgets
+     * — the per-budget {@code fundBudget} endpoint remains available).
+     */
+    @PostMapping("/bulk-action") @Operation(operationId = "bulkActionBudgets")
+    public ResponseEntity<BudgetBulkActionResponse> bulkAction(
+            @Valid @RequestBody BudgetBulkActionRequest request, HttpServletRequest httpRequest) {
+        // Action/payload validation runs BEFORE any Redis read so that
+        // malformed combos fail fast with 400 and never enter the match /
+        // apply path (spec requirement).
+        validateBulkActionPayload(request);
+        String searchNorm = parseSearch(request.getFilter().getSearch());
+        BudgetBulkFilter filter = request.getFilter();
+        filter.setSearch(searchNorm);
+
+        var cached = idempotencyStore.lookup(
+            BULK_IDEMPOTENCY_ENDPOINT, request.getIdempotencyKey(),
+            BudgetBulkActionResponse.class);
+        if (cached.isPresent()) {
+            return ResponseEntity.ok(cached.get());
+        }
+
+        // Fetch up to cap+1 so size > cap is detectable without hydrating
+        // the remainder. The +1 is the "this filter is too wide" sentinel.
+        List<BudgetLedger> matched = repository.matchForBulk(
+            filter.getTenantId(),
+            BudgetListFilters.fromBulkFilter(filter),
+            BULK_ACTION_LIMIT);
+        if (matched.size() > BULK_ACTION_LIMIT) {
+            throw new GovernanceException(ErrorCode.LIMIT_EXCEEDED,
+                "filter matches more than " + BULK_ACTION_LIMIT
+                    + " budgets; narrow the filter and retry",
+                400,
+                Map.of("total_matched", matched.size()));
+        }
+        if (request.getExpectedCount() != null && request.getExpectedCount() != matched.size()) {
+            throw new GovernanceException(ErrorCode.COUNT_MISMATCH,
+                "expected_count " + request.getExpectedCount()
+                    + " differs from server-counted matches " + matched.size(),
+                409,
+                Map.of("total_matched", matched.size()));
+        }
+
+        List<BulkActionRowOutcome> succeeded = new ArrayList<>();
+        List<BulkActionRowOutcome> failed = new ArrayList<>();
+        List<BulkActionRowOutcome> skipped = new ArrayList<>();
+        for (BudgetLedger ledger : matched) {
+            applyBudgetAction(ledger, request, succeeded, failed, skipped);
+        }
+
+        BudgetBulkActionResponse response = BudgetBulkActionResponse.builder()
+            .action(request.getAction())
+            .totalMatched(matched.size())
+            .succeeded(succeeded)
+            .failed(failed)
+            .skipped(skipped)
+            .idempotencyKey(request.getIdempotencyKey())
+            .build();
+
+        idempotencyStore.store(BULK_IDEMPOTENCY_ENDPOINT, request.getIdempotencyKey(), response);
+
+        Map<String, Object> auditMeta = new java.util.LinkedHashMap<>();
+        auditMeta.put("action", request.getAction().name());
+        auditMeta.put("total_matched", matched.size());
+        auditMeta.put("succeeded", succeeded.size());
+        auditMeta.put("failed", failed.size());
+        auditMeta.put("skipped", skipped.size());
+        auditMeta.put("idempotency_key", request.getIdempotencyKey());
+        auditRepository.log(buildAuditEntry(httpRequest)
+            .tenantId(filter.getTenantId())
+            .resourceType("budget").resourceId("bulk-action")
+            .operation("bulkActionBudgets").status(200)
+            .metadata(auditMeta)
+            .build());
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Envelope-level validation — catches every invalid action/payload
+     * combination before the match phase so no Redis work is wasted on a
+     * malformed request. Per spec v0.1.25.26: every one of the five
+     * actions (CREDIT, DEBIT, RESET, REPAY_DEBT, RESET_SPENT) requires
+     * {@code amount}; {@code spent} is honoured only for RESET_SPENT and
+     * must be non-negative when present; {@code utilization_min} cannot
+     * exceed {@code utilization_max}.
+     */
+    private void validateBulkActionPayload(BudgetBulkActionRequest request) {
+        if (request.getAmount() == null) {
+            throw new GovernanceException(ErrorCode.INVALID_REQUEST,
+                "amount is required for bulk action " + request.getAction().name(), 400);
+        }
+        if (request.getAction() != FundingOperation.RESET_SPENT && request.getSpent() != null) {
+            throw new GovernanceException(ErrorCode.INVALID_REQUEST,
+                "spent is only honoured when action is RESET_SPENT", 400);
+        }
+        if (request.getSpent() != null && request.getSpent().getAmount() < 0L) {
+            throw new GovernanceException(ErrorCode.INVALID_REQUEST,
+                "spent must be >= 0", 400);
+        }
+        BudgetBulkFilter f = request.getFilter();
+        if (f.getUtilizationMin() != null && f.getUtilizationMax() != null
+                && f.getUtilizationMin() > f.getUtilizationMax()) {
+            throw new GovernanceException(ErrorCode.INVALID_REQUEST,
+                "utilization_min must be <= utilization_max", 400);
+        }
+    }
+
+    /**
+     * Apply one row of the bulk-action and bucket the outcome. Per-row
+     * failures never abort the loop — each matched ledger is attempted.
+     *
+     * <p>Pre-checks run before invoking {@link BudgetRepository#fund} so
+     * the spec-mandated row-level error codes (INVALID_TRANSITION for
+     * unit mismatch, ALREADY_IN_TARGET_STATE for REPAY_DEBT on zero debt)
+     * are surfaced without a wasted Lua round-trip.
+     *
+     * <p>Row-level idempotency: a derived key {@code bulkKey:scope:unit}
+     * is passed to fund() so that a network retry which re-enters this
+     * loop will short-circuit at the atomic Lua idempotency check in
+     * {@code BudgetRepository}, preventing double-application of
+     * CREDIT/DEBIT/etc. The outer bulk-op idempotency ({@code IdempotencyStore})
+     * handles the envelope-level replay within 15 minutes; the per-row
+     * derived key handles the rarer "client narrowed the filter to
+     * the previously-failed set and retried after the envelope TTL
+     * expired" case.
+     */
+    private void applyBudgetAction(BudgetLedger ledger, BudgetBulkActionRequest bulk,
+                                    List<BulkActionRowOutcome> succeeded,
+                                    List<BulkActionRowOutcome> failed,
+                                    List<BulkActionRowOutcome> skipped) {
+        // Spec v0.1.25.26 BudgetBulkActionResponse.succeeded: "Per-row `id`
+        // is the ledger_id." The ledger_id is the stable unique identifier;
+        // scope is the routing/matching key passed to fund().
+        String id = ledger.getLedgerId();
+        if (bulk.getAmount().getUnit() != ledger.getUnit()) {
+            failed.add(BulkActionRowOutcome.builder()
+                .id(id).errorCode("INVALID_TRANSITION")
+                .message("unit mismatch: expected " + ledger.getUnit()
+                    + ", got " + bulk.getAmount().getUnit()).build());
+            return;
+        }
+        if (bulk.getAction() == FundingOperation.REPAY_DEBT) {
+            long debtAmount = ledger.getDebt() != null ? ledger.getDebt().getAmount() : 0L;
+            if (debtAmount == 0L) {
+                skipped.add(BulkActionRowOutcome.builder()
+                    .id(id).reason("ALREADY_IN_TARGET_STATE").build());
+                return;
+            }
+        }
+        BudgetFundingRequest fundingRequest = new BudgetFundingRequest();
+        fundingRequest.setOperation(bulk.getAction());
+        fundingRequest.setAmount(bulk.getAmount());
+        fundingRequest.setSpent(bulk.getSpent());
+        fundingRequest.setReason(bulk.getReason());
+        fundingRequest.setIdempotencyKey(bulk.getIdempotencyKey()
+            + ":" + ledger.getScope() + ":" + ledger.getUnit().name());
+        try {
+            repository.fund(ledger.getTenantId(), ledger.getScope(), ledger.getUnit(), fundingRequest);
+            succeeded.add(BulkActionRowOutcome.builder().id(id).build());
+        } catch (GovernanceException e) {
+            failed.add(BulkActionRowOutcome.builder()
+                .id(id)
+                .errorCode(classifyBudgetFailureCode(e))
+                .message(e.getMessage()).build());
+        } catch (Exception e) {
+            LOG.warn("Bulk-action row failed for budget {}: {}", id, e.getMessage());
+            failed.add(BulkActionRowOutcome.builder()
+                .id(id).errorCode("INTERNAL_ERROR").message("Internal error").build());
+        }
+    }
+
+    /**
+     * Maps request-level {@link ErrorCode} values raised by
+     * {@link BudgetRepository#fund} into the row-level known-codes set
+     * documented by spec v0.1.25.26 for {@link BulkActionRowOutcome#getErrorCode}.
+     * BUDGET_EXCEEDED covers the DEBIT-goes-negative case; INVALID_TRANSITION
+     * is the umbrella for ledger-state rejections (frozen / closed / invalid
+     * request shape); everything else falls into INTERNAL_ERROR so clients
+     * never see an unknown code.
+     */
+    private static String classifyBudgetFailureCode(GovernanceException e) {
+        switch (e.getErrorCode()) {
+            case BUDGET_EXCEEDED:
+                return "BUDGET_EXCEEDED";
+            case BUDGET_FROZEN:
+            case BUDGET_CLOSED:
+            case INVALID_REQUEST:
+                return "INVALID_TRANSITION";
+            case BUDGET_NOT_FOUND:
+            case NOT_FOUND:
+                return "NOT_FOUND";
+            case FORBIDDEN:
+            case INSUFFICIENT_PERMISSIONS:
+                return "PERMISSION_DENIED";
+            default:
+                return "INTERNAL_ERROR";
+        }
     }
 
     private void validateCreateUnits(BudgetCreateRequest request) {

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BudgetControllerBulkActionTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BudgetControllerBulkActionTest.java
@@ -1,0 +1,602 @@
+package io.runcycles.admin.api.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.runcycles.admin.api.contract.ContractValidationConfig;
+import io.runcycles.admin.api.service.EventService;
+import io.runcycles.admin.api.support.MetricsTestConfiguration;
+import io.runcycles.admin.data.exception.GovernanceException;
+import io.runcycles.admin.data.idempotency.IdempotencyStore;
+import io.runcycles.admin.data.repository.ApiKeyRepository;
+import io.runcycles.admin.data.repository.AuditRepository;
+import io.runcycles.admin.data.repository.BudgetListFilters;
+import io.runcycles.admin.data.repository.BudgetRepository;
+import io.runcycles.admin.model.audit.AuditLogEntry;
+import io.runcycles.admin.model.auth.ApiKeyValidationResponse;
+import io.runcycles.admin.model.budget.BudgetBulkActionResponse;
+import io.runcycles.admin.model.budget.BudgetFundingRequest;
+import io.runcycles.admin.model.budget.BudgetLedger;
+import io.runcycles.admin.model.budget.BudgetStatus;
+import io.runcycles.admin.model.budget.FundingOperation;
+import io.runcycles.admin.model.shared.Amount;
+import io.runcycles.admin.model.shared.BulkActionRowOutcome;
+import io.runcycles.admin.model.shared.ErrorCode;
+import io.runcycles.admin.model.shared.UnitEnum;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import redis.clients.jedis.JedisPool;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Contract tests for {@code POST /v1/admin/budgets/bulk-action} (spec
+ * v0.1.25.26). Covers the envelope flow end-to-end under the controller
+ * layer — happy paths per action, all three row-outcome buckets, the
+ * four envelope-level 4xx gates (validation 400s, COUNT_MISMATCH 409,
+ * LIMIT_EXCEEDED 400), idempotency replay, per-row classifier mapping,
+ * audit metadata, and auth enforcement.
+ */
+@WebMvcTest(BudgetController.class)
+@Import({MetricsTestConfiguration.class, ContractValidationConfig.class})
+class BudgetControllerBulkActionTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @MockitoBean private BudgetRepository budgetRepository;
+    @MockitoBean private AuditRepository auditRepository;
+    @MockitoBean private ApiKeyRepository apiKeyRepository;
+    @MockitoBean private JedisPool jedisPool;
+    @MockitoBean private EventService eventService;
+    @MockitoBean private IdempotencyStore idempotencyStore;
+
+    private static final String ADMIN_KEY = "test-admin-key";
+    private static final String TENANT = "acme";
+    private static final String BULK_NS = "budgets-bulk";
+
+    private static BudgetLedger ledger(String scope, long allocated, long spent, Long debt) {
+        BudgetLedger.BudgetLedgerBuilder b = BudgetLedger.builder()
+                .ledgerId("led-" + scope).tenantId(TENANT)
+                .scope(scope).unit(UnitEnum.USD_MICROCENTS)
+                .allocated(new Amount(UnitEnum.USD_MICROCENTS, allocated))
+                .spent(new Amount(UnitEnum.USD_MICROCENTS, spent))
+                .remaining(new Amount(UnitEnum.USD_MICROCENTS, allocated - spent))
+                .status(BudgetStatus.ACTIVE);
+        if (debt != null) b.debt(new Amount(UnitEnum.USD_MICROCENTS, debt));
+        return b.build();
+    }
+
+    private static BudgetLedger ledger(String scope) {
+        return ledger(scope, 1_000_000L, 0L, 0L);
+    }
+
+    private static String body(String filterJson, String actionBlock, String idemKey, String extra) {
+        StringBuilder sb = new StringBuilder("{\"filter\":").append(filterJson)
+                .append(",\"action\":\"").append(actionBlock).append("\"");
+        if (extra != null && !extra.isEmpty()) sb.append(",").append(extra);
+        sb.append(",\"idempotency_key\":\"").append(idemKey).append("\"}");
+        return sb.toString();
+    }
+
+    private static String filter(String extras) {
+        String base = "{\"tenant_id\":\"" + TENANT + "\"";
+        if (extras != null && !extras.isEmpty()) base += "," + extras;
+        return base + "}";
+    }
+
+    private void noReplay() {
+        when(idempotencyStore.lookup(eq(BULK_NS), anyString(), eq(BudgetBulkActionResponse.class)))
+                .thenReturn(Optional.empty());
+    }
+
+    // -------- Happy paths: one per FundingOperation ---------------------
+
+    @Test
+    void bulkAction_credit_happyPath_returns200_withSucceededRow() throws Exception {
+        noReplay();
+        when(budgetRepository.matchForBulk(eq(TENANT), any(BudgetListFilters.class), eq(500)))
+                .thenReturn(List.of(ledger("tenant:acme/workspace:eng")));
+
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter(""), "CREDIT", "k1",
+                                "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":500}")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.action").value("CREDIT"))
+                .andExpect(jsonPath("$.total_matched").value(1))
+                .andExpect(jsonPath("$.succeeded.length()").value(1))
+                .andExpect(jsonPath("$.succeeded[0].id").value("led-tenant:acme/workspace:eng"))
+                .andExpect(jsonPath("$.failed.length()").value(0))
+                .andExpect(jsonPath("$.skipped.length()").value(0))
+                .andExpect(jsonPath("$.idempotency_key").value("k1"));
+
+        ArgumentCaptor<BudgetFundingRequest> fundArg = ArgumentCaptor.forClass(BudgetFundingRequest.class);
+        verify(budgetRepository).fund(eq(TENANT), eq("tenant:acme/workspace:eng"),
+                eq(UnitEnum.USD_MICROCENTS), fundArg.capture());
+        // derived per-row idempotency key = bulkKey:scope:unit
+        assertEquals("k1:tenant:acme/workspace:eng:USD_MICROCENTS",
+                fundArg.getValue().getIdempotencyKey());
+        assertEquals(FundingOperation.CREDIT, fundArg.getValue().getOperation());
+        verify(idempotencyStore).store(eq(BULK_NS), eq("k1"), any(BudgetBulkActionResponse.class));
+    }
+
+    @Test
+    void bulkAction_debit_happyPath_returns200() throws Exception {
+        noReplay();
+        when(budgetRepository.matchForBulk(eq(TENANT), any(BudgetListFilters.class), eq(500)))
+                .thenReturn(List.of(ledger("tenant:acme/workspace:eng", 1_000L, 100L, 0L)));
+
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter(""), "DEBIT", "k1",
+                                "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":100}")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.action").value("DEBIT"))
+                .andExpect(jsonPath("$.succeeded.length()").value(1));
+    }
+
+    @Test
+    void bulkAction_reset_happyPath_returns200() throws Exception {
+        noReplay();
+        when(budgetRepository.matchForBulk(eq(TENANT), any(BudgetListFilters.class), eq(500)))
+                .thenReturn(List.of(ledger("tenant:acme/workspace:eng")));
+
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter(""), "RESET", "k1",
+                                "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":1000000}")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.action").value("RESET"))
+                .andExpect(jsonPath("$.succeeded.length()").value(1));
+    }
+
+    @Test
+    void bulkAction_repayDebt_happyPath_returns200() throws Exception {
+        noReplay();
+        when(budgetRepository.matchForBulk(eq(TENANT), any(BudgetListFilters.class), eq(500)))
+                .thenReturn(List.of(ledger("tenant:acme/workspace:eng", 1_000L, 0L, 250L)));
+
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter(""), "REPAY_DEBT", "k1",
+                                "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":250}")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.action").value("REPAY_DEBT"))
+                .andExpect(jsonPath("$.succeeded.length()").value(1));
+    }
+
+    @Test
+    void bulkAction_resetSpent_happyPath_returns200_withSpentPayload() throws Exception {
+        noReplay();
+        when(budgetRepository.matchForBulk(eq(TENANT), any(BudgetListFilters.class), eq(500)))
+                .thenReturn(List.of(ledger("tenant:acme/workspace:eng", 1_000L, 500L, 0L)));
+
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter(""), "RESET_SPENT", "k1",
+                                "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":1000},"
+                                        + "\"spent\":{\"unit\":\"USD_MICROCENTS\",\"amount\":0}")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.action").value("RESET_SPENT"))
+                .andExpect(jsonPath("$.succeeded.length()").value(1));
+
+        ArgumentCaptor<BudgetFundingRequest> fundArg = ArgumentCaptor.forClass(BudgetFundingRequest.class);
+        verify(budgetRepository).fund(eq(TENANT), anyString(), eq(UnitEnum.USD_MICROCENTS), fundArg.capture());
+        assertEquals(0L, fundArg.getValue().getSpent().getAmount());
+    }
+
+    // -------- Per-row classification ------------------------------------
+
+    @Test
+    void bulkAction_unitMismatch_landsInFailed_INVALID_TRANSITION() throws Exception {
+        noReplay();
+        BudgetLedger row = BudgetLedger.builder()
+                .ledgerId("led-a").tenantId(TENANT).scope("tenant:acme/workspace:eu")
+                .unit(UnitEnum.TOKENS)
+                .allocated(new Amount(UnitEnum.TOKENS, 1000L))
+                .status(BudgetStatus.ACTIVE).build();
+        when(budgetRepository.matchForBulk(eq(TENANT), any(BudgetListFilters.class), eq(500)))
+                .thenReturn(List.of(row));
+
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter(""), "CREDIT", "k1",
+                                "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":500}")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.failed.length()").value(1))
+                .andExpect(jsonPath("$.failed[0].id").value("led-a"))
+                .andExpect(jsonPath("$.failed[0].error_code").value("INVALID_TRANSITION"))
+                .andExpect(jsonPath("$.failed[0].message",
+                        org.hamcrest.Matchers.containsString("unit mismatch")));
+
+        verify(budgetRepository, never()).fund(anyString(), anyString(), any(), any());
+    }
+
+    @Test
+    void bulkAction_repayDebtOnZeroDebt_landsInSkipped_ALREADY_IN_TARGET_STATE() throws Exception {
+        noReplay();
+        when(budgetRepository.matchForBulk(eq(TENANT), any(BudgetListFilters.class), eq(500)))
+                .thenReturn(List.of(ledger("tenant:acme/workspace:eng", 1_000L, 0L, 0L)));
+
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter(""), "REPAY_DEBT", "k1",
+                                "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":100}")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.skipped.length()").value(1))
+                .andExpect(jsonPath("$.skipped[0].id").value("led-tenant:acme/workspace:eng"))
+                .andExpect(jsonPath("$.skipped[0].reason").value("ALREADY_IN_TARGET_STATE"))
+                .andExpect(jsonPath("$.succeeded.length()").value(0));
+
+        verify(budgetRepository, never()).fund(anyString(), anyString(), any(), any());
+    }
+
+    @Test
+    void bulkAction_debitIntoNegative_landsInFailed_BUDGET_EXCEEDED() throws Exception {
+        noReplay();
+        when(budgetRepository.matchForBulk(eq(TENANT), any(BudgetListFilters.class), eq(500)))
+                .thenReturn(List.of(ledger("tenant:acme/workspace:eng", 100L, 50L, 0L)));
+        when(budgetRepository.fund(eq(TENANT), anyString(), any(), any()))
+                .thenThrow(GovernanceException.insufficientFunds("tenant:acme/workspace:eng"));
+
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter(""), "DEBIT", "k1",
+                                "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":1000}")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.failed.length()").value(1))
+                .andExpect(jsonPath("$.failed[0].error_code").value("BUDGET_EXCEEDED"));
+    }
+
+    @Test
+    void bulkAction_frozenLedger_landsInFailed_INVALID_TRANSITION() throws Exception {
+        noReplay();
+        when(budgetRepository.matchForBulk(eq(TENANT), any(BudgetListFilters.class), eq(500)))
+                .thenReturn(List.of(ledger("tenant:acme/workspace:eng")));
+        when(budgetRepository.fund(eq(TENANT), anyString(), any(), any()))
+                .thenThrow(new GovernanceException(ErrorCode.BUDGET_FROZEN,
+                        "Budget is frozen: tenant:acme/workspace:eng", 409));
+
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter(""), "CREDIT", "k1",
+                                "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":500}")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.failed[0].error_code").value("INVALID_TRANSITION"));
+    }
+
+    @Test
+    void bulkAction_closedLedger_landsInFailed_INVALID_TRANSITION() throws Exception {
+        noReplay();
+        when(budgetRepository.matchForBulk(eq(TENANT), any(BudgetListFilters.class), eq(500)))
+                .thenReturn(List.of(ledger("tenant:acme/workspace:eng")));
+        when(budgetRepository.fund(eq(TENANT), anyString(), any(), any()))
+                .thenThrow(new GovernanceException(ErrorCode.BUDGET_CLOSED,
+                        "Budget is closed", 409));
+
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter(""), "CREDIT", "k1",
+                                "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":500}")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.failed[0].error_code").value("INVALID_TRANSITION"));
+    }
+
+    @Test
+    void bulkAction_ledgerRaceDeleted_landsInFailed_NOT_FOUND() throws Exception {
+        noReplay();
+        when(budgetRepository.matchForBulk(eq(TENANT), any(BudgetListFilters.class), eq(500)))
+                .thenReturn(List.of(ledger("tenant:acme/workspace:eng")));
+        when(budgetRepository.fund(eq(TENANT), anyString(), any(), any()))
+                .thenThrow(new GovernanceException(ErrorCode.BUDGET_NOT_FOUND, "gone", 404));
+
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter(""), "CREDIT", "k1",
+                                "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":500}")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.failed[0].error_code").value("NOT_FOUND"));
+    }
+
+    @Test
+    void bulkAction_permissionDenied_classifiedAsPERMISSION_DENIED() throws Exception {
+        noReplay();
+        when(budgetRepository.matchForBulk(eq(TENANT), any(BudgetListFilters.class), eq(500)))
+                .thenReturn(List.of(ledger("tenant:acme/workspace:eng")));
+        when(budgetRepository.fund(eq(TENANT), anyString(), any(), any()))
+                .thenThrow(new GovernanceException(ErrorCode.INSUFFICIENT_PERMISSIONS, "denied", 403));
+
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter(""), "CREDIT", "k1",
+                                "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":500}")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.failed[0].error_code").value("PERMISSION_DENIED"));
+    }
+
+    @Test
+    void bulkAction_genericRuntimeException_classifiedAsINTERNAL_ERROR() throws Exception {
+        noReplay();
+        when(budgetRepository.matchForBulk(eq(TENANT), any(BudgetListFilters.class), eq(500)))
+                .thenReturn(List.of(ledger("tenant:acme/workspace:eng")));
+        when(budgetRepository.fund(eq(TENANT), anyString(), any(), any()))
+                .thenThrow(new RuntimeException("redis-down"));
+
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter(""), "CREDIT", "k1",
+                                "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":500}")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.failed[0].error_code").value("INTERNAL_ERROR"));
+    }
+
+    @Test
+    void bulkAction_unknownGovernanceErrorCode_classifiedAsINTERNAL_ERROR() throws Exception {
+        noReplay();
+        when(budgetRepository.matchForBulk(eq(TENANT), any(BudgetListFilters.class), eq(500)))
+                .thenReturn(List.of(ledger("tenant:acme/workspace:eng")));
+        // ErrorCode not in the classifier switch → default branch
+        when(budgetRepository.fund(eq(TENANT), anyString(), any(), any()))
+                .thenThrow(new GovernanceException(ErrorCode.INTERNAL_ERROR, "boom", 500));
+
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter(""), "CREDIT", "k1",
+                                "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":500}")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.failed[0].error_code").value("INTERNAL_ERROR"));
+    }
+
+    // -------- Envelope gates: LIMIT_EXCEEDED, COUNT_MISMATCH, validation -
+
+    @Test
+    void bulkAction_over500Matches_returns400_LIMIT_EXCEEDED_noWrites() throws Exception {
+        noReplay();
+        List<BudgetLedger> oversized = new ArrayList<>();
+        for (int i = 0; i < 501; i++) oversized.add(ledger("tenant:acme/workspace:s" + i));
+        when(budgetRepository.matchForBulk(eq(TENANT), any(BudgetListFilters.class), eq(500)))
+                .thenReturn(oversized);
+
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter(""), "CREDIT", "k1",
+                                "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":500}")))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("LIMIT_EXCEEDED"))
+                .andExpect(jsonPath("$.details.total_matched").value(501));
+
+        verify(budgetRepository, never()).fund(anyString(), anyString(), any(), any());
+        verify(idempotencyStore, never()).store(anyString(), anyString(), any());
+    }
+
+    @Test
+    void bulkAction_expectedCountMismatch_returns409_COUNT_MISMATCH_noWrites() throws Exception {
+        noReplay();
+        when(budgetRepository.matchForBulk(eq(TENANT), any(BudgetListFilters.class), eq(500)))
+                .thenReturn(List.of(ledger("tenant:acme/workspace:a"), ledger("tenant:acme/workspace:b")));
+
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter(""), "CREDIT", "k1",
+                                "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":500},"
+                                        + "\"expected_count\":5")))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error").value("COUNT_MISMATCH"))
+                .andExpect(jsonPath("$.details.total_matched").value(2));
+
+        verify(budgetRepository, never()).fund(anyString(), anyString(), any(), any());
+        verify(idempotencyStore, never()).store(anyString(), anyString(), any());
+    }
+
+    @Test
+    void bulkAction_missingAmount_returns400() throws Exception {
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter(""), "CREDIT", "k1", null)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("INVALID_REQUEST"));
+
+        verify(budgetRepository, never()).matchForBulk(anyString(), any(), anyInt());
+    }
+
+    @Test
+    void bulkAction_spentOnNonResetSpentAction_returns400() throws Exception {
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter(""), "CREDIT", "k1",
+                                "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":500},"
+                                        + "\"spent\":{\"unit\":\"USD_MICROCENTS\",\"amount\":0}")))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("INVALID_REQUEST"));
+    }
+
+    @Test
+    void bulkAction_resetSpentWithNegativeSpent_returns400() throws Exception {
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter(""), "RESET_SPENT", "k1",
+                                "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":1000},"
+                                        + "\"spent\":{\"unit\":\"USD_MICROCENTS\",\"amount\":-1}")))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("INVALID_REQUEST"));
+    }
+
+    @Test
+    void bulkAction_missingTenantId_returns400() throws Exception {
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"filter\":{},\"action\":\"CREDIT\","
+                                + "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":500},"
+                                + "\"idempotency_key\":\"k1\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("INVALID_REQUEST"));
+
+        verify(budgetRepository, never()).matchForBulk(anyString(), any(), anyInt());
+    }
+
+    @Test
+    void bulkAction_utilizationMinGreaterThanMax_returns400() throws Exception {
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter("\"utilization_min\":0.9,\"utilization_max\":0.1"),
+                                "CREDIT", "k1",
+                                "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":500}")))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("INVALID_REQUEST"));
+
+        verify(budgetRepository, never()).matchForBulk(anyString(), any(), anyInt());
+    }
+
+    @Test
+    void bulkAction_missingIdempotencyKey_returns400() throws Exception {
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"filter\":" + filter("") + ",\"action\":\"CREDIT\","
+                                + "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":500}}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("INVALID_REQUEST"));
+    }
+
+    @Test
+    void bulkAction_searchOver128Chars_returns400() throws Exception {
+        String over = "x".repeat(129);
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter("\"search\":\"" + over + "\""),
+                                "CREDIT", "k1",
+                                "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":500}")))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("INVALID_REQUEST"));
+
+        verify(budgetRepository, never()).matchForBulk(anyString(), any(), anyInt());
+    }
+
+    // -------- Idempotency replay ----------------------------------------
+
+    @Test
+    void bulkAction_idempotencyReplay_returnsCachedEnvelope_noRepoWork() throws Exception {
+        BudgetBulkActionResponse cached = BudgetBulkActionResponse.builder()
+                .action(FundingOperation.CREDIT)
+                .totalMatched(3)
+                .succeeded(List.of(BulkActionRowOutcome.builder().id("s1").build()))
+                .failed(List.of())
+                .skipped(List.of())
+                .idempotencyKey("k1")
+                .build();
+        when(idempotencyStore.lookup(eq(BULK_NS), eq("k1"), eq(BudgetBulkActionResponse.class)))
+                .thenReturn(Optional.of(cached));
+
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter(""), "CREDIT", "k1",
+                                "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":500}")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total_matched").value(3))
+                .andExpect(jsonPath("$.succeeded[0].id").value("s1"));
+
+        verify(budgetRepository, never()).matchForBulk(anyString(), any(), anyInt());
+        verify(budgetRepository, never()).fund(anyString(), anyString(), any(), any());
+        verify(idempotencyStore, never()).store(anyString(), anyString(), any());
+        verify(auditRepository, never()).log(any());
+    }
+
+    // -------- Audit metadata --------------------------------------------
+
+    @Test
+    void bulkAction_emitsAuditLogEntryWithMetadataKeys() throws Exception {
+        noReplay();
+        when(budgetRepository.matchForBulk(eq(TENANT), any(BudgetListFilters.class), eq(500)))
+                .thenReturn(List.of(ledger("tenant:acme/workspace:eng")));
+
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter(""), "CREDIT", "k1",
+                                "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":500}")))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<AuditLogEntry> auditArg = ArgumentCaptor.forClass(AuditLogEntry.class);
+        verify(auditRepository).log(auditArg.capture());
+        AuditLogEntry entry = auditArg.getValue();
+        assertEquals("bulkActionBudgets", entry.getOperation());
+        assertEquals("budget", entry.getResourceType());
+        assertEquals("bulk-action", entry.getResourceId());
+        assertEquals(TENANT, entry.getTenantId());
+        assertEquals("CREDIT", entry.getMetadata().get("action"));
+        assertEquals(1, entry.getMetadata().get("total_matched"));
+        assertEquals(1, entry.getMetadata().get("succeeded"));
+        assertEquals(0, entry.getMetadata().get("failed"));
+        assertEquals(0, entry.getMetadata().get("skipped"));
+        assertEquals("k1", entry.getMetadata().get("idempotency_key"));
+    }
+
+    // -------- Auth ------------------------------------------------------
+
+    @Test
+    void bulkAction_noAdminKey_returns401() throws Exception {
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter(""), "CREDIT", "k1",
+                                "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":500}")))
+                .andExpect(status().isUnauthorized());
+
+        verify(budgetRepository, never()).matchForBulk(anyString(), any(), anyInt());
+    }
+
+    @Test
+    void bulkAction_tenantKeyRejected_returns401() throws Exception {
+        // Spec v0.1.25.26: AdminKeyAuth only. Tenant API key header must not
+        // grant access — interceptor routes POST /v1/admin/budgets/bulk-action
+        // through the admin path, which requires X-Admin-API-Key.
+        when(apiKeyRepository.validate("valid-api-key")).thenReturn(
+                ApiKeyValidationResponse.builder()
+                        .valid(true).tenantId(TENANT).keyId("key_1")
+                        .permissions(List.of("budgets:write")).build());
+
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Cycles-API-Key", "valid-api-key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter(""), "CREDIT", "k1",
+                                "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":500}")))
+                .andExpect(status().isUnauthorized());
+
+        verify(budgetRepository, never()).matchForBulk(anyString(), any(), anyInt());
+    }
+}

--- a/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/BudgetListFilters.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/BudgetListFilters.java
@@ -1,5 +1,6 @@
 package io.runcycles.admin.data.repository;
 
+import io.runcycles.admin.model.budget.BudgetBulkFilter;
 import io.runcycles.admin.model.budget.BudgetLedger;
 import io.runcycles.admin.model.budget.BudgetStatus;
 import io.runcycles.admin.model.shared.SearchSpec;
@@ -35,6 +36,23 @@ public record BudgetListFilters(
 
     public static BudgetListFilters empty() {
         return new BudgetListFilters(null, null, null, null, null, null, null, null);
+    }
+
+    /**
+     * Adapter for the bulk-action filter DTO (spec v0.1.25.26). Drops the
+     * required {@code tenant_id} — that is applied by the caller as a
+     * tenant-scoped repository walk, not as a per-ledger predicate — and
+     * forwards every remaining dimension verbatim. Guarantees the
+     * bulk-action and listBudgets endpoints agree on what "matches"
+     * for any given filter set, which is the spec-level contract for
+     * the operator preview → bulk workflow.
+     */
+    public static BudgetListFilters fromBulkFilter(BudgetBulkFilter bulk) {
+        return new BudgetListFilters(
+                bulk.getScopePrefix(), bulk.getUnit(), bulk.getStatus(),
+                bulk.getOverLimit(), bulk.getHasDebt(),
+                bulk.getUtilizationMin(), bulk.getUtilizationMax(),
+                bulk.getSearch());
     }
 
     /**

--- a/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/BudgetRepository.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/BudgetRepository.java
@@ -663,6 +663,42 @@ public class BudgetRepository {
         return list(tenantId, null, null, null, null, 1000);
     }
 
+    /**
+     * Tenant-scoped bulk-match for {@code POST /v1/admin/budgets/bulk-action}
+     * (spec v0.1.25.26). Hydrates up to {@code cap + 1} matching ledgers
+     * from {@code budgets:{tenantId}} and applies {@link BudgetListFilters#matches}
+     * for zero-drift semantics with listBudgets. The {@code +1} is the
+     * "filter is too wide" sentinel — callers check {@code size() > cap}
+     * and raise LIMIT_EXCEEDED without hydrating the remainder.
+     *
+     * <p>No cross-tenant path: the bulk endpoint requires {@code tenant_id}
+     * so the walk is constrained to a single tenant's budget index.
+     */
+    public List<BudgetLedger> matchForBulk(String tenantId, BudgetListFilters filters, int cap) {
+        BudgetListFilters effective = filters != null ? filters : BudgetListFilters.empty();
+        List<BudgetLedger> matched = new ArrayList<>();
+        try (Jedis jedis = jedisPool.getResource()) {
+            Set<String> keys = jedis.smembers("budgets:" + tenantId);
+            for (String key : keys) {
+                try {
+                    Map<String, String> hash = jedis.hgetAll(key);
+                    if (hash.isEmpty()) {
+                        LOG.warn("Budget data missing for key: {}, cleaning index", key);
+                        jedis.srem("budgets:" + tenantId, key);
+                        continue;
+                    }
+                    BudgetLedger ledger = hashToBudgetLedger(hash, key);
+                    if (!effective.matches(ledger)) continue;
+                    matched.add(ledger);
+                    if (matched.size() > cap) break;
+                } catch (Exception e) {
+                    LOG.warn("Failed to parse budget: {}", key, e);
+                }
+            }
+        }
+        return matched;
+    }
+
     public BudgetLedger getByExactScope(String scope, UnitEnum unit) {
         String normalizedScope = normalizeScope(scope);
         String key = "budget:" + normalizedScope + ":" + unit;

--- a/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/BudgetRepositoryBulkMatchTest.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/BudgetRepositoryBulkMatchTest.java
@@ -1,0 +1,332 @@
+package io.runcycles.admin.data.repository;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.runcycles.admin.model.budget.BudgetLedger;
+import io.runcycles.admin.model.budget.BudgetStatus;
+import io.runcycles.admin.model.shared.UnitEnum;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+/**
+ * Focused coverage for {@link BudgetRepository#matchForBulk}
+ * (spec v0.1.25.26 — bulk-action match phase). Exercises each of the
+ * eight filter dimensions on {@link BudgetListFilters}, the cap+1
+ * sentinel behaviour, tenant isolation, and the stale-index cleanup
+ * branch. Split out from {@code BudgetRepositoryTest} to keep the
+ * bulk-action-specific fixtures and hash shapes localised.
+ */
+@ExtendWith(MockitoExtension.class)
+class BudgetRepositoryBulkMatchTest {
+
+    @Mock private JedisPool jedisPool;
+    @Mock private Jedis jedis;
+    @Spy private ObjectMapper objectMapper = createObjectMapper();
+    @InjectMocks private BudgetRepository repository;
+
+    private static ObjectMapper createObjectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return mapper;
+    }
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(jedisPool.getResource()).thenReturn(jedis);
+    }
+
+    private static Map<String, String> hash(
+            String ledgerId, String tenantId, String scope, String unit,
+            String allocated, String spent, String debt, String status,
+            String isOverLimit) {
+        Map<String, String> h = new LinkedHashMap<>();
+        h.put("ledger_id", ledgerId);
+        h.put("tenant_id", tenantId);
+        h.put("scope", scope);
+        h.put("unit", unit);
+        h.put("allocated", allocated);
+        h.put("remaining", allocated);
+        h.put("reserved", "0");
+        h.put("spent", spent);
+        h.put("debt", debt);
+        h.put("overdraft_limit", "0");
+        h.put("is_over_limit", isOverLimit);
+        h.put("status", status);
+        h.put("created_at", "1700000000000");
+        return h;
+    }
+
+    private static Map<String, String> activeUsd(String scope, String tenant, long allocated, long spent) {
+        return hash("led-" + scope, tenant, scope, "USD_MICROCENTS",
+                String.valueOf(allocated), String.valueOf(spent), "0",
+                BudgetStatus.ACTIVE.name(), "false");
+    }
+
+    // -------- Filter dimensions --------
+
+    @Test
+    void matchForBulk_scopePrefix_matchesOnlyPrefixedRows() {
+        Set<String> keys = new LinkedHashSet<>(List.of(
+                "budget:tenant:acme/workspace:eng:USD_MICROCENTS",
+                "budget:tenant:acme/workspace:ops:USD_MICROCENTS"));
+        when(jedis.smembers("budgets:acme")).thenReturn(keys);
+        when(jedis.hgetAll("budget:tenant:acme/workspace:eng:USD_MICROCENTS"))
+                .thenReturn(activeUsd("tenant:acme/workspace:eng", "acme", 1000, 0));
+        when(jedis.hgetAll("budget:tenant:acme/workspace:ops:USD_MICROCENTS"))
+                .thenReturn(activeUsd("tenant:acme/workspace:ops", "acme", 1000, 0));
+
+        List<BudgetLedger> result = repository.matchForBulk("acme",
+                new BudgetListFilters("tenant:acme/workspace:eng", null, null, null, null, null, null),
+                500);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getScope()).isEqualTo("tenant:acme/workspace:eng");
+    }
+
+    @Test
+    void matchForBulk_unit_filtersByUnit() {
+        Set<String> keys = new LinkedHashSet<>(List.of(
+                "budget:s1:USD_MICROCENTS", "budget:s2:TOKENS"));
+        when(jedis.smembers("budgets:acme")).thenReturn(keys);
+        when(jedis.hgetAll("budget:s1:USD_MICROCENTS")).thenReturn(
+                activeUsd("s1", "acme", 1000, 0));
+        when(jedis.hgetAll("budget:s2:TOKENS")).thenReturn(hash(
+                "led-s2", "acme", "s2", "TOKENS", "500", "0", "0",
+                BudgetStatus.ACTIVE.name(), "false"));
+
+        List<BudgetLedger> result = repository.matchForBulk("acme",
+                new BudgetListFilters(null, UnitEnum.TOKENS, null, null, null, null, null),
+                500);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getUnit()).isEqualTo(UnitEnum.TOKENS);
+    }
+
+    @Test
+    void matchForBulk_status_filtersByStatus() {
+        Set<String> keys = new LinkedHashSet<>(List.of(
+                "budget:a:USD_MICROCENTS", "budget:b:USD_MICROCENTS"));
+        when(jedis.smembers("budgets:acme")).thenReturn(keys);
+        when(jedis.hgetAll("budget:a:USD_MICROCENTS")).thenReturn(
+                activeUsd("a", "acme", 1000, 0));
+        when(jedis.hgetAll("budget:b:USD_MICROCENTS")).thenReturn(hash(
+                "led-b", "acme", "b", "USD_MICROCENTS", "1000", "0", "0",
+                BudgetStatus.FROZEN.name(), "false"));
+
+        List<BudgetLedger> result = repository.matchForBulk("acme",
+                new BudgetListFilters(null, null, BudgetStatus.FROZEN, null, null, null, null),
+                500);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getScope()).isEqualTo("b");
+    }
+
+    @Test
+    void matchForBulk_overLimit_filtersByOverLimitFlag() {
+        Set<String> keys = new LinkedHashSet<>(List.of(
+                "budget:a:USD_MICROCENTS", "budget:b:USD_MICROCENTS"));
+        when(jedis.smembers("budgets:acme")).thenReturn(keys);
+        when(jedis.hgetAll("budget:a:USD_MICROCENTS")).thenReturn(
+                activeUsd("a", "acme", 1000, 0));
+        when(jedis.hgetAll("budget:b:USD_MICROCENTS")).thenReturn(hash(
+                "led-b", "acme", "b", "USD_MICROCENTS", "1000", "0", "0",
+                BudgetStatus.ACTIVE.name(), "true"));
+
+        List<BudgetLedger> result = repository.matchForBulk("acme",
+                new BudgetListFilters(null, null, null, Boolean.TRUE, null, null, null),
+                500);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getScope()).isEqualTo("b");
+    }
+
+    @Test
+    void matchForBulk_hasDebt_filtersByDebtPositive() {
+        Set<String> keys = new LinkedHashSet<>(List.of(
+                "budget:a:USD_MICROCENTS", "budget:b:USD_MICROCENTS"));
+        when(jedis.smembers("budgets:acme")).thenReturn(keys);
+        when(jedis.hgetAll("budget:a:USD_MICROCENTS")).thenReturn(hash(
+                "led-a", "acme", "a", "USD_MICROCENTS", "1000", "0", "0",
+                BudgetStatus.ACTIVE.name(), "false"));
+        when(jedis.hgetAll("budget:b:USD_MICROCENTS")).thenReturn(hash(
+                "led-b", "acme", "b", "USD_MICROCENTS", "1000", "0", "250",
+                BudgetStatus.ACTIVE.name(), "false"));
+
+        List<BudgetLedger> result = repository.matchForBulk("acme",
+                new BudgetListFilters(null, null, null, null, Boolean.TRUE, null, null),
+                500);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getScope()).isEqualTo("b");
+    }
+
+    @Test
+    void matchForBulk_utilizationRange_filtersBySpentOverAllocated() {
+        // a: 0% util, b: 50% util, c: 100% util. range [0.4, 0.9] → only b.
+        Set<String> keys = new LinkedHashSet<>(List.of(
+                "budget:a:USD_MICROCENTS", "budget:b:USD_MICROCENTS", "budget:c:USD_MICROCENTS"));
+        when(jedis.smembers("budgets:acme")).thenReturn(keys);
+        when(jedis.hgetAll("budget:a:USD_MICROCENTS")).thenReturn(
+                activeUsd("a", "acme", 1000, 0));
+        when(jedis.hgetAll("budget:b:USD_MICROCENTS")).thenReturn(
+                activeUsd("b", "acme", 1000, 500));
+        when(jedis.hgetAll("budget:c:USD_MICROCENTS")).thenReturn(
+                activeUsd("c", "acme", 1000, 1000));
+
+        List<BudgetLedger> result = repository.matchForBulk("acme",
+                new BudgetListFilters(null, null, null, null, null, 0.4, 0.9),
+                500);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getScope()).isEqualTo("b");
+    }
+
+    @Test
+    void matchForBulk_search_matchesTenantIdOrScopeSubstring() {
+        Set<String> keys = new LinkedHashSet<>(List.of(
+                "budget:tenant:acme/workspace:eng:USD_MICROCENTS",
+                "budget:tenant:acme/workspace:ops:USD_MICROCENTS"));
+        when(jedis.smembers("budgets:acme")).thenReturn(keys);
+        when(jedis.hgetAll("budget:tenant:acme/workspace:eng:USD_MICROCENTS"))
+                .thenReturn(activeUsd("tenant:acme/workspace:eng", "acme", 1000, 0));
+        when(jedis.hgetAll("budget:tenant:acme/workspace:ops:USD_MICROCENTS"))
+                .thenReturn(activeUsd("tenant:acme/workspace:ops", "acme", 1000, 0));
+
+        BudgetListFilters filters = new BudgetListFilters(null, null, null, null, null, null, null, "eng");
+        List<BudgetLedger> result = repository.matchForBulk("acme", filters, 500);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getScope()).contains("eng");
+    }
+
+    @Test
+    void matchForBulk_emptyFilter_returnsAllMatching() {
+        Set<String> keys = new LinkedHashSet<>(List.of(
+                "budget:a:USD_MICROCENTS", "budget:b:USD_MICROCENTS"));
+        when(jedis.smembers("budgets:acme")).thenReturn(keys);
+        when(jedis.hgetAll("budget:a:USD_MICROCENTS")).thenReturn(
+                activeUsd("a", "acme", 1000, 0));
+        when(jedis.hgetAll("budget:b:USD_MICROCENTS")).thenReturn(
+                activeUsd("b", "acme", 1000, 0));
+
+        List<BudgetLedger> result = repository.matchForBulk("acme",
+                BudgetListFilters.empty(), 500);
+
+        assertThat(result).hasSize(2);
+    }
+
+    @Test
+    void matchForBulk_nullFilter_treatedAsEmpty() {
+        Set<String> keys = new LinkedHashSet<>(List.of("budget:a:USD_MICROCENTS"));
+        when(jedis.smembers("budgets:acme")).thenReturn(keys);
+        when(jedis.hgetAll("budget:a:USD_MICROCENTS")).thenReturn(
+                activeUsd("a", "acme", 1000, 0));
+
+        List<BudgetLedger> result = repository.matchForBulk("acme", null, 500);
+
+        assertThat(result).hasSize(1);
+    }
+
+    // -------- Cap + tenant isolation + cleanup --------
+
+    @Test
+    void matchForBulk_capPlusOneSentinel_stopsAfterCapExceeded() {
+        // Build 5 matching keys with cap=3 → expect result.size() > cap
+        // (the controller reads this as "too wide" and raises LIMIT_EXCEEDED).
+        Set<String> keys = new LinkedHashSet<>();
+        for (int i = 0; i < 5; i++) keys.add("budget:s" + i + ":USD_MICROCENTS");
+        when(jedis.smembers("budgets:acme")).thenReturn(keys);
+        for (int i = 0; i < 5; i++) {
+            // Loop breaks after matched.size() > cap, so some of these
+            // stubs may go unused — mark lenient to keep strict mode happy.
+            lenient().when(jedis.hgetAll("budget:s" + i + ":USD_MICROCENTS"))
+                    .thenReturn(activeUsd("s" + i, "acme", 1000, 0));
+        }
+
+        List<BudgetLedger> result = repository.matchForBulk("acme",
+                BudgetListFilters.empty(), 3);
+
+        // size > cap is the signal; we stop reading after matched.size() > cap.
+        assertThat(result.size()).isGreaterThan(3);
+        assertThat(result.size()).isLessThanOrEqualTo(5);
+    }
+
+    @Test
+    void matchForBulk_tenantIsolation_onlyReadsRequestedTenantSet() {
+        Set<String> keys = new LinkedHashSet<>(List.of("budget:a:USD_MICROCENTS"));
+        when(jedis.smembers("budgets:acme")).thenReturn(keys);
+        when(jedis.hgetAll("budget:a:USD_MICROCENTS")).thenReturn(
+                activeUsd("a", "acme", 1000, 0));
+
+        repository.matchForBulk("acme", BudgetListFilters.empty(), 500);
+
+        verify(jedis).smembers("budgets:acme");
+        verify(jedis, never()).smembers("budgets:other");
+    }
+
+    @Test
+    void matchForBulk_emptyHashData_cleansIndexAndSkips() {
+        Set<String> keys = new LinkedHashSet<>(List.of(
+                "budget:stale:USD_MICROCENTS", "budget:valid:USD_MICROCENTS"));
+        when(jedis.smembers("budgets:acme")).thenReturn(keys);
+        when(jedis.hgetAll("budget:stale:USD_MICROCENTS")).thenReturn(Collections.emptyMap());
+        when(jedis.hgetAll("budget:valid:USD_MICROCENTS")).thenReturn(
+                activeUsd("valid", "acme", 1000, 0));
+
+        List<BudgetLedger> result = repository.matchForBulk("acme",
+                BudgetListFilters.empty(), 500);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getScope()).isEqualTo("valid");
+        verify(jedis).srem("budgets:acme", "budget:stale:USD_MICROCENTS");
+    }
+
+    @Test
+    void matchForBulk_parseFailure_swallowedAndContinues() {
+        // Bad unit → hashToBudgetLedger throws → swallowed by the catch,
+        // good row still returned.
+        Set<String> keys = new LinkedHashSet<>(List.of(
+                "budget:bad:USD_MICROCENTS", "budget:ok:USD_MICROCENTS"));
+        when(jedis.smembers("budgets:acme")).thenReturn(keys);
+        Map<String, String> bad = activeUsd("bad", "acme", 1000, 0);
+        bad.put("unit", "NOT_A_UNIT");
+        when(jedis.hgetAll("budget:bad:USD_MICROCENTS")).thenReturn(bad);
+        when(jedis.hgetAll("budget:ok:USD_MICROCENTS")).thenReturn(
+                activeUsd("ok", "acme", 1000, 0));
+
+        List<BudgetLedger> result = repository.matchForBulk("acme",
+                BudgetListFilters.empty(), 500);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getScope()).isEqualTo("ok");
+    }
+
+    @Test
+    void matchForBulk_noKeys_returnsEmptyList() {
+        when(jedis.smembers("budgets:acme")).thenReturn(Collections.emptySet());
+
+        List<BudgetLedger> result = repository.matchForBulk("acme",
+                BudgetListFilters.empty(), 500);
+
+        assertThat(result).isEmpty();
+    }
+}

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/budget/BudgetBulkActionRequest.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/budget/BudgetBulkActionRequest.java
@@ -1,0 +1,35 @@
+package io.runcycles.admin.model.budget;
+import com.fasterxml.jackson.annotation.*;
+import io.runcycles.admin.model.shared.Amount;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import lombok.*;
+/**
+ * Request envelope for POST /v1/admin/budgets/bulk-action (spec v0.1.25.26).
+ * Operation-discriminated: the {@code action} enum names which
+ * balance-mutation to apply uniformly across the matched set. The action
+ * determines which payload fields are required — see per-action notes on
+ * each property.
+ *
+ * <p>Server MUST validate the action/payload combination BEFORE running
+ * the filter or counting matches. An invalid combination (e.g. CREDIT
+ * without {@code amount}, RESET_SPENT with negative {@code spent}) MUST
+ * return HTTP 400 with no writes.
+ *
+ * <p>Safety semantics mirror {@code TenantBulkActionRequest}: 500-row
+ * hard cap (LIMIT_EXCEEDED → 400), {@code expectedCount} mismatch →
+ * COUNT_MISMATCH → 409, 15-minute {@code idempotencyKey} replay window,
+ * overall HTTP 200 even with per-row failures.
+ */
+@Data @Builder @NoArgsConstructor @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = false)
+public class BudgetBulkActionRequest {
+    @NotNull @Valid @JsonProperty("filter") private BudgetBulkFilter filter;
+    @NotNull @JsonProperty("action") private FundingOperation action;
+    @Valid @JsonProperty("amount") private Amount amount;
+    @Valid @JsonProperty("spent") private Amount spent;
+    @Size(max = 512) @JsonProperty("reason") private String reason;
+    @Min(0) @JsonProperty("expected_count") private Integer expectedCount;
+    @NotBlank @Size(min = 1, max = 128) @JsonProperty("idempotency_key") private String idempotencyKey;
+}

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/budget/BudgetBulkActionResponse.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/budget/BudgetBulkActionResponse.java
@@ -1,0 +1,28 @@
+package io.runcycles.admin.model.budget;
+import com.fasterxml.jackson.annotation.*;
+import io.runcycles.admin.model.shared.BulkActionRowOutcome;
+import lombok.*;
+import java.util.List;
+/**
+ * Response envelope for POST /v1/admin/budgets/bulk-action (spec v0.1.25.26).
+ * Splits the affected ledgers into succeeded / failed / skipped with
+ * per-row detail, echoes the action and idempotency_key so callers can
+ * confirm they observed the intended effect. Mirrors
+ * {@code TenantBulkActionResponse} and {@code WebhookBulkActionResponse}.
+ *
+ * <p>{@code totalMatched} is the server-counted match — the invariant
+ * {@code succeeded.size() + failed.size() + skipped.size() ==
+ * totalMatched} holds. Overall HTTP status is 200 even when some rows
+ * land in failed[]. Common per-row failure codes: BUDGET_EXCEEDED (DEBIT
+ * would take remaining negative), INVALID_TRANSITION (unit mismatch,
+ * ledger FROZEN/CLOSED).
+ */
+@Data @Builder @NoArgsConstructor @AllArgsConstructor
+public class BudgetBulkActionResponse {
+    @JsonProperty("action") private FundingOperation action;
+    @JsonProperty("total_matched") private int totalMatched;
+    @JsonProperty("succeeded") private List<BulkActionRowOutcome> succeeded;
+    @JsonProperty("failed") private List<BulkActionRowOutcome> failed;
+    @JsonProperty("skipped") private List<BulkActionRowOutcome> skipped;
+    @JsonProperty("idempotency_key") private String idempotencyKey;
+}

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/budget/BudgetBulkFilter.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/budget/BudgetBulkFilter.java
@@ -1,0 +1,39 @@
+package io.runcycles.admin.model.budget;
+import com.fasterxml.jackson.annotation.*;
+import io.runcycles.admin.model.shared.UnitEnum;
+import jakarta.validation.constraints.*;
+import lombok.*;
+/**
+ * Filter selecting which budget ledgers a bulk-action applies to (spec
+ * v0.1.25.26). Shape mirrors the query params of {@code listBudgets} so
+ * operators can preview the match set via {@code GET /v1/admin/budgets}
+ * and then submit the same filter to {@code POST /v1/admin/budgets/bulk-action}.
+ *
+ * <p>Cross-tenant safety: {@code tenant_id} is REQUIRED (unlike listBudgets
+ * where it is optional under AdminKeyAuth). Every bulk-action MUST target
+ * exactly one tenant — prevents accidental all-tenant fan-out and keeps
+ * the audit-log entry cleanly attributable.
+ *
+ * <p>Cascading reset across a scope subtree uses {@code scope_prefix} (e.g.
+ * {@code tenant:acme/workspace:eng} matches all descendants of that
+ * scope). The hierarchy is encoded in the scope path; no separate
+ * {@code cascade} flag is needed.
+ *
+ * <p>{@code additionalProperties: false} is enforced by
+ * {@code @JsonIgnoreProperties(ignoreUnknown = false)} — unknown keys
+ * surface as a 400 parse failure.
+ */
+@Data @Builder @NoArgsConstructor @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = false)
+public class BudgetBulkFilter {
+    @NotBlank @JsonProperty("tenant_id") private String tenantId;
+    @JsonProperty("scope_prefix") private String scopePrefix;
+    @JsonProperty("unit") private UnitEnum unit;
+    @JsonProperty("status") private BudgetStatus status;
+    @JsonProperty("over_limit") private Boolean overLimit;
+    @JsonProperty("has_debt") private Boolean hasDebt;
+    @DecimalMin("0.0") @DecimalMax("1.0") @JsonProperty("utilization_min") private Double utilizationMin;
+    @DecimalMin("0.0") @DecimalMax("1.0") @JsonProperty("utilization_max") private Double utilizationMax;
+    @Size(max = 128) @JsonProperty("search") private String search;
+}

--- a/cycles-admin-service/pom.xml
+++ b/cycles-admin-service/pom.xml
@@ -18,7 +18,7 @@
         <module>cycles-admin-service-api</module>
     </modules>
     <properties>
-        <revision>0.1.25.28</revision>
+        <revision>0.1.25.29</revision>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/docker-compose.full-stack.prod.yml
+++ b/docker-compose.full-stack.prod.yml
@@ -13,7 +13,7 @@ services:
       retries: 5
 
   cycles-admin:
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.28
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.29
     restart: unless-stopped
     ports:
       - "7979:7979"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,7 +13,7 @@ services:
       retries: 5
 
   cycles-admin:
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.28
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.29
     restart: unless-stopped
     ports:
       - "7979:7979"


### PR DESCRIPTION
## Summary

Implements `POST /v1/admin/budgets/bulk-action` to match cycles-protocol admin spec **v0.1.25.26**, resolving issue #99 (*Bulk Budget Reset at Tenant or Parent-Scope Level*). Operators rolling over a billing period can now issue one filtered bulk request instead of iterating `listBudgets` + per-row `fundBudget`.

Shape mirrors the tenant/webhook bulk-action pattern already shipped in v0.1.25.26.

### Endpoint

| Method | Path | Auth | Purpose |
|---|---|---|---|
| POST | `/v1/admin/budgets/bulk-action` | AdminKeyAuth only | Apply a `FundingOperation` (CREDIT / DEBIT / RESET / REPAY_DEBT / RESET_SPENT) to every budget matching a filter, bounded to 500 rows. |

### Safety & semantics

- **500-row hard cap** → 400 `LIMIT_EXCEEDED`
- **expected_count** gate → 409 `COUNT_MISMATCH`
- **15-min idempotency replay** via `IdempotencyStore` (returns cached envelope verbatim)
- **Per-row derived idempotency key** (`bulkKey:scope:unit`) → Lua fund short-circuit prevents double-apply on retry-the-failed-set
- **Row-level known codes**: `BUDGET_EXCEEDED`, `INVALID_TRANSITION`, `NOT_FOUND`, `PERMISSION_DENIED`, `INTERNAL_ERROR`
- **Skipped bucket**: `REPAY_DEBT` on debt==0 → `reason=ALREADY_IN_TARGET_STATE`
- **Cross-tenant safety**: `filter.tenant_id` is required; missing → 400
- **Zero-drift matcher**: `BudgetListFilters.fromBulkFilter(...)` ensures `listBudgets` preview and `bulk-action` always agree on what matches
- **AuthInterceptor plugged**: explicit AdminKeyAuth branch — tenant keys rejected 401
- **AuditLogEntry**: one per bulk-op with per-bucket counts in metadata
- **Per-row id**: `ledger_id` (per spec `BudgetBulkActionResponse.succeeded.description`)

### Files changed

- **New DTOs** (model): `BudgetBulkFilter`, `BudgetBulkActionRequest`, `BudgetBulkActionResponse`
- **BudgetRepository**: new `matchForBulk(tenantId, filters, cap)` + `fromBulkFilter` static factory on `BudgetListFilters`
- **BudgetController**: new `bulkActionBudgets` handler — validate → idempotency lookup → match → limit check → count gate → per-row apply → store → audit
- **AuthInterceptor**: explicit `/v1/admin/budgets/bulk-action` admin-key branch
- **Version**: `0.1.25.28` → `0.1.25.29` in `pom.xml`, `docker-compose.prod.yml`, `docker-compose.full-stack.prod.yml`
- **AUDIT.md**: new dated section with full design rationale

### Test coverage

- `BudgetControllerBulkActionTest` — 27 tests (happy paths × 5 actions, classification branches, validation 400s, idempotency replay, audit metadata, auth)
- `BudgetRepositoryBulkMatchTest` — 14 tests (each filter dimension, cap+1 sentinel, tenant isolation, stale-index cleanup, parse-failure tolerance)
- **698/698 tests green**; **JaCoCo ≥95%** per module
- `OpenApiContractDiffTest` + `SpecCoverageReportTest` clean against spec v0.1.25.26 on cycles-protocol/main

Closes #99.

## Test plan

- [x] `mvn-proxy -B verify --file cycles-admin-service/pom.xml -Dtest='!*IntegrationTest' -Dsurefire.failIfNoSpecifiedTests=false` — 698/698 green
- [x] `BudgetControllerBulkActionTest` — 27/27 green
- [x] `BudgetRepositoryBulkMatchTest` — 14/14 green
- [x] `OpenApiContractDiffTest` + `SpecCoverageReportTest` — 46/46 spec operations covered
- [x] JaCoCo ≥95% per-module
- [ ] Manual curl smoke (admin server on 7979): preview via `listBudgets`, `bulk-action` with `expected_count`, 409 on count drift, 400 on missing amount
- [ ] CI green on this PR