### PR TITLE
fix(test/v0.1.25.28.1): soak AS4 must sum __admin__ sentinel delta

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -5,6 +5,34 @@
 **Spec:** [`cycles-governance-admin-v0.1.25.yaml`](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml) (OpenAPI 3.1.0, info.version `0.1.25.26`; adds `POST /v1/admin/budgets/bulk-action` — fifth bulk-action endpoint, mirrors the tenant/webhook envelope) in [cycles-protocol](https://github.com/runcycles/cycles-protocol)
 **Server:** Spring Boot 3.5.11 / Java 21 / Redis
 
+### 2026-04-18 — v0.1.25.28.1 test fix: nightly soak AS4 must include `__admin__` sentinel
+
+**What broke.** The nightly audit-soak workflow went red on 2026-04-18 after v0.1.25.28 (run [`24599992000`](https://github.com/runcycles/cycles-server-admin/actions/runs/24599992000)). The AS4 tier-sum invariant in `AuditFailureSoakIntegrationTest` failed with `expected: 14000L, but was: 8923L` — a shortfall of exactly **5077**, matching the 400-response count the soak driver issued (401=3920, 403=5003, **400=5077**).
+
+**Root cause (test-only).** v0.1.25.28 split the pre-auth `tenant_id` sentinel in `AuditFailureService` into two tiers: `__unauth__` (no / invalid / revoked key) and `__admin__` (valid admin key, downstream validation failed). The production write path correctly routes to whichever sentinel applies — AS3 (`written + error + sampled-out == total_requests`) and AS4's first invariant (`globalDelta == written`) both passed on the failing run. But AS4's per-tier equality check was still summing only `__unauth__` + `tenant-soak`; the 5077 entries under `__admin__` (all the 400-wave audit rows) weren't included. The shortfall exactly equalled the `__admin__` tier cardinality.
+
+**Fix.** `AuditFailureSoakIntegrationTest.java`:
+- Capture a baseline for both `audit:logs:__unauth__` and `audit:logs:__admin__` after setup (same pattern as the existing `_all` / `tenant-soak` baselines; protects against setup-path contamination even though current setup only hits SUCCESS paths).
+- Sum three tier deltas in the AS4 equality: `__unauth__` + `__admin__` + `tenant-soak`.
+- Updated assertion description to name all three tiers and print each delta on failure, so future regressions triangulate to the offending family immediately.
+
+**Why this is a test fix, not a production fix.** Production `AuditFailureService.resolveTenantId` already stamps `__admin__` for admin-key-authenticated failures (v0.1.25.28 `AuthInterceptor` sets `authenticated_actor_type="admin"`, and `resolveTenantId` reads it). All 14000 writes landed in the global index and incremented the counter correctly. The nightly flagged a **coverage gap in the invariant** — AS4's tier-sum was stale against the sentinel split, not a real audit-integrity regression.
+
+**Scope.** No server / spec / data changes. One test file. Shipping as `v0.1.25.28.1` (point release) rather than piggybacking on v0.1.25.29 so the fix is attributable to the sentinel-split change that introduced the test coverage gap.
+
+**Verification.**
+
+```bash
+# Nightly soak (requires Docker; ~11 min)
+mvn-proxy -B test --file cycles-admin-service/pom.xml \
+  -pl cycles-admin-service-api -am \
+  -Psoak -Dsoak.duration.minutes=10 -Dsoak.target.rps=500 \
+  -Dtest=AuditFailureSoakIntegrationTest \
+  -Dsurefire.failIfNoSpecifiedTests=false
+```
+
+The manual trigger on the PR branch must be green before this merges.
+
 ### 2026-04-18 — v0.1.25.29 budget bulk-action endpoint (spec v0.1.25.26)
 
 Closes [cycles-server-admin issue #99](https://github.com/runcycles/cycles-server-admin/issues/99) ("Bulk Budget Reset at Tenant or Parent-Scope Level"). Operators rolling over a billing period previously had to iterate `listBudgets` + per-row `fundBudget` — painful for a tenant with dozens or hundreds of ledgers, and no atomic count-gate to catch drift between preview and apply. The new endpoint lets them issue one filtered bulk request. Spec v0.1.25.26 (merged to cycles-protocol `main` via PR #55) had already shipped the analogous endpoints for tenants and webhooks in server v0.1.25.26; budgets were the last gap.

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/integration/AuditFailureSoakIntegrationTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/integration/AuditFailureSoakIntegrationTest.java
@@ -134,9 +134,13 @@ class AuditFailureSoakIntegrationTest extends BaseIntegrationTest {
         // counter" — which needs the baseline subtraction.
         long indexBaselineGlobal;
         long indexBaselineTenant;
+        long indexBaselineUnauthSentinel;
+        long indexBaselineAdminSentinel;
         try (Jedis jedis = jedisPool.getResource()) {
             indexBaselineGlobal = jedis.zcard("audit:logs:_all");
             indexBaselineTenant = jedis.zcard("audit:logs:tenant-soak");
+            indexBaselineUnauthSentinel = jedis.zcard("audit:logs:__unauth__");
+            indexBaselineAdminSentinel = jedis.zcard("audit:logs:__admin__");
         }
 
         ExecutorService pool = Executors.newFixedThreadPool(WORKER_THREADS);
@@ -302,15 +306,24 @@ class AuditFailureSoakIntegrationTest extends BaseIntegrationTest {
             // Per-tier delta sanity: every failure write lands in exactly
             // one tier index (sentinel OR real tenant). Their delta sum
             // must equal the global delta — guards against a ZADD going
-            // into only one of the two index families.
-            long sentinelIndex = jedis.zcard("audit:logs:__unauth__");
-            long tenantSoakIndex = jedis.zcard("audit:logs:tenant-soak");
-            long tenantSoakDelta = tenantSoakIndex - indexBaselineTenant;
-            assertThat(sentinelIndex + tenantSoakDelta)
-                    .as("AS4: sentinel + (tenant-soak - baseline) must equal "
-                            + "load-phase global delta — ensures every write lands in "
-                            + "both its tier index AND the global index",
-                            sentinelIndex, tenantSoakDelta, globalDelta)
+            // into only one of the index families. v0.1.25.28 split the
+            // pre-auth sentinel into two tiers: __unauth__ (no auth
+            // header / invalid key) and __admin__ (valid admin key, but
+            // downstream validation failed → 400). Both must be summed
+            // in so 400-wave traffic is accounted for.
+            long unauthSentinelDelta = jedis.zcard("audit:logs:__unauth__")
+                    - indexBaselineUnauthSentinel;
+            long adminSentinelDelta = jedis.zcard("audit:logs:__admin__")
+                    - indexBaselineAdminSentinel;
+            long tenantSoakDelta = jedis.zcard("audit:logs:tenant-soak")
+                    - indexBaselineTenant;
+            assertThat(unauthSentinelDelta + adminSentinelDelta + tenantSoakDelta)
+                    .as("AS4: (__unauth__ + __admin__ + tenant-soak) load-phase "
+                            + "deltas must equal global delta — ensures every write "
+                            + "lands in both its tier index AND the global index. "
+                            + "unauth=%d admin=%d tenant-soak=%d global=%d",
+                            unauthSentinelDelta, adminSentinelDelta,
+                            tenantSoakDelta, globalDelta)
                     .isEqualTo(globalDelta);
         }
 


### PR DESCRIPTION
## Summary

Nightly audit-soak went red on 2026-04-18 ([run 24599992000](https://github.com/runcycles/cycles-server-admin/actions/runs/24599992000)) with AS4 failing `expected: 14000L, but was: 8923L`. The shortfall of **5077** matched the 400-response count the soak driver issues (401=3920, 403=5003, **400=5077**).

**Root cause is a test-only coverage gap**, not a production audit-integrity regression. v0.1.25.28's sentinel split added a second pre-auth tier (`__admin__`, for valid-admin-key requests failing downstream validation), but AS4's tier-equality check still summed only `__unauth__ + tenant-soak`. The production write path routes correctly — AS3 (counter-sum) and AS4's first invariant (`globalDelta == written`) both passed on the failing run.

## Fix

- Capture baselines for `audit:logs:__unauth__` and `audit:logs:__admin__` after setup (same pattern as existing `_all` / `tenant-soak` baselines).
- AS4 now sums **all three** tier deltas: `__unauth__ + __admin__ + tenant-soak == globalDelta`.
- Assertion description names all three tiers and prints every delta on failure, so future regressions triangulate the offending family immediately.

**Scope:** one test file + AUDIT.md entry. No server, spec, or data changes. Shipping as `v0.1.25.28.1` — attributable to the sentinel-split that introduced the gap, not to v0.1.25.29 which is in flight.

## Test plan

- [x] Static review — the 400-wave arithmetic works out: `unauth(3920) + admin(5077) + tenant-soak(5003) = 14000`.
- [ ] Manual soak trigger on this branch (10 min × 500 rps with Docker) — nightly workflow on `workflow_dispatch`.
- [ ] CI unit + integration green.
- [ ] Next scheduled nightly (2026-04-19 08:09 UTC) green.

Relates to the [2026-04-18 soak failure](https://github.com/runcycles/cycles-server-admin/actions/runs/24599992000) following PR #111 (v0.1.25.28 sentinel split).