### PR TITLE
feat(v0.1.25.30): enrich bulk-action audit metadata for triage

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,9 +1,67 @@
-# Complete Budget Governance v0.1.25.29 — Admin Server Audit
+# Complete Budget Governance v0.1.25.30 — Admin Server Audit
 
-**Server version:** 0.1.25.29 (2026-04-18 — budget bulk-action endpoint, spec v0.1.25.26)
-**Date:** 2026-04-18 (v0.1.25.29 budget bulk-action), 2026-04-17 (v0.1.25.28 audit sentinel split), 2026-04-17 (v0.1.25.27 audit filter DSL upgrade), 2026-04-17 (v0.1.25.26 bulk-action endpoints), 2026-04-17 (v0.1.25.25 search on six list endpoints), 2026-04-16 (v0.1.25.24 server-side sort — six admin list endpoints), 2026-04-16 (v0.1.25.23 BudgetLedger tenant_id on wire), 2026-04-16 (v0.1.25.22 cross-tenant list + filters), 2026-04-16 (v0.1.25.21 nightly CI), 2026-04-16 (v0.1.25.20 audit-on-failure), 2026-04-16 (v0.1.25.19 introspect dual-auth + operator docs), 2026-04-15 (v0.1.25.18 RESET_SPENT operation), 2026-04-14 (v0.1.25.17 cjson round-trip sweep: apikey + policy + tenant), 2026-04-13 (v0.1.25.16 webhooks dual-auth), 2026-04-13 (v0.1.25.15 ScopeValidator), 2026-04-13 (v0.1.25.14 admin-on-behalf-of dual-auth), 2026-04-13 (v0.1.25.13 CORS PUT fix), 2026-04-12 (v0.1.25.12 spec-compliance hardening + observability), 2026-04-12 (v0.1.25.11 contract-testing default ON), 2026-04-12 (v0.1.25.10 spec-compliance hardening), 2026-04-10 (v0.1.25.9 release), 2026-04-10 (CORS hardening + prod config), 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
+**Server version:** 0.1.25.30 (2026-04-18 — bulk-action audit metadata enrichment; spec v0.1.25.26, no spec bump)
+**Date:** 2026-04-18 (v0.1.25.30 bulk-action audit enrichment), 2026-04-18 (v0.1.25.29 budget bulk-action), 2026-04-17 (v0.1.25.28 audit sentinel split), 2026-04-17 (v0.1.25.27 audit filter DSL upgrade), 2026-04-17 (v0.1.25.26 bulk-action endpoints), 2026-04-17 (v0.1.25.25 search on six list endpoints), 2026-04-16 (v0.1.25.24 server-side sort — six admin list endpoints), 2026-04-16 (v0.1.25.23 BudgetLedger tenant_id on wire), 2026-04-16 (v0.1.25.22 cross-tenant list + filters), 2026-04-16 (v0.1.25.21 nightly CI), 2026-04-16 (v0.1.25.20 audit-on-failure), 2026-04-16 (v0.1.25.19 introspect dual-auth + operator docs), 2026-04-15 (v0.1.25.18 RESET_SPENT operation), 2026-04-14 (v0.1.25.17 cjson round-trip sweep: apikey + policy + tenant), 2026-04-13 (v0.1.25.16 webhooks dual-auth), 2026-04-13 (v0.1.25.15 ScopeValidator), 2026-04-13 (v0.1.25.14 admin-on-behalf-of dual-auth), 2026-04-13 (v0.1.25.13 CORS PUT fix), 2026-04-12 (v0.1.25.12 spec-compliance hardening + observability), 2026-04-12 (v0.1.25.11 contract-testing default ON), 2026-04-12 (v0.1.25.10 spec-compliance hardening), 2026-04-10 (v0.1.25.9 release), 2026-04-10 (CORS hardening + prod config), 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
 **Spec:** [`cycles-governance-admin-v0.1.25.yaml`](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml) (OpenAPI 3.1.0, info.version `0.1.25.26`; adds `POST /v1/admin/budgets/bulk-action` — fifth bulk-action endpoint, mirrors the tenant/webhook envelope) in [cycles-protocol](https://github.com/runcycles/cycles-protocol)
 **Server:** Spring Boot 3.5.11 / Java 21 / Redis
+
+### 2026-04-18 — v0.1.25.30 bulk-action audit metadata enrichment (no spec bump)
+
+**Motivation — triage gap.** Prior to v0.1.25.30 the single `AuditLogEntry` emitted per bulk-action invocation (tenant / webhook / budget) carried only the five bucket counts + `idempotency_key` in its `metadata` map. Post-incident triage of a failed bulk-op required either the operator's own copy of the synchronous response envelope (which they may not have preserved) or re-running the op (not acceptable for destructive actions like DELETE / DEBIT). The audit log was a **dead end** for "which rows actually failed and why?"
+
+**Scope.** All three bulk-action endpoints — `bulkActionTenants`, `bulkActionWebhooks`, `bulkActionBudgets` — now emit the full per-row outcome arrays plus surrounding context. Unified through one shared helper so the three controllers cannot drift.
+
+**New metadata keys (additive — existing keys unchanged):**
+
+| Key | Type | Purpose |
+|---|---|---|
+| `succeeded_ids` | `List<String>` | Per-row ids of successful operations — paper trail for compliance. |
+| `failed_rows` | `List<BulkActionRowOutcome>` | Full `id + error_code + message` per failure — replaces the "re-run to see what broke" workflow. |
+| `skipped_rows` | `List<BulkActionRowOutcome>` | Full `id + reason` per skip — distinguishes `ALREADY_IN_TARGET_STATE` from `ALREADY_DELETED`. |
+| `filter` | Object | The normalized filter echoed as-is. Reconstructs operator intent from the audit log alone. |
+| `duration_ms` | `long` | Handler-entry → audit-emit wall-clock — SLO triage without needing trace sampling. |
+
+**Bounding.** The existing 500-row bulk-action cap bounds worst-case metadata size to ~40 KB (500 × ~80 bytes per outcome + filter echo + fixed keys), well within Redis value-size comfort range. No new limits required.
+
+**Ordering.** The helper uses `LinkedHashMap` so JSON serialization preserves the documented key order — aids human scannability in log viewers and pins the contract for downstream dashboards.
+
+**What changed:**
+
+- New `BulkActionAuditMetadataBuilder` utility (`cycles-admin-service-api/src/main/java/.../api/service/`). Single static `build(...)` method taking the inputs every bulk-action controller already has in scope: `actionName`, `totalMatched`, the three outcome lists, `idempotencyKey`, `filter`, and `startTimeNanos` captured at handler entry.
+- `TenantController.bulkAction` / `WebhookAdminController.bulkAction` / `BudgetController.bulkAction` — each replaced the 6-line inline `auditMeta.put(...)` block with one call to the helper. Also capture `long startNanos = System.nanoTime()` as the first statement of each handler so `duration_ms` measures match/apply time end-to-end.
+
+**What did NOT change:**
+
+- No spec bump. `AuditLogEntry.metadata` is already typed as a free-form `object` with `additionalProperties: true` in the OpenAPI spec. Adding keys is additive per the spec's compatibility contract. The `OpenApiContractDiffTest` / `SpecCoverageReportTest` gates remain green against spec v0.1.25.26 with no changes needed on the cycles-protocol side.
+- No request / response shape changes. The synchronous bulk-action response envelope continues to be the record of truth for callers; this enrichment only adds parallel detail to the audit persistence path.
+- No new ErrorCode values, no new HTTP status codes.
+
+**Why a single helper, not controller-local blocks.** The three bulk-action handlers have been drifting slightly on `metadata` since v0.1.25.26 shipped (one used `new LinkedHashMap<>()`, another used `HashMap`, the ordering guarantee was not explicit). Consolidating the builder pins key order and key set for every future bulk-action endpoint we add.
+
+**Verification.**
+
+```bash
+# Targeted
+mvn-proxy -B test --file cycles-admin-service/pom.xml \
+  -pl cycles-admin-service-api \
+  -Dtest=BulkActionAuditMetadataBuilderTest,TenantControllerTest,WebhookAdminControllerTest,BudgetControllerBulkActionTest
+
+# Full verify (no Docker)
+mvn-proxy -B verify --file cycles-admin-service/pom.xml \
+  -Dtest='!*IntegrationTest' -Dsurefire.failIfNoSpecifiedTests=false
+```
+
+**Tests added / extended:**
+
+- `BulkActionAuditMetadataBuilderTest` (new, 5 tests): covers every key the helper emits, pins the documented ordering contract (`containsExactly`), exercises the empty-buckets case, null-filter passthrough, `duration_ms` non-negative, and `succeeded_ids` ordering mirrors the input list.
+- `BudgetControllerBulkActionTest.bulkAction_emitsAuditLogEntryWithMetadataKeys` — extended to assert the five new keys on the happy-path envelope.
+- `TenantControllerTest.bulkActionTenants_auditMetadata_carriesV030EnrichmentKeys` (new): smoke-asserts the wiring against a real controller handler — proves the helper is called and `startNanos` is threaded correctly.
+- `WebhookAdminControllerTest.bulkActionWebhooks_auditMetadata_carriesV030EnrichmentKeys` (new): same pattern for the webhook endpoint.
+
+**Release versions bumped:**
+
+- `cycles-admin-service/pom.xml` — `0.1.25.29` → `0.1.25.30`
+- `docker-compose.prod.yml` / `docker-compose.full-stack.prod.yml` — image tag to `0.1.25.30`
 
 ### 2026-04-18 — v0.1.25.28.1 test fix: nightly soak AS4 must include `__admin__` sentinel
 

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/BudgetController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/BudgetController.java
@@ -14,6 +14,7 @@ import io.runcycles.admin.model.shared.SortSpec;
 import io.runcycles.admin.model.shared.UnitEnum;
 import io.runcycles.admin.api.config.ScopeFilterUtil;
 import io.runcycles.admin.api.config.ScopeValidator;
+import io.runcycles.admin.api.service.BulkActionAuditMetadataBuilder;
 import io.runcycles.admin.api.service.EventService;
 import io.runcycles.admin.model.event.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -449,6 +450,7 @@ public class BudgetController {
     @PostMapping("/bulk-action") @Operation(operationId = "bulkActionBudgets")
     public ResponseEntity<BudgetBulkActionResponse> bulkAction(
             @Valid @RequestBody BudgetBulkActionRequest request, HttpServletRequest httpRequest) {
+        long startNanos = System.nanoTime();
         // Action/payload validation runs BEFORE any Redis read so that
         // malformed combos fail fast with 400 and never enter the match /
         // apply path (spec requirement).
@@ -503,13 +505,10 @@ public class BudgetController {
 
         idempotencyStore.store(BULK_IDEMPOTENCY_ENDPOINT, request.getIdempotencyKey(), response);
 
-        Map<String, Object> auditMeta = new java.util.LinkedHashMap<>();
-        auditMeta.put("action", request.getAction().name());
-        auditMeta.put("total_matched", matched.size());
-        auditMeta.put("succeeded", succeeded.size());
-        auditMeta.put("failed", failed.size());
-        auditMeta.put("skipped", skipped.size());
-        auditMeta.put("idempotency_key", request.getIdempotencyKey());
+        Map<String, Object> auditMeta = BulkActionAuditMetadataBuilder.build(
+            request.getAction().name(), matched.size(),
+            succeeded, failed, skipped,
+            request.getIdempotencyKey(), filter, startNanos);
         auditRepository.log(buildAuditEntry(httpRequest)
             .tenantId(filter.getTenantId())
             .resourceType("budget").resourceId("bulk-action")

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/TenantController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/TenantController.java
@@ -18,6 +18,7 @@ import io.runcycles.admin.model.tenant.TenantCreateRequest;
 import io.runcycles.admin.model.tenant.TenantListResponse;
 import io.runcycles.admin.model.tenant.TenantStatus;
 import io.runcycles.admin.model.tenant.TenantUpdateRequest;
+import io.runcycles.admin.api.service.BulkActionAuditMetadataBuilder;
 import io.runcycles.admin.api.service.EventService;
 import io.runcycles.admin.model.event.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -202,6 +203,7 @@ public class TenantController {
     @PostMapping("/bulk-action") @Operation(operationId = "bulkActionTenants")
     public ResponseEntity<TenantBulkActionResponse> bulkAction(
             @Valid @RequestBody TenantBulkActionRequest request, HttpServletRequest httpRequest) {
+        long startNanos = System.nanoTime();
         if (request.getFilter() == null || request.getFilter().isEmpty()) {
             throw new GovernanceException(ErrorCode.INVALID_REQUEST,
                 "filter must contain at least one property", 400);
@@ -259,13 +261,10 @@ public class TenantController {
 
         idempotencyStore.store(BULK_IDEMPOTENCY_ENDPOINT, request.getIdempotencyKey(), response);
 
-        Map<String, Object> auditMeta = new java.util.LinkedHashMap<>();
-        auditMeta.put("action", request.getAction().name());
-        auditMeta.put("total_matched", matched.size());
-        auditMeta.put("succeeded", succeeded.size());
-        auditMeta.put("failed", failed.size());
-        auditMeta.put("skipped", skipped.size());
-        auditMeta.put("idempotency_key", request.getIdempotencyKey());
+        Map<String, Object> auditMeta = BulkActionAuditMetadataBuilder.build(
+            request.getAction().name(), matched.size(),
+            succeeded, failed, skipped,
+            request.getIdempotencyKey(), request.getFilter(), startNanos);
         auditRepository.log(buildAuditEntry(httpRequest)
             .resourceType("tenant").resourceId("bulk-action")
             .operation("bulkActionTenants").status(200)

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/WebhookAdminController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/WebhookAdminController.java
@@ -1,5 +1,6 @@
 package io.runcycles.admin.api.controller;
 
+import io.runcycles.admin.api.service.BulkActionAuditMetadataBuilder;
 import io.runcycles.admin.api.service.EventService;
 import io.runcycles.admin.api.service.WebhookService;
 import io.runcycles.admin.data.exception.GovernanceException;
@@ -202,6 +203,7 @@ public class WebhookAdminController {
     @PostMapping("/bulk-action") @Operation(operationId = "bulkActionWebhooks")
     public ResponseEntity<WebhookBulkActionResponse> bulkAction(
             @Valid @RequestBody WebhookBulkActionRequest request, HttpServletRequest httpRequest) {
+        long startNanos = System.nanoTime();
         if (request.getFilter() == null || request.getFilter().isEmpty()) {
             throw new GovernanceException(ErrorCode.INVALID_REQUEST,
                 "filter must contain at least one property", 400);
@@ -254,13 +256,10 @@ public class WebhookAdminController {
 
         idempotencyStore.store(BULK_IDEMPOTENCY_ENDPOINT, request.getIdempotencyKey(), response);
 
-        Map<String, Object> auditMeta = new java.util.LinkedHashMap<>();
-        auditMeta.put("action", request.getAction().name());
-        auditMeta.put("total_matched", matched.size());
-        auditMeta.put("succeeded", succeeded.size());
-        auditMeta.put("failed", failed.size());
-        auditMeta.put("skipped", skipped.size());
-        auditMeta.put("idempotency_key", request.getIdempotencyKey());
+        Map<String, Object> auditMeta = BulkActionAuditMetadataBuilder.build(
+            request.getAction().name(), matched.size(),
+            succeeded, failed, skipped,
+            request.getIdempotencyKey(), request.getFilter(), startNanos);
         auditRepository.log(buildAuditEntry(httpRequest)
             .resourceType("webhook").resourceId("bulk-action")
             .operation("bulkActionWebhooks").status(200)

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/BulkActionAuditMetadataBuilder.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/BulkActionAuditMetadataBuilder.java
@@ -1,0 +1,82 @@
+package io.runcycles.admin.api.service;
+
+import io.runcycles.admin.model.shared.BulkActionRowOutcome;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builds the {@code metadata} map embedded in the single {@code AuditLogEntry}
+ * emitted per bulk-action invocation (v0.1.25.30 enrichment).
+ *
+ * <p>Prior to v0.1.25.30 the map carried bucket counts only, which meant
+ * post-incident triage of a bulk-op required either (a) the operator's
+ * own copy of the response envelope or (b) re-running the op. Neither
+ * is acceptable for compliance review. This builder closes that gap by
+ * embedding the full per-row outcomes plus enough surrounding context
+ * (filter echo, duration) to reconstruct intent.
+ *
+ * <p><b>Emitted keys</b> (stable — downstream dashboards rely on them):
+ * <table>
+ *   <tr><th>key</th><th>type</th><th>purpose</th></tr>
+ *   <tr><td>{@code action}</td><td>String</td><td>echo of the action enum</td></tr>
+ *   <tr><td>{@code total_matched}</td><td>int</td><td>rows the filter matched</td></tr>
+ *   <tr><td>{@code succeeded}</td><td>int</td><td>count — kept for backward compat</td></tr>
+ *   <tr><td>{@code failed}</td><td>int</td><td>count — kept for backward compat</td></tr>
+ *   <tr><td>{@code skipped}</td><td>int</td><td>count — kept for backward compat</td></tr>
+ *   <tr><td>{@code succeeded_ids}</td><td>List&lt;String&gt;</td>
+ *       <td>per-row ids of successful operations — paper trail</td></tr>
+ *   <tr><td>{@code failed_rows}</td><td>List&lt;BulkActionRowOutcome&gt;</td>
+ *       <td>full id + error_code + message per failure</td></tr>
+ *   <tr><td>{@code skipped_rows}</td><td>List&lt;BulkActionRowOutcome&gt;</td>
+ *       <td>full id + reason per skip</td></tr>
+ *   <tr><td>{@code filter}</td><td>Object</td>
+ *       <td>normalized filter — reconstructs operator intent</td></tr>
+ *   <tr><td>{@code idempotency_key}</td><td>String</td>
+ *       <td>correlates envelope ↔ retries ↔ audit</td></tr>
+ *   <tr><td>{@code duration_ms}</td><td>long</td>
+ *       <td>handler-entry → audit-emit wall-clock — SLO triage</td></tr>
+ * </table>
+ *
+ * <p><b>Bounding.</b> The 500-row bulk-action cap bounds worst-case metadata
+ * size to ~40 KB, well within Redis value-size comfort range.
+ *
+ * <p><b>Ordering.</b> Returns a {@link LinkedHashMap} so JSON serialization
+ * preserves the table order above — aids human scannability in log viewers.
+ */
+public final class BulkActionAuditMetadataBuilder {
+
+    private BulkActionAuditMetadataBuilder() {}
+
+    /**
+     * @param startTimeNanos value of {@link System#nanoTime()} captured
+     *                       at handler entry. Used to compute
+     *                       {@code duration_ms} at emit time.
+     */
+    public static Map<String, Object> build(
+            String actionName,
+            int totalMatched,
+            List<BulkActionRowOutcome> succeeded,
+            List<BulkActionRowOutcome> failed,
+            List<BulkActionRowOutcome> skipped,
+            String idempotencyKey,
+            Object filter,
+            long startTimeNanos) {
+        Map<String, Object> meta = new LinkedHashMap<>();
+        meta.put("action", actionName);
+        meta.put("total_matched", totalMatched);
+        meta.put("succeeded", succeeded.size());
+        meta.put("failed", failed.size());
+        meta.put("skipped", skipped.size());
+        meta.put("succeeded_ids", succeeded.stream()
+                .map(BulkActionRowOutcome::getId)
+                .toList());
+        meta.put("failed_rows", failed);
+        meta.put("skipped_rows", skipped);
+        meta.put("filter", filter);
+        meta.put("idempotency_key", idempotencyKey);
+        meta.put("duration_ms", (System.nanoTime() - startTimeNanos) / 1_000_000L);
+        return meta;
+    }
+}

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BudgetControllerBulkActionTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BudgetControllerBulkActionTest.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -565,6 +566,12 @@ class BudgetControllerBulkActionTest {
         assertEquals(0, entry.getMetadata().get("failed"));
         assertEquals(0, entry.getMetadata().get("skipped"));
         assertEquals("k1", entry.getMetadata().get("idempotency_key"));
+        // v0.1.25.30 enrichment — per-row outcomes + filter echo + wall-clock
+        assertEquals(List.of("led-tenant:acme/workspace:eng"), entry.getMetadata().get("succeeded_ids"));
+        assertEquals(List.of(), entry.getMetadata().get("failed_rows"));
+        assertEquals(List.of(), entry.getMetadata().get("skipped_rows"));
+        assertThat(entry.getMetadata()).containsKey("filter");
+        assertThat((Long) entry.getMetadata().get("duration_ms")).isGreaterThanOrEqualTo(0L);
     }
 
     // -------- Auth ------------------------------------------------------

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/TenantControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/TenantControllerTest.java
@@ -926,6 +926,39 @@ class TenantControllerTest {
     }
 
     @Test
+    void bulkActionTenants_auditMetadata_carriesV030EnrichmentKeys() throws Exception {
+        // v0.1.25.30: audit metadata now carries per-row outcomes + filter
+        // echo + duration so post-incident triage needs only the audit log.
+        when(idempotencyStore.lookup(anyString(), anyString(), eq(TenantBulkActionResponse.class)))
+                .thenReturn(java.util.Optional.empty());
+        when(tenantRepository.matchForBulk(eq(TenantStatus.ACTIVE), isNull(), isNull(), eq(500)))
+                .thenReturn(List.of(tenantRow("t1", TenantStatus.ACTIVE)));
+        when(tenantRepository.get("t1")).thenReturn(tenantRow("t1", TenantStatus.ACTIVE));
+        when(tenantRepository.update(eq("t1"), any()))
+                .thenReturn(tenantRow("t1", TenantStatus.SUSPENDED));
+
+        mockMvc.perform(post("/v1/admin/tenants/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"filter\":{\"status\":\"ACTIVE\"},\"action\":\"SUSPEND\",\"idempotency_key\":\"k1\"}"))
+                .andExpect(status().isOk());
+
+        org.mockito.ArgumentCaptor<io.runcycles.admin.model.audit.AuditLogEntry> auditArg =
+                org.mockito.ArgumentCaptor.forClass(io.runcycles.admin.model.audit.AuditLogEntry.class);
+        verify(auditRepository).log(auditArg.capture());
+        java.util.Map<String, Object> meta = auditArg.getValue().getMetadata();
+        assertEquals("bulkActionTenants", auditArg.getValue().getOperation());
+        assertEquals("SUSPEND", meta.get("action"));
+        assertEquals(1, meta.get("total_matched"));
+        assertEquals(List.of("t1"), meta.get("succeeded_ids"));
+        assertEquals(List.of(), meta.get("failed_rows"));
+        assertEquals(List.of(), meta.get("skipped_rows"));
+        assertEquals("k1", meta.get("idempotency_key"));
+        org.assertj.core.api.Assertions.assertThat(meta).containsKey("filter");
+        org.assertj.core.api.Assertions.assertThat((Long) meta.get("duration_ms")).isGreaterThanOrEqualTo(0L);
+    }
+
+    @Test
     void bulkActionTenants_genericException_classifiedAsInternalError() throws Exception {
         // Non-GovernanceException falls into the generic Exception catch,
         // logged and reported as INTERNAL_ERROR.

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookAdminControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookAdminControllerTest.java
@@ -647,6 +647,38 @@ class WebhookAdminControllerTest {
     }
 
     @Test
+    void bulkActionWebhooks_auditMetadata_carriesV030EnrichmentKeys() throws Exception {
+        // v0.1.25.30: audit metadata now carries per-row outcomes + filter
+        // echo + duration_ms so post-incident triage needs only the audit log.
+        when(idempotencyStore.lookup(anyString(), anyString(), eq(WebhookBulkActionResponse.class)))
+                .thenReturn(java.util.Optional.empty());
+        when(webhookRepository.matchForBulk(isNull(), eq(WebhookStatus.ACTIVE), isNull(), isNull(), eq(500)))
+                .thenReturn(List.of(webhookRow("whsub_1", WebhookStatus.ACTIVE)));
+        when(webhookRepository.findById("whsub_1")).thenReturn(webhookRow("whsub_1", WebhookStatus.ACTIVE));
+        when(webhookService.update(anyString(), any())).thenReturn(webhookRow("whsub_1", WebhookStatus.PAUSED));
+
+        mockMvc.perform(post("/v1/admin/webhooks/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"filter\":{\"status\":\"ACTIVE\"},\"action\":\"PAUSE\",\"idempotency_key\":\"k1\"}"))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<io.runcycles.admin.model.audit.AuditLogEntry> auditArg =
+                ArgumentCaptor.forClass(io.runcycles.admin.model.audit.AuditLogEntry.class);
+        verify(auditRepository).log(auditArg.capture());
+        java.util.Map<String, Object> meta = auditArg.getValue().getMetadata();
+        org.junit.jupiter.api.Assertions.assertEquals("bulkActionWebhooks", auditArg.getValue().getOperation());
+        org.junit.jupiter.api.Assertions.assertEquals("PAUSE", meta.get("action"));
+        org.junit.jupiter.api.Assertions.assertEquals(1, meta.get("total_matched"));
+        org.junit.jupiter.api.Assertions.assertEquals(List.of("whsub_1"), meta.get("succeeded_ids"));
+        org.junit.jupiter.api.Assertions.assertEquals(List.of(), meta.get("failed_rows"));
+        org.junit.jupiter.api.Assertions.assertEquals(List.of(), meta.get("skipped_rows"));
+        org.junit.jupiter.api.Assertions.assertEquals("k1", meta.get("idempotency_key"));
+        org.assertj.core.api.Assertions.assertThat(meta).containsKey("filter");
+        org.assertj.core.api.Assertions.assertThat((Long) meta.get("duration_ms")).isGreaterThanOrEqualTo(0L);
+    }
+
+    @Test
     void bulkActionWebhooks_genericException_classifiedAsInternalError() throws Exception {
         when(idempotencyStore.lookup(anyString(), anyString(), eq(WebhookBulkActionResponse.class)))
                 .thenReturn(java.util.Optional.empty());

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/BulkActionAuditMetadataBuilderTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/BulkActionAuditMetadataBuilderTest.java
@@ -1,0 +1,101 @@
+package io.runcycles.admin.api.service;
+
+import io.runcycles.admin.model.shared.BulkActionRowOutcome;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Covers every key the v0.1.25.30 bulk-action metadata builder emits
+ * and pins the ordering contract so downstream dashboards that rely on
+ * JSON field order do not silently regress.
+ */
+class BulkActionAuditMetadataBuilderTest {
+
+    @Test
+    void build_emitsAllKeysInDocumentedOrder() {
+        List<BulkActionRowOutcome> succeeded = List.of(row("t_ok_1"), row("t_ok_2"));
+        List<BulkActionRowOutcome> failed = List.of(
+                BulkActionRowOutcome.builder().id("t_fail").errorCode("BUDGET_EXCEEDED")
+                        .message("remaining would go negative").build());
+        List<BulkActionRowOutcome> skipped = List.of(
+                BulkActionRowOutcome.builder().id("t_skip").reason("ALREADY_IN_TARGET_STATE").build());
+        Object filter = Map.of("tenant_id", "acme", "scope_prefix", "tenant:acme/workspace:eng");
+        long startNanos = System.nanoTime() - 5_000_000L; // ~5 ms ago
+
+        Map<String, Object> meta = BulkActionAuditMetadataBuilder.build(
+                "CREDIT", 4, succeeded, failed, skipped, "rollover-2026-04", filter, startNanos);
+
+        assertThat(meta.keySet()).containsExactly(
+                "action", "total_matched", "succeeded", "failed", "skipped",
+                "succeeded_ids", "failed_rows", "skipped_rows",
+                "filter", "idempotency_key", "duration_ms");
+        assertThat(meta.get("action")).isEqualTo("CREDIT");
+        assertThat(meta.get("total_matched")).isEqualTo(4);
+        assertThat(meta.get("succeeded")).isEqualTo(2);
+        assertThat(meta.get("failed")).isEqualTo(1);
+        assertThat(meta.get("skipped")).isEqualTo(1);
+        assertThat(meta.get("succeeded_ids")).isEqualTo(List.of("t_ok_1", "t_ok_2"));
+        assertThat(meta.get("failed_rows")).isEqualTo(failed);
+        assertThat(meta.get("skipped_rows")).isEqualTo(skipped);
+        assertThat(meta.get("filter")).isEqualTo(filter);
+        assertThat(meta.get("idempotency_key")).isEqualTo("rollover-2026-04");
+        assertThat((Long) meta.get("duration_ms")).isGreaterThanOrEqualTo(0L);
+    }
+
+    @Test
+    void build_allEmptyBuckets_stillEmitsArrays() {
+        Map<String, Object> meta = BulkActionAuditMetadataBuilder.build(
+                "DELETE", 0, List.of(), List.of(), List.of(),
+                "k1", Map.of("tenant_id", "acme"), System.nanoTime());
+
+        assertThat(meta.get("succeeded")).isEqualTo(0);
+        assertThat(meta.get("failed")).isEqualTo(0);
+        assertThat(meta.get("skipped")).isEqualTo(0);
+        assertThat((List<?>) meta.get("succeeded_ids")).isEmpty();
+        assertThat((List<?>) meta.get("failed_rows")).isEmpty();
+        assertThat((List<?>) meta.get("skipped_rows")).isEmpty();
+    }
+
+    @Test
+    void build_nullFilter_isPassedThroughUnchanged() {
+        // A controller that rejects a missing filter at validation time never reaches the
+        // builder, but defense-in-depth: null is allowed and echoed, not substituted.
+        Map<String, Object> meta = BulkActionAuditMetadataBuilder.build(
+                "RESET", 0, List.of(), List.of(), List.of(), "k1", null, System.nanoTime());
+
+        assertThat(meta).containsKey("filter");
+        assertThat(meta.get("filter")).isNull();
+    }
+
+    @Test
+    void build_durationMs_isMonotonicAndNonNegative() {
+        long start = System.nanoTime();
+        Map<String, Object> meta = BulkActionAuditMetadataBuilder.build(
+                "PAUSE", 0, List.of(), List.of(), List.of(), "k1",
+                Map.of("tenant_id", "acme"), start);
+        assertThat((Long) meta.get("duration_ms")).isGreaterThanOrEqualTo(0L);
+    }
+
+    @Test
+    void build_succeededIdsOrder_mirrorsInputOrder() {
+        List<BulkActionRowOutcome> succeeded = new ArrayList<>();
+        succeeded.add(row("id-3"));
+        succeeded.add(row("id-1"));
+        succeeded.add(row("id-2"));
+
+        Map<String, Object> meta = BulkActionAuditMetadataBuilder.build(
+                "RESUME", 3, succeeded, List.of(), List.of(), "k1",
+                Map.of("tenant_id", "acme"), System.nanoTime());
+
+        assertThat(meta.get("succeeded_ids")).isEqualTo(List.of("id-3", "id-1", "id-2"));
+    }
+
+    private static BulkActionRowOutcome row(String id) {
+        return BulkActionRowOutcome.builder().id(id).build();
+    }
+}

--- a/cycles-admin-service/pom.xml
+++ b/cycles-admin-service/pom.xml
@@ -18,7 +18,7 @@
         <module>cycles-admin-service-api</module>
     </modules>
     <properties>
-        <revision>0.1.25.29</revision>
+        <revision>0.1.25.30</revision>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/docker-compose.full-stack.prod.yml
+++ b/docker-compose.full-stack.prod.yml
@@ -13,7 +13,7 @@ services:
       retries: 5
 
   cycles-admin:
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.29
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.30
     restart: unless-stopped
     ports:
       - "7979:7979"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,7 +13,7 @@ services:
       retries: 5
 
   cycles-admin:
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.29
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.30
     restart: unless-stopped
     ports:
       - "7979:7979"


### PR DESCRIPTION
## Summary

- **Problem:** Before v0.1.25.30 the single `AuditLogEntry` emitted per bulk-action invocation (tenant / webhook / budget) carried only bucket counts + `idempotency_key` in its `metadata` map. Post-incident triage of a failed bulk-op required the operator's own copy of the response envelope or re-running the op — neither acceptable for compliance review or for destructive actions (DELETE / DEBIT). The audit log was a **dead end** for _\"which rows actually failed and why?\"_
- **Fix:** Five new metadata keys across all three bulk-action endpoints (`bulkActionTenants` / `bulkActionWebhooks` / `bulkActionBudgets`): `succeeded_ids`, `failed_rows`, `skipped_rows`, `filter` echo, `duration_ms`. Additive only — existing keys unchanged.
- **Shape:** Worst-case metadata ~40 KB (500-row cap × ~80 B per outcome), well within Redis value-size comfort range. `LinkedHashMap` pins key order for downstream dashboard compatibility.
- **Refactor:** Three previously inline ``auditMeta.put(...)`` blocks consolidated into one ``BulkActionAuditMetadataBuilder.build(...)`` helper so future bulk-action endpoints cannot drift on key set or key order.
- **No spec bump:** `AuditLogEntry.metadata` is already typed `object` with `additionalProperties: true` in spec v0.1.25.26 — this enrichment is additive by the spec contract. ``OpenApiContractDiffTest`` and ``SpecCoverageReportTest`` both remain green with no cycles-protocol changes.

### New metadata keys

| Key | Type | Purpose |
|---|---|---|
| ``succeeded_ids`` | ``List<String>`` | Per-row ids of successful operations — paper trail. |
| ``failed_rows`` | ``List<BulkActionRowOutcome>`` | Full ``id + error_code + message`` per failure — replaces re-run-to-see-what-broke. |
| ``skipped_rows`` | ``List<BulkActionRowOutcome>`` | Full ``id + reason`` per skip — distinguishes ``ALREADY_IN_TARGET_STATE`` from ``ALREADY_DELETED``. |
| ``filter`` | Object | Normalized filter echoed as-is — reconstructs operator intent from audit alone. |
| ``duration_ms`` | ``long`` | Handler-entry → audit-emit wall-clock — SLO triage without trace sampling. |

## Test plan

- [x] ``BulkActionAuditMetadataBuilderTest`` (new, 5 cases): every key, documented key ordering, empty buckets, null filter passthrough, ``duration_ms`` non-negative, ``succeeded_ids`` order mirrors input.
- [x] ``BudgetControllerBulkActionTest.bulkAction_emitsAuditLogEntryWithMetadataKeys`` — extended to assert all five new keys on the happy-path envelope.
- [x] ``TenantControllerTest.bulkActionTenants_auditMetadata_carriesV030EnrichmentKeys`` (new) — proves helper is wired and ``startNanos`` is threaded correctly.
- [x] ``WebhookAdminControllerTest.bulkActionWebhooks_auditMetadata_carriesV030EnrichmentKeys`` (new) — same for webhook endpoint.
- [x] Full non-integration verify green: **705 tests pass**, JaCoCo ≥95% per module, ``SpecCoverageReportTest`` 46/46 covered, ``OpenApiContractDiffTest`` green.
- [ ] Nightly soak (Docker-gated) after merge — no production path changes, expected green.

### Version bumps

- ``cycles-admin-service/pom.xml`` → ``0.1.25.30``
- ``docker-compose.prod.yml`` / ``docker-compose.full-stack.prod.yml`` → image tag ``0.1.25.30``