### PR TITLE
chore(deps): fix Dependabot maven directory for multi-module layout

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "maven"
-    directory: "/"
+    directory: "/cycles-admin-service"
     schedule:
       interval: "weekly"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary

`.github/dependabot.yml` had `directory: "/"` for the maven ecosystem, but this repo has no pom.xml at root — Maven lives under `cycles-admin-service/`. Dependabot silently found no pom and has never opened a single Maven dependency PR for this repo (verified: full PR history shows only GitHub Actions bumps).

## Fix

Point maven at `/cycles-admin-service` where the multi-module parent lives. Dependabot recursively traverses `<modules>`, so this one entry covers `-model`, `-data`, and `-api`.

## Expected follow-up

First post-fix Dependabot run will likely surface a backlog of previously-invisible bumps — including Spring Boot 3.5.13 → 4.0.5 and likely Jedis 5 → 7 (same proposals already open on cycles-server-events). That backlog is deliberate: we want the visibility now that it's exposed.

## Test plan

- [ ] Merge
- [ ] Wait for next scheduled Dependabot run (or trigger via repo Insights → Dependency graph → Dependabot → "Check for updates")
- [ ] Confirm Maven PRs start arriving