### PR TITLE
chore(ci): auto-merge Dependabot patch-level bumps

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,23 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Enable auto-merge for patch updates
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/dependabot-auto-merge.yml` — auto-merges Dependabot PRs classified as `version-update:semver-patch`. Minor and major bumps still require human review.

## Why

Cuts the weekly Dependabot manual-merge grind. Patch-level bumps carry vanishingly low breaking-change risk, and merge is gated by `--auto`, which waits for the repo's required status checks (CI + CodeQL) to pass before completing.

Safe only because branch protection on `main` with required status checks was added recently — without it, a failing patch bump would merge immediately.

## Scope of auto-merge

| Update type | Behavior |
|---|---|
| `version-update:semver-patch` | Auto-merge after CI green |
| `version-update:semver-minor` | Manual review |
| `version-update:semver-major` | Manual review |
| Security updates | Auto-merge if patch; manual otherwise |

## Test plan

- [ ] Workflow syntax valid (CodeQL `Analyze (actions)` passes)
- [ ] First post-merge Dependabot patch PR auto-merges after checks pass
- [ ] First post-merge Dependabot minor/major PR does NOT auto-merge (stays open for review)
