### PR TITLE
feat(admin): v0.1.25.36 — expand Rule 2 TENANT_CLOSED guard to all mutation sites

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,9 +1,91 @@
-# Complete Budget Governance v0.1.25.35 — Admin Server Audit
+# Complete Budget Governance v0.1.25.36 — Admin Server Audit
 
-**Server version:** 0.1.25.35 (2026-04-20 — spec v0.1.25.29 CASCADE SEMANTICS; Rule 1 tenant-close cascade + Rule 2 TENANT_CLOSED mutation guard)
-**Date:** 2026-04-20 (v0.1.25.35 cascade + TENANT_CLOSED guard), 2026-04-19 (v0.1.25.34 commons-lang3 CVE pin), 2026-04-19 (v0.1.25.33 Spring Boot / Tomcat CVE bump), 2026-04-18 (v0.1.25.32 cross-plane read tolerance hardening), 2026-04-18 (v0.1.25.31 trace_id cross-surface correlation), 2026-04-18 (v0.1.25.30 bulk-action audit enrichment), 2026-04-18 (v0.1.25.29 budget bulk-action), 2026-04-17 (v0.1.25.28 audit sentinel split), 2026-04-17 (v0.1.25.27 audit filter DSL upgrade), 2026-04-17 (v0.1.25.26 bulk-action endpoints), 2026-04-17 (v0.1.25.25 search on six list endpoints), 2026-04-16 (v0.1.25.24 server-side sort — six admin list endpoints), 2026-04-16 (v0.1.25.23 BudgetLedger tenant_id on wire), 2026-04-16 (v0.1.25.22 cross-tenant list + filters), 2026-04-16 (v0.1.25.21 nightly CI), 2026-04-16 (v0.1.25.20 audit-on-failure), 2026-04-16 (v0.1.25.19 introspect dual-auth + operator docs), 2026-04-15 (v0.1.25.18 RESET_SPENT operation), 2026-04-14 (v0.1.25.17 cjson round-trip sweep: apikey + policy + tenant), 2026-04-13 (v0.1.25.16 webhooks dual-auth), 2026-04-13 (v0.1.25.15 ScopeValidator), 2026-04-13 (v0.1.25.14 admin-on-behalf-of dual-auth), 2026-04-13 (v0.1.25.13 CORS PUT fix), 2026-04-12 (v0.1.25.12 spec-compliance hardening + observability), 2026-04-12 (v0.1.25.11 contract-testing default ON), 2026-04-12 (v0.1.25.10 spec-compliance hardening), 2026-04-10 (v0.1.25.9 release), 2026-04-10 (CORS hardening + prod config), 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
+**Server version:** 0.1.25.36 (2026-04-20 — spec v0.1.25.29 CASCADE SEMANTICS Rule 2 guard coverage expanded across all admin-mutating endpoints)
+**Date:** 2026-04-20 (v0.1.25.36 Rule 2 guard expansion: policies + api-keys + webhook-admin create/update/delete/test/replay + budgets and webhooks bulk-action per-row + webhook-tenant delete/test), 2026-04-20 (v0.1.25.35 cascade + TENANT_CLOSED guard), 2026-04-19 (v0.1.25.34 commons-lang3 CVE pin), 2026-04-19 (v0.1.25.33 Spring Boot / Tomcat CVE bump), 2026-04-18 (v0.1.25.32 cross-plane read tolerance hardening), 2026-04-18 (v0.1.25.31 trace_id cross-surface correlation), 2026-04-18 (v0.1.25.30 bulk-action audit enrichment), 2026-04-18 (v0.1.25.29 budget bulk-action), 2026-04-17 (v0.1.25.28 audit sentinel split), 2026-04-17 (v0.1.25.27 audit filter DSL upgrade), 2026-04-17 (v0.1.25.26 bulk-action endpoints), 2026-04-17 (v0.1.25.25 search on six list endpoints), 2026-04-16 (v0.1.25.24 server-side sort — six admin list endpoints), 2026-04-16 (v0.1.25.23 BudgetLedger tenant_id on wire), 2026-04-16 (v0.1.25.22 cross-tenant list + filters), 2026-04-16 (v0.1.25.21 nightly CI), 2026-04-16 (v0.1.25.20 audit-on-failure), 2026-04-16 (v0.1.25.19 introspect dual-auth + operator docs), 2026-04-15 (v0.1.25.18 RESET_SPENT operation), 2026-04-14 (v0.1.25.17 cjson round-trip sweep: apikey + policy + tenant), 2026-04-13 (v0.1.25.16 webhooks dual-auth), 2026-04-13 (v0.1.25.15 ScopeValidator), 2026-04-13 (v0.1.25.14 admin-on-behalf-of dual-auth), 2026-04-13 (v0.1.25.13 CORS PUT fix), 2026-04-12 (v0.1.25.12 spec-compliance hardening + observability), 2026-04-12 (v0.1.25.11 contract-testing default ON), 2026-04-12 (v0.1.25.10 spec-compliance hardening), 2026-04-10 (v0.1.25.9 release), 2026-04-10 (CORS hardening + prod config), 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
 **Spec:** [`cycles-governance-admin-v0.1.25.yaml`](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml) (OpenAPI 3.1.0, info.version `0.1.25.29`; adds CASCADE SEMANTICS — Rule 1 `POST /admin/tenants/{id}` PATCH→CLOSED cascades owned budgets (→CLOSED), webhook subscriptions (→DISABLED), and API keys (→REVOKED) atomically under a shared correlation_id, and Rule 2 rejects any mutating operation against an object whose owning tenant is CLOSED with 409 `TENANT_CLOSED`; adds the `TENANT_CLOSED` error code to the shared enum and the four `*_via_tenant_cascade` event kinds: `budget.closed_via_tenant_cascade`, `webhook.disabled_via_tenant_cascade`, `api_key.revoked_via_tenant_cascade`, `reservation.released_via_tenant_cascade`) in [cycles-protocol](https://github.com/runcycles/cycles-protocol)
 **Server:** Spring Boot 3.5.13 / Java 21 / Redis · Tomcat 10.1.54 pin · commons-lang3 3.18.0 pin
+
+### 2026-04-20 — v0.1.25.36: Rule 2 guard coverage completed (spec v0.1.25.29 MUST)
+
+**Motivation.** A conformance review of server v0.1.25.35 against
+governance-admin spec v0.1.25.29 found that Rule 2 (terminal-owner
+mutation guard) was wired only into `BudgetController`
+(create/update/fund/freeze/unfreeze) and `WebhookTenantController`
+(create/update). The remaining admin-mutating endpoints — policies,
+API keys, admin-scoped webhooks (create/update/delete/test/replay),
+webhook-tenant delete/test, and the budgets + webhooks bulk-action
+endpoints' per-row apply — still let a mutation land against an
+object whose owning tenant was `CLOSED`, violating a spec MUST.
+v0.1.25.35's own AUDIT entry scoped this to a ".36 follow-up." This
+release closes that gap.
+
+**Scope of this release — guard callsites added.**
+
+| Controller | Endpoint(s) | Guard method used |
+|---|---|---|
+| `PolicyController` | `createPolicy`, `updatePolicy` | `assertTenantOpen(tenantId)`, `assertOpenForScope(scope)` |
+| `ApiKeyController` | `createApiKey`, `updateApiKey`, `revokeApiKey` | `assertTenantOpen(tenantId)` — revoke/update resolve owner via inline JedisPool read of `apikey:<id>` |
+| `WebhookAdminController` | `create`, `update`, `delete`, `test`, `replay`, `bulk-action` (per-row) | `assertTenantOpen`, `assertOpenForWebhook` |
+| `WebhookTenantController` | `delete`, `test` (create + update were already guarded) | `assertTenantOpen(existing.getTenantId())` |
+| `BudgetController` | `bulk-action` (per-row, pre-apply) | `assertTenantOpen(ledger.getTenantId())` |
+
+Controllers not in this release: tenant-scoped endpoints that mutate
+the tenant itself (`TenantController.bulkAction` SUSPEND branch etc.)
+stay out of scope — Rule 2 applies to *owned* objects; the tenant's
+own lifecycle is governed by Rule 1 + the existing
+`INVALID_TRANSITION` state machine.
+
+**Bulk-action behavior.** For both budgets and webhooks, a closed-
+owner row lands in `failed[]` with `error_code: "TENANT_CLOSED"`
+rather than aborting the whole batch — same bucketing discipline as
+the existing per-row rejection cases. `classifyFailureCode` /
+`classifyBudgetFailureCode` gained a `case TENANT_CLOSED → "TENANT_CLOSED"`
+branch so the row-level wire code matches the envelope-level one.
+
+**API-key owner resolution.** `updateApiKey` and `revokeApiKey` do
+not carry `tenant_id` on the request — the owning tenant is derived
+from the stored key record. To keep the guard callsite tight, both
+paths resolve the tenant via an inline `jedisPool.getResource()` +
+`jedis.get("apikey:<id>")` + `objectMapper.readValue(...)` (the same
+pattern already used by `updateApiKey` to load the prior record). A
+lookup miss → `null` tenant → guard no-ops, deferring to the
+controller's own 404 on the missing-key path; this keeps the guard
+from leaking existence via a different error code.
+
+**Test coverage added.** Each newly-guarded mutation site has a new
+contract test that stubs
+`doThrow(new GovernanceException(ErrorCode.TENANT_CLOSED, ..., 409))`
+on the mocked `TerminalOwnerMutationGuard` and asserts:
+- `409 Conflict` + `error: TENANT_CLOSED` for single-object paths.
+- Row lands in `failed[]` with `error_code: TENANT_CLOSED` and no
+  downstream repo/service call for bulk-action paths.
+
+New tests:
+- `PolicyControllerTest`: `createPolicy_closedTenant_returns409_tenantClosed`, `updatePolicy_closedTenant_returns409_tenantClosed`.
+- `ApiKeyControllerTest`: `createApiKey_closedTenant_returns409_tenantClosed`.
+- `WebhookAdminControllerTest`: `updateWebhook_closedTenant_returns409_tenantClosed`, `bulkActionWebhooks_closedTenantRow_landsInFailed_tenantClosed`.
+- `WebhookTenantControllerTest`: `deleteWebhook_closedTenant_returns409_tenantClosed`, `testWebhook_closedTenant_returns409_tenantClosed`.
+- `BudgetControllerBulkActionTest`: `bulkAction_closedTenantRow_landsInFailed_tenantClosed`.
+
+All four previously-unmocked test slices (`PolicyControllerTest`,
+`ApiKeyControllerTest`, `WebhookAdminControllerTest`,
+`BudgetControllerBulkActionTest`) now declare
+`@MockitoBean private TerminalOwnerMutationGuard mutationGuard;` so
+the `@WebMvcTest` context can wire the controllers without pulling
+the real `TenantRepository` / `WebhookRepository` transitive deps.
+
+**No wire change.** The `TENANT_CLOSED` error code landed in the
+shared `ErrorCode` enum in v0.1.25.35; .36 is purely additional
+callsites + row-level classifier coverage. OpenAPI contract diff,
+DTO contract tests, property-based audit invariants: unchanged.
+`declared=46 covered=46 missing=0` still holds.
+
+**Conformance posture vs. spec v0.1.25.29.**
+
+| Rule | v0.1.25.35 | v0.1.25.36 |
+|---|---|---|
+| Rule 1 — close-time cascade | ✅ complete | ✅ complete |
+| Rule 2 — terminal-owner mutation guard | ⚠️ partial (budgets + webhook-tenant create/update only) | ✅ complete (all admin mutation sites) |
 
 ### 2026-04-20 — v0.1.25.35: Cascade semantics (spec v0.1.25.29 Rule 1 + Rule 2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,36 @@ changes to request/response bodies or Lua-script semantics would require a
 minor bump. Additive fields (new optional response fields, new enum values,
 new optional request fields) are **not** considered breaking.
 
+## [0.1.25.36] — 2026-04-20
+
+### Added
+
+- **Rule 2 terminal-owner mutation guard coverage completed** —
+  closes the conformance gap flagged in v0.1.25.35's AUDIT entry.
+  Any mutation on an object whose owning tenant is `CLOSED` now
+  returns `409 TENANT_CLOSED` from every admin-mutating endpoint,
+  per spec v0.1.25.29 (MUST).
+
+  New guard callsites:
+  - `POST /v1/admin/policies`, `PATCH /v1/admin/policies/{id}`
+  - `POST /v1/admin/api-keys`, `PATCH /v1/admin/api-keys/{id}`,
+    `DELETE /v1/admin/api-keys/{id}`
+  - `POST /v1/admin/webhooks`, `PATCH /v1/admin/webhooks/{id}`,
+    `DELETE /v1/admin/webhooks/{id}`,
+    `POST /v1/admin/webhooks/{id}/test`,
+    `POST /v1/admin/webhooks/{id}/replay`
+  - `DELETE /v1/webhooks/{id}`, `POST /v1/webhooks/{id}/test`
+  - Per-row in `POST /v1/admin/budgets/bulk-action` and
+    `POST /v1/admin/webhooks/bulk-action` — closed-owner rows land
+    in `failed[]` with `error_code: "TENANT_CLOSED"`; sibling rows
+    still proceed.
+
+### Unchanged
+
+- No wire / OpenAPI / DTO contract change. `TENANT_CLOSED` already
+  shipped in the shared `ErrorCode` enum in v0.1.25.35; .36 adds
+  only callsites and the row-level classifier branch.
+
 ## [0.1.25.35] — 2026-04-20
 
 ### Added

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/ApiKeyController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/ApiKeyController.java
@@ -11,6 +11,7 @@ import io.runcycles.admin.model.shared.SortSpec;
 import io.runcycles.admin.api.filter.RequestIdFilter;
 import io.runcycles.admin.api.filter.TraceContextFilter;
 import io.runcycles.admin.api.service.EventService;
+import io.runcycles.admin.api.service.TerminalOwnerMutationGuard;
 import io.runcycles.admin.model.event.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
@@ -40,8 +41,10 @@ public class ApiKeyController {
     @Autowired private EventService eventService;
     @Autowired private ObjectMapper objectMapper;
     @Autowired private JedisPool jedisPool;
+    @Autowired private TerminalOwnerMutationGuard mutationGuard;
     @PostMapping @Operation(operationId = "createApiKey")
     public ResponseEntity<ApiKeyCreateResponse> create(@Valid @RequestBody ApiKeyCreateRequest request, HttpServletRequest httpRequest) {
+        mutationGuard.assertTenantOpen(request.getTenantId());
         ApiKeyCreateResponse response = repository.create(request);
         auditRepository.log(buildAuditEntry(httpRequest)
             .tenantId(request.getTenantId())
@@ -136,7 +139,7 @@ public class ApiKeyController {
     @PatchMapping("/{key_id}") @Operation(operationId = "updateApiKey")
     public ResponseEntity<ApiKeyResponse> update(@PathVariable("key_id") String keyId,
             @Valid @RequestBody ApiKeyUpdateRequest request, HttpServletRequest httpRequest) {
-        // Read old key state for change detection
+        // Read old key state for change detection + owner-tenant resolution (Rule 2).
         ApiKey oldKey = null;
         try (var jedis = jedisPool.getResource()) {
             String data = jedis.get("apikey:" + keyId);
@@ -144,6 +147,7 @@ public class ApiKeyController {
         } catch (Exception e) {
             LOG.warn("Failed to read old key for change detection: {}", e.getMessage());
         }
+        if (oldKey != null) mutationGuard.assertTenantOpen(oldKey.getTenantId());
 
         ApiKey updated = repository.update(keyId, request);
         ApiKeyResponse response = ApiKeyResponse.from(updated);
@@ -183,6 +187,10 @@ public class ApiKeyController {
 
     @DeleteMapping("/{key_id}") @Operation(operationId = "revokeApiKey")
     public ResponseEntity<ApiKeyResponse> revoke(@PathVariable("key_id") String keyId, @RequestParam(required = false) String reason, HttpServletRequest httpRequest) {
+        // Resolve the owning tenant pre-revoke so Rule 2 fires before the write;
+        // tolerant of missing keys so the repository's own NOT_FOUND path stays
+        // authoritative for that case.
+        mutationGuard.assertTenantOpen(resolveKeyTenantId(keyId));
         ApiKeyResponse response = ApiKeyResponse.from(repository.revoke(keyId, reason));
         auditRepository.log(buildAuditEntry(httpRequest)
             .tenantId(response.getTenantId())
@@ -202,6 +210,16 @@ public class ApiKeyController {
             LOG.warn("Failed to emit event: {}", e.getMessage());
         }
         return ResponseEntity.ok(response);
+    }
+
+    private String resolveKeyTenantId(String keyId) {
+        try (var jedis = jedisPool.getResource()) {
+            String data = jedis.get("apikey:" + keyId);
+            if (data == null) return null;
+            return objectMapper.readValue(data, ApiKey.class).getTenantId();
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     private Map<String, Object> buildRevokeMeta(String name, String reason) {

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/BudgetController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/BudgetController.java
@@ -584,6 +584,19 @@ public class BudgetController {
         // is the ledger_id." The ledger_id is the stable unique identifier;
         // scope is the routing/matching key passed to fund().
         String id = ledger.getLedgerId();
+        // Rule 2 (v0.1.25.29): any mutation on a budget whose owning tenant
+        // is CLOSED returns TENANT_CLOSED. Bucketed per-row so one closed
+        // tenant doesn't poison the whole batch; classifyBudgetFailureCode
+        // maps the ErrorCode to the spec's known row-level code.
+        try {
+            mutationGuard.assertTenantOpen(ledger.getTenantId());
+        } catch (GovernanceException e) {
+            failed.add(BulkActionRowOutcome.builder()
+                .id(id)
+                .errorCode(classifyBudgetFailureCode(e))
+                .message(e.getMessage()).build());
+            return;
+        }
         if (bulk.getAmount().getUnit() != ledger.getUnit()) {
             failed.add(BulkActionRowOutcome.builder()
                 .id(id).errorCode("INVALID_TRANSITION")
@@ -644,6 +657,8 @@ public class BudgetController {
             case FORBIDDEN:
             case INSUFFICIENT_PERMISSIONS:
                 return "PERMISSION_DENIED";
+            case TENANT_CLOSED:
+                return "TENANT_CLOSED";
             default:
                 return "INTERNAL_ERROR";
         }

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/PolicyController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/PolicyController.java
@@ -13,6 +13,7 @@ import io.runcycles.admin.api.config.ScopeFilterUtil;
 import io.runcycles.admin.api.filter.RequestIdFilter;
 import io.runcycles.admin.api.filter.TraceContextFilter;
 import io.runcycles.admin.api.service.EventService;
+import io.runcycles.admin.api.service.TerminalOwnerMutationGuard;
 import io.runcycles.admin.model.event.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
@@ -34,6 +35,7 @@ public class PolicyController {
     @Autowired private AuditRepository auditRepository;
     @Autowired private EventService eventService;
     @Autowired private ObjectMapper objectMapper;
+    @Autowired private TerminalOwnerMutationGuard mutationGuard;
     @PostMapping @Operation(operationId = "createPolicy")
     public ResponseEntity<Policy> create(@Valid @RequestBody PolicyCreateRequest request, HttpServletRequest httpRequest) {
         // v0.1.25.15: enforce canonical scope-pattern grammar. Wildcards
@@ -58,6 +60,7 @@ public class PolicyController {
         }
         String tenantId = isAdminAuth ? request.getTenantId() : authTenantId;
         ScopeValidator.validateScopeMatchesTenant(request.getScopePattern(), tenantId);
+        mutationGuard.assertTenantOpen(tenantId);
         Policy policy = repository.create(tenantId, request);
         auditRepository.log(buildAuditEntry(httpRequest)
             .tenantId(tenantId)
@@ -101,6 +104,7 @@ public class PolicyController {
         // the persisted record's tenant_id is trusted as the audit subject.
         String authTenantId = (String) httpRequest.getAttribute("authenticated_tenant_id");
         boolean isAdminAuth = authTenantId == null;
+        mutationGuard.assertOpenForScope(scopePattern);
         Policy policy = repository.update(authTenantId, policyId, request);
         // For audit / event the subject tenant is the policy's stored owner,
         // not the (possibly null) caller — keeps history attributable to the

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/WebhookAdminController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/WebhookAdminController.java
@@ -4,6 +4,7 @@ import io.runcycles.admin.api.filter.RequestIdFilter;
 import io.runcycles.admin.api.filter.TraceContextFilter;
 import io.runcycles.admin.api.service.BulkActionAuditMetadataBuilder;
 import io.runcycles.admin.api.service.EventService;
+import io.runcycles.admin.api.service.TerminalOwnerMutationGuard;
 import io.runcycles.admin.api.service.WebhookService;
 import io.runcycles.admin.data.exception.GovernanceException;
 import io.runcycles.admin.data.idempotency.IdempotencyStore;
@@ -48,12 +49,16 @@ public class WebhookAdminController {
     @Autowired private WebhookRepository webhookRepository;
     @Autowired private AuditRepository auditRepository;
     @Autowired private IdempotencyStore idempotencyStore;
+    @Autowired private TerminalOwnerMutationGuard mutationGuard;
 
     @PostMapping @Operation(operationId = "createWebhookSubscription")
     public ResponseEntity<WebhookCreateResponse> create(
             @RequestParam(required = false) String tenant_id,
             @Valid @RequestBody WebhookCreateRequest request, HttpServletRequest httpRequest) {
         String tenantId = tenant_id != null ? tenant_id : "__system__";
+        // Rule 2: refuse creating a subscription under a CLOSED tenant. Guard
+        // no-ops on the "__system__" sentinel (no tenant record exists for it).
+        if (tenant_id != null) mutationGuard.assertTenantOpen(tenantId);
         WebhookCreateResponse response = webhookService.create(tenantId, request);
         auditRepository.log(buildAuditEntry(httpRequest)
             .tenantId(tenantId)
@@ -115,6 +120,7 @@ public class WebhookAdminController {
     public ResponseEntity<WebhookSubscription> update(
             @PathVariable("subscription_id") String subscriptionId,
             @Valid @RequestBody WebhookUpdateRequest request, HttpServletRequest httpRequest) {
+        mutationGuard.assertOpenForWebhook(subscriptionId);
         WebhookSubscription updated = webhookService.update(subscriptionId, request);
         java.util.Map<String, Object> updateMeta = new java.util.LinkedHashMap<>();
         updateMeta.put("url", updated.getUrl());
@@ -134,6 +140,7 @@ public class WebhookAdminController {
     @DeleteMapping("/{subscription_id}") @Operation(operationId = "deleteWebhookSubscription")
     public ResponseEntity<Void> delete(@PathVariable("subscription_id") String subscriptionId, HttpServletRequest httpRequest) {
         WebhookSubscription sub = webhookService.get(subscriptionId);
+        mutationGuard.assertTenantOpen(sub.getTenantId());
         webhookService.delete(subscriptionId);
         auditRepository.log(buildAuditEntry(httpRequest)
             .tenantId(sub.getTenantId())
@@ -147,6 +154,7 @@ public class WebhookAdminController {
     @PostMapping("/{subscription_id}/test") @Operation(operationId = "testWebhookSubscription")
     public ResponseEntity<WebhookTestResponse> test(
             @PathVariable("subscription_id") String subscriptionId, HttpServletRequest httpRequest) {
+        mutationGuard.assertOpenForWebhook(subscriptionId);
         WebhookTestResponse response = webhookService.test(subscriptionId);
         java.util.Map<String, Object> testMeta = new java.util.LinkedHashMap<>();
         testMeta.put("success", response.isSuccess());
@@ -177,6 +185,7 @@ public class WebhookAdminController {
     public ResponseEntity<ReplayResponse> replay(
             @PathVariable("subscription_id") String subscriptionId,
             @Valid @RequestBody ReplayRequest request, HttpServletRequest httpRequest) {
+        mutationGuard.assertOpenForWebhook(subscriptionId);
         ReplayResponse response = webhookService.replay(subscriptionId, request);
         auditRepository.log(buildAuditEntry(httpRequest)
             .resourceType("webhook").resourceId(subscriptionId)
@@ -289,6 +298,10 @@ public class WebhookAdminController {
                                      List<BulkActionRowOutcome> skipped) {
         String id = matched.getSubscriptionId();
         try {
+            // Rule 2 (v0.1.25.29): reject mutation on subscriptions whose
+            // owning tenant is CLOSED. Bucketed into failed[] via the outer
+            // catch so one closed-owner row doesn't poison the whole batch.
+            mutationGuard.assertTenantOpen(matched.getTenantId());
             if (action == WebhookBulkAction.DELETE) {
                 try {
                     webhookService.delete(id);
@@ -364,6 +377,8 @@ public class WebhookAdminController {
                 return "PERMISSION_DENIED";
             case INVALID_REQUEST:
                 return "INVALID_TRANSITION";
+            case TENANT_CLOSED:
+                return "TENANT_CLOSED";
             default:
                 return "INTERNAL_ERROR";
         }

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/WebhookTenantController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/WebhookTenantController.java
@@ -129,6 +129,7 @@ public class WebhookTenantController {
         WebhookSubscription existing = webhookService.get(subscriptionId);
         boolean isAdminAuth = isAdminAuth(httpRequest);
         enforceTenantOwnership(httpRequest, existing);
+        mutationGuard.assertTenantOpen(existing.getTenantId());
         webhookService.delete(subscriptionId);
         java.util.Map<String, Object> delMeta = new java.util.LinkedHashMap<>();
         delMeta.put("url", existing.getUrl());
@@ -149,6 +150,7 @@ public class WebhookTenantController {
         WebhookSubscription existing = webhookService.get(subscriptionId);
         boolean isAdminAuth = isAdminAuth(httpRequest);
         enforceTenantOwnership(httpRequest, existing);
+        mutationGuard.assertTenantOpen(existing.getTenantId());
         WebhookTestResponse response = webhookService.test(subscriptionId);
         java.util.Map<String, Object> testMeta = new java.util.LinkedHashMap<>();
         testMeta.put("success", response.isSuccess());

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/ApiKeyControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/ApiKeyControllerTest.java
@@ -35,6 +35,7 @@ class ApiKeyControllerTest {
     @MockitoBean private AuditRepository auditRepository;
     @MockitoBean private io.runcycles.admin.api.service.EventService eventService;
     @MockitoBean private JedisPool jedisPool;
+    @MockitoBean private io.runcycles.admin.api.service.TerminalOwnerMutationGuard mutationGuard;
 
     private static final String ADMIN_KEY = "test-admin-key";
 
@@ -95,6 +96,23 @@ class ApiKeyControllerTest {
                         .param("reason", "test"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("REVOKED"));
+    }
+
+    // v0.1.25.36 — Cascade Rule 2: owner-tenant guard on create.
+    @Test
+    void createApiKey_closedTenant_returns409_tenantClosed() throws Exception {
+        doThrow(new GovernanceException(ErrorCode.TENANT_CLOSED,
+            "Tenant tenant-1 is closed; owned objects are read-only", 409))
+            .when(mutationGuard).assertTenantOpen("tenant-1");
+
+        mockMvc.perform(post("/v1/admin/api-keys")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"tenant_id\":\"tenant-1\",\"name\":\"Blocked\"}"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error").value("TENANT_CLOSED"));
+
+        verify(apiKeyRepository, never()).create(any());
     }
 
     @Test

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BudgetControllerBulkActionTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BudgetControllerBulkActionTest.java
@@ -3,6 +3,7 @@ package io.runcycles.admin.api.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.runcycles.admin.api.contract.ContractValidationConfig;
 import io.runcycles.admin.api.service.EventService;
+import io.runcycles.admin.api.service.TerminalOwnerMutationGuard;
 import io.runcycles.admin.api.support.MetricsTestConfiguration;
 import io.runcycles.admin.data.exception.GovernanceException;
 import io.runcycles.admin.data.idempotency.IdempotencyStore;
@@ -63,6 +64,7 @@ class BudgetControllerBulkActionTest {
     @MockitoBean private JedisPool jedisPool;
     @MockitoBean private EventService eventService;
     @MockitoBean private IdempotencyStore idempotencyStore;
+    @MockitoBean private TerminalOwnerMutationGuard mutationGuard;
 
     private static final String ADMIN_KEY = "test-admin-key";
     private static final String TENANT = "acme";
@@ -605,5 +607,30 @@ class BudgetControllerBulkActionTest {
                 .andExpect(status().isUnauthorized());
 
         verify(budgetRepository, never()).matchForBulk(anyString(), any(), anyInt());
+    }
+
+    // -------- Cascade Rule 2: closed-owner per-row rejection -----------
+    // v0.1.25.36 (spec v0.1.25.29 Rule 2): any ledger whose owning tenant
+    // is CLOSED lands in failed[] with TENANT_CLOSED; other rows proceed.
+    @Test
+    void bulkAction_closedTenantRow_landsInFailed_tenantClosed() throws Exception {
+        noReplay();
+        when(budgetRepository.matchForBulk(eq(TENANT), any(BudgetListFilters.class), eq(500)))
+                .thenReturn(List.of(ledger("tenant:acme/workspace:eng")));
+        doThrow(new GovernanceException(ErrorCode.TENANT_CLOSED,
+            "Tenant " + TENANT + " is closed; owned objects are read-only", 409))
+            .when(mutationGuard).assertTenantOpen(TENANT);
+
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter(""), "CREDIT", "k_tc",
+                                "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":500}")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.failed.length()").value(1))
+                .andExpect(jsonPath("$.failed[0].error_code").value("TENANT_CLOSED"))
+                .andExpect(jsonPath("$.succeeded.length()").value(0));
+
+        verify(budgetRepository, never()).fund(anyString(), anyString(), any(), any());
     }
 }

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/PolicyControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/PolicyControllerTest.java
@@ -1,10 +1,12 @@
 package io.runcycles.admin.api.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.runcycles.admin.api.service.TerminalOwnerMutationGuard;
 import io.runcycles.admin.data.exception.GovernanceException;
 import io.runcycles.admin.data.repository.AuditRepository;
 import io.runcycles.admin.data.repository.ApiKeyRepository;
 import io.runcycles.admin.data.repository.PolicyRepository;
+import io.runcycles.admin.model.shared.ErrorCode;
 import io.runcycles.admin.model.auth.ApiKeyValidationResponse;
 import io.runcycles.admin.model.policy.*;
 import org.junit.jupiter.api.Test;
@@ -37,6 +39,7 @@ class PolicyControllerTest {
     @MockitoBean private ApiKeyRepository apiKeyRepository;
     @MockitoBean private JedisPool jedisPool;
     @MockitoBean private io.runcycles.admin.api.service.EventService eventService;
+    @MockitoBean private TerminalOwnerMutationGuard mutationGuard;
 
     private void setupApiKeyAuth() {
         when(apiKeyRepository.validate("valid-api-key")).thenReturn(
@@ -443,6 +446,42 @@ class PolicyControllerTest {
                 "tenant-acme".equals(entry.getTenantId()) && // subject from policy, not null caller
                 entry.getMetadata() != null &&
                 "admin_on_behalf_of".equals(entry.getMetadata().get("actor_type"))));
+    }
+
+    // v0.1.25.36 — Cascade Rule 2: owner-tenant guard.
+    @Test
+    void createPolicy_closedTenant_returns409_tenantClosed() throws Exception {
+        setupApiKeyAuth();
+        doThrow(new GovernanceException(ErrorCode.TENANT_CLOSED,
+            "Tenant tenant-1 is closed; owned objects are read-only", 409))
+            .when(mutationGuard).assertTenantOpen("tenant-1");
+
+        mockMvc.perform(post("/v1/admin/policies")
+                        .header("X-Cycles-API-Key", "valid-api-key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"P\",\"scope_pattern\":\"tenant:tenant-1/*\"}"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error").value("TENANT_CLOSED"));
+
+        verify(policyRepository, never()).create(any(), any());
+    }
+
+    @Test
+    void updatePolicy_closedTenant_returns409_tenantClosed() throws Exception {
+        setupApiKeyAuth();
+        when(policyRepository.getScopePattern("pol_x")).thenReturn("tenant:tenant-1/*");
+        doThrow(new GovernanceException(ErrorCode.TENANT_CLOSED,
+            "Tenant tenant-1 is closed; owned objects are read-only", 409))
+            .when(mutationGuard).assertOpenForScope("tenant:tenant-1/*");
+
+        mockMvc.perform(patch("/v1/admin/policies/pol_x")
+                        .header("X-Cycles-API-Key", "valid-api-key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"blocked\"}"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error").value("TENANT_CLOSED"));
+
+        verify(policyRepository, never()).update(any(), any(), any());
     }
 
     @Test

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookAdminControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookAdminControllerTest.java
@@ -1,6 +1,7 @@
 package io.runcycles.admin.api.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.runcycles.admin.api.service.TerminalOwnerMutationGuard;
 import io.runcycles.admin.api.service.WebhookService;
 import io.runcycles.admin.data.exception.GovernanceException;
 import io.runcycles.admin.data.idempotency.IdempotencyStore;
@@ -8,6 +9,7 @@ import io.runcycles.admin.data.repository.AuditRepository;
 import io.runcycles.admin.data.repository.ApiKeyRepository;
 import io.runcycles.admin.data.repository.WebhookRepository;
 import io.runcycles.admin.model.event.EventType;
+import io.runcycles.admin.model.shared.ErrorCode;
 import io.runcycles.admin.model.shared.SortDirection;
 import io.runcycles.admin.model.shared.SortSpec;
 import io.runcycles.admin.model.webhook.*;
@@ -43,6 +45,7 @@ class WebhookAdminControllerTest {
     @MockitoBean private ApiKeyRepository apiKeyRepository;
     @MockitoBean private JedisPool jedisPool;
     @MockitoBean private IdempotencyStore idempotencyStore;
+    @MockitoBean private TerminalOwnerMutationGuard mutationGuard;
 
     private static final String ADMIN_KEY = "test-admin-key";
 
@@ -676,6 +679,47 @@ class WebhookAdminControllerTest {
         org.junit.jupiter.api.Assertions.assertEquals("k1", meta.get("idempotency_key"));
         org.assertj.core.api.Assertions.assertThat(meta).containsKey("filter");
         org.assertj.core.api.Assertions.assertThat((Long) meta.get("duration_ms")).isGreaterThanOrEqualTo(0L);
+    }
+
+    // v0.1.25.36 — Cascade Rule 2 on bulk-action: closed-owner rows land in failed[] with TENANT_CLOSED.
+    @Test
+    void bulkActionWebhooks_closedTenantRow_landsInFailed_tenantClosed() throws Exception {
+        when(idempotencyStore.lookup(eq("webhooks-bulk"), anyString(), eq(WebhookBulkActionResponse.class)))
+                .thenReturn(java.util.Optional.empty());
+        when(webhookRepository.matchForBulk(any(), any(), any(), any(), eq(500)))
+                .thenReturn(List.of(webhookRow("whsub_1", WebhookStatus.ACTIVE)));
+        doThrow(new GovernanceException(ErrorCode.TENANT_CLOSED,
+            "Tenant tenant-1 is closed; owned objects are read-only", 409))
+            .when(mutationGuard).assertTenantOpen("tenant-1");
+
+        mockMvc.perform(post("/v1/admin/webhooks/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"filter\":{\"status\":\"ACTIVE\"},\"action\":\"PAUSE\",\"idempotency_key\":\"k_tc\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.failed.length()").value(1))
+                .andExpect(jsonPath("$.failed[0].error_code").value("TENANT_CLOSED"))
+                .andExpect(jsonPath("$.succeeded.length()").value(0));
+
+        verify(webhookService, never()).update(anyString(), any());
+        verify(webhookService, never()).delete(anyString());
+    }
+
+    // v0.1.25.36 — Cascade Rule 2 on update: CLOSED owner → 409.
+    @Test
+    void updateWebhook_closedTenant_returns409_tenantClosed() throws Exception {
+        doThrow(new GovernanceException(ErrorCode.TENANT_CLOSED,
+            "Tenant tenant-1 is closed; owned objects are read-only", 409))
+            .when(mutationGuard).assertOpenForWebhook("whsub_1");
+
+        mockMvc.perform(patch("/v1/admin/webhooks/whsub_1")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"status\":\"ACTIVE\"}"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error").value("TENANT_CLOSED"));
+
+        verify(webhookService, never()).update(anyString(), any());
     }
 
     @Test

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookTenantControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookTenantControllerTest.java
@@ -8,6 +8,7 @@ import io.runcycles.admin.data.repository.AuditRepository;
 import io.runcycles.admin.data.repository.ApiKeyRepository;
 import io.runcycles.admin.model.auth.ApiKeyValidationResponse;
 import io.runcycles.admin.model.event.EventType;
+import io.runcycles.admin.model.shared.ErrorCode;
 import io.runcycles.admin.model.webhook.*;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -130,6 +131,46 @@ class WebhookTenantControllerTest {
                 "tenant-1".equals(entry.getTenantId()) &&
                 "key_1".equals(entry.getKeyId()) &&
                 entry.getStatus() == 204));
+    }
+
+    // v0.1.25.36 — Cascade Rule 2: delete on CLOSED-owner webhook → 409.
+    @Test
+    void deleteWebhook_closedTenant_returns409_tenantClosed() throws Exception {
+        setupApiKeyAuth();
+        WebhookSubscription sub = WebhookSubscription.builder()
+            .subscriptionId("whsub_1").tenantId("tenant-1").url("https://example.com/wh")
+            .status(WebhookStatus.DISABLED).createdAt(Instant.now()).build();
+        when(webhookService.get("whsub_1")).thenReturn(sub);
+        doThrow(new GovernanceException(ErrorCode.TENANT_CLOSED,
+            "Tenant tenant-1 is closed; owned objects are read-only", 409))
+            .when(mutationGuard).assertTenantOpen("tenant-1");
+
+        mockMvc.perform(delete("/v1/webhooks/whsub_1")
+                        .header("X-Cycles-API-Key", "valid-api-key"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error").value("TENANT_CLOSED"));
+
+        verify(webhookService, never()).delete(anyString());
+    }
+
+    // v0.1.25.36 — Cascade Rule 2: test on CLOSED-owner webhook → 409.
+    @Test
+    void testWebhook_closedTenant_returns409_tenantClosed() throws Exception {
+        setupApiKeyAuth();
+        WebhookSubscription sub = WebhookSubscription.builder()
+            .subscriptionId("whsub_1").tenantId("tenant-1").url("https://example.com/wh")
+            .status(WebhookStatus.DISABLED).createdAt(Instant.now()).build();
+        when(webhookService.get("whsub_1")).thenReturn(sub);
+        doThrow(new GovernanceException(ErrorCode.TENANT_CLOSED,
+            "Tenant tenant-1 is closed; owned objects are read-only", 409))
+            .when(mutationGuard).assertTenantOpen("tenant-1");
+
+        mockMvc.perform(post("/v1/webhooks/whsub_1/test")
+                        .header("X-Cycles-API-Key", "valid-api-key"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error").value("TENANT_CLOSED"));
+
+        verify(webhookService, never()).test(anyString());
     }
 
     @Test

--- a/cycles-admin-service/pom.xml
+++ b/cycles-admin-service/pom.xml
@@ -18,7 +18,7 @@
         <module>cycles-admin-service-api</module>
     </modules>
     <properties>
-        <revision>0.1.25.35</revision>
+        <revision>0.1.25.36</revision>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>


### PR DESCRIPTION
## Summary

Closes the only remaining spec-MUST gap from the v0.1.25 conformance review: `TerminalOwnerMutationGuard` was previously wired only into `BudgetController` (create/update/fund/freeze/unfreeze) and `WebhookTenantController` (create/update). `CASCADE SEMANTICS` Rule 2 in `cycles-governance-admin-v0.1.25.yaml` requires **every** mutating admin-plane operation on an owned object to reject with `HTTP 409 / error_code=TENANT_CLOSED` when the owning tenant is CLOSED.

### Guard now wired at

| Controller | Operations newly guarded |
|---|---|
| `PolicyController` | create, update |
| `ApiKeyController` | create, update, revoke |
| `WebhookAdminController` | create, update, delete, test, replay, bulk-action (per-row TENANT_CLOSED mapped in failure outcome) |
| `WebhookTenantController` | delete, test (create/update already guarded) |
| `BudgetController` | bulk-action (per-row guard on owner tenant; existing single-op guards retained) |

### Test coverage

- Every newly-guarded controller test gets `@MockitoBean TerminalOwnerMutationGuard`
- Added negative tests asserting `409 TENANT_CLOSED` on closed-owner paths for Policy create/update, ApiKey create, Webhook admin bulk-action, Webhook admin update, Webhook tenant delete/test, Budget bulk-action
- **747 tests green / 0 failures / 0 errors**
- Spec coverage: `declared=46 covered=46 missing=0`

### Release metadata

- `<revision>` bumped `0.1.25.35 → 0.1.25.36`
- `AUDIT.md` — prepended v0.1.25.36 section documenting the guard expansion
- `CHANGELOG.md` — prepended v0.1.25.36 entry

### Paired spec PR

This PR is paired with [runcycles/cycles-protocol#70](https://github.com/runcycles/cycles-protocol/pull/70), which bumps the spec to `v0.1.25.30` and declares `409 TENANT_CLOSED` on the five ops whose response catalog previously omitted it. Tests in this branch run against that revised spec.

## Test plan

- [x] `mvn -pl cycles-admin-service-api -am test` — 747 green
- [x] `OpenApiContractDiffTest` — green against spec v0.1.25.30 (no phantom endpoints)
- [x] `DtoConstraintContractTest` — green
- [ ] Wait for cycles-protocol#70 to merge so CI picks up the published spec
- [ ] Manual smoke (post-merge): close a tenant via `PATCH /v1/admin/tenants/{id}` with `status=CLOSED`; attempt each mutating op on its owned policies / api-keys / webhooks / bulk-actions — each must return 409 with `error_code=TENANT_CLOSED`.