### PR TITLE
docs: bump spec pointer v0.1.25.31 + Mode B conformance commentary

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,8 +1,8 @@
 # Complete Budget Governance v0.1.25.36 — Admin Server Audit
 
-**Server version:** 0.1.25.36 (2026-04-20 — spec v0.1.25.29 CASCADE SEMANTICS Rule 2 guard coverage expanded across all admin-mutating endpoints)
+**Server version:** 0.1.25.36 (2026-04-20 — spec v0.1.25.31 CASCADE SEMANTICS; Mode B flip-first-with-guarded-cascade conformant; Rule 2 guard coverage complete across all admin-mutating endpoints)
 **Date:** 2026-04-20 (v0.1.25.36 Rule 2 guard expansion: policies + api-keys + webhook-admin create/update/delete/test/replay + budgets and webhooks bulk-action per-row + webhook-tenant delete/test), 2026-04-20 (v0.1.25.35 cascade + TENANT_CLOSED guard), 2026-04-19 (v0.1.25.34 commons-lang3 CVE pin), 2026-04-19 (v0.1.25.33 Spring Boot / Tomcat CVE bump), 2026-04-18 (v0.1.25.32 cross-plane read tolerance hardening), 2026-04-18 (v0.1.25.31 trace_id cross-surface correlation), 2026-04-18 (v0.1.25.30 bulk-action audit enrichment), 2026-04-18 (v0.1.25.29 budget bulk-action), 2026-04-17 (v0.1.25.28 audit sentinel split), 2026-04-17 (v0.1.25.27 audit filter DSL upgrade), 2026-04-17 (v0.1.25.26 bulk-action endpoints), 2026-04-17 (v0.1.25.25 search on six list endpoints), 2026-04-16 (v0.1.25.24 server-side sort — six admin list endpoints), 2026-04-16 (v0.1.25.23 BudgetLedger tenant_id on wire), 2026-04-16 (v0.1.25.22 cross-tenant list + filters), 2026-04-16 (v0.1.25.21 nightly CI), 2026-04-16 (v0.1.25.20 audit-on-failure), 2026-04-16 (v0.1.25.19 introspect dual-auth + operator docs), 2026-04-15 (v0.1.25.18 RESET_SPENT operation), 2026-04-14 (v0.1.25.17 cjson round-trip sweep: apikey + policy + tenant), 2026-04-13 (v0.1.25.16 webhooks dual-auth), 2026-04-13 (v0.1.25.15 ScopeValidator), 2026-04-13 (v0.1.25.14 admin-on-behalf-of dual-auth), 2026-04-13 (v0.1.25.13 CORS PUT fix), 2026-04-12 (v0.1.25.12 spec-compliance hardening + observability), 2026-04-12 (v0.1.25.11 contract-testing default ON), 2026-04-12 (v0.1.25.10 spec-compliance hardening), 2026-04-10 (v0.1.25.9 release), 2026-04-10 (CORS hardening + prod config), 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
-**Spec:** [`cycles-governance-admin-v0.1.25.yaml`](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml) (OpenAPI 3.1.0, info.version `0.1.25.29`; adds CASCADE SEMANTICS — Rule 1 `POST /admin/tenants/{id}` PATCH→CLOSED cascades owned budgets (→CLOSED), webhook subscriptions (→DISABLED), and API keys (→REVOKED) atomically under a shared correlation_id, and Rule 2 rejects any mutating operation against an object whose owning tenant is CLOSED with 409 `TENANT_CLOSED`; adds the `TENANT_CLOSED` error code to the shared enum and the four `*_via_tenant_cascade` event kinds: `budget.closed_via_tenant_cascade`, `webhook.disabled_via_tenant_cascade`, `api_key.revoked_via_tenant_cascade`, `reservation.released_via_tenant_cascade`) in [cycles-protocol](https://github.com/runcycles/cycles-protocol)
+**Spec:** [`cycles-governance-admin-v0.1.25.yaml`](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml) (OpenAPI 3.1.0, info.version `0.1.25.31`; adds CASCADE SEMANTICS — Rule 1 `POST /admin/tenants/{id}` PATCH→CLOSED cascades owned budgets (→CLOSED), webhook subscriptions (→DISABLED), and API keys (→REVOKED) under a shared correlation_id — Rule 1 permits **Mode A (atomic)** or **Mode B (flip-first-with-guarded-cascade)** as of v0.1.25.31, and Rule 2 rejects any mutating operation against an object whose owning tenant is CLOSED with 409 `TENANT_CLOSED`; adds the `TENANT_CLOSED` error code to the shared enum and the four `*_via_tenant_cascade` event kinds: `budget.closed_via_tenant_cascade`, `webhook.disabled_via_tenant_cascade`, `api_key.revoked_via_tenant_cascade`, `reservation.released_via_tenant_cascade`) in [cycles-protocol](https://github.com/runcycles/cycles-protocol)
 **Server:** Spring Boot 3.5.13 / Java 21 / Redis · Tomcat 10.1.54 pin · commons-lang3 3.18.0 pin
 
 ### 2026-04-20 — v0.1.25.36: Rule 2 guard coverage completed (spec v0.1.25.29 MUST)
@@ -80,12 +80,25 @@ callsites + row-level classifier coverage. OpenAPI contract diff,
 DTO contract tests, property-based audit invariants: unchanged.
 `declared=46 covered=46 missing=0` still holds.
 
-**Conformance posture vs. spec v0.1.25.29.**
+**Conformance posture vs. spec v0.1.25.31.**
 
 | Rule | v0.1.25.35 | v0.1.25.36 |
 |---|---|---|
-| Rule 1 — close-time cascade | ✅ complete | ✅ complete |
+| Rule 1 — close-time cascade | ✅ complete (Mode B) | ✅ complete (Mode B) |
 | Rule 2 — terminal-owner mutation guard | ⚠️ partial (budgets + webhook-tenant create/update only) | ✅ complete (all admin mutation sites) |
+
+**Cascade mode: Mode B (flip-first-with-guarded-cascade).** Spec v0.1.25.31 relaxed Rule 1 to permit two conformant cascade modes. This server implements **Mode B**: the tenant status flip to `CLOSED` commits first, Rule 2's `TENANT_CLOSED` guard is active from that moment, and children are driven to terminal states per-child (not in one transaction) under a shared `correlation_id = tenant_close_cascade:<tenant_id>:<request_id>`. Mode A (single-transaction atomic cascade) would require cross-key transactions spanning `tenant:*`, `budget:*`, `webhook:*`, and `apikey:*` Redis keys — not available in the backing store — so Mode B is the correct choice for this implementation.
+
+Mode B requires four invariants (spec v0.1.25.31 Rule 1 (a)–(d)); this server satisfies all four:
+
+| Invariant | How this server satisfies it |
+|---|---|
+| (a) Rule 2 guard active at/before CLOSED flip durability | `TerminalOwnerMutationGuard` reads `tenant:<id>.status` on every mutating call; once the flip commits the guard returns `TENANT_CLOSED` on the next call, with no coordination gap. |
+| (b) Idempotent cascade | Every `cascadeClose` / `cascadeDisable` / `cascadeRevoke` step is a no-op for already-terminal children (conditional `MULTI/EXEC` guard on the child's current status). Audit/event rows are emitted only on actual state change. |
+| (c) Bounded eventual convergence, documented | Convergence mechanism is operator-issued re-close (`PATCH {status: CLOSED}` is a tenant-level no-op that re-runs the cascade). Documented in `OPERATIONS.md` §Tenant-close cascade. Bound is operator-reaction-time — no background reconciler is on the roadmap for this release. |
+| (d) Consistent reads of non-terminal children of CLOSED tenant | `GET` paths on owned objects are never guarded; a reader observing a partially-cascaded tenant sees each child's stored (pre-cascade) status until the child's transition commits. |
+
+**Consequence for client contracts.** Clients relying on the v0.1.25.29 "atomic / single transaction" wording must treat it as now-relaxed: between the CLOSED flip and the last child's terminal transition, a reader MAY observe a non-terminal child of a CLOSED tenant. Any mutation against that child fails `409 TENANT_CLOSED` (Rule 2); the child converges to its terminal state per Rule 1(c). This is the client-observable guarantee — not atomicity — that matters.
 
 ### 2026-04-20 — v0.1.25.35: Cascade semantics (spec v0.1.25.29 Rule 1 + Rule 2)
 

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -199,10 +199,17 @@ into a fixed DTO must tolerate unknown keys (Jackson
 
 ### Tenant-close cascade (v0.1.25.35+)
 
+**Cascade mode: Mode B (flip-first-with-guarded-cascade).** Spec
+v0.1.25.31 Rule 1 defines two conformant cascade modes; this server
+implements **Mode B**. The tenant flip commits first; Rule 2's
+`TENANT_CLOSED` guard activates; children transition per-child (not
+atomically). Convergence is operator-driven — see "Convergence
+mechanism (Rule 1(c) — MUST be documented)" below for the bound.
+
 Closing a tenant via `PATCH /v1/admin/tenants/{id}` with
 `status=CLOSED` (or via `POST /v1/admin/tenants/bulk-action` with
 `action=CLOSE`) cascades owned objects into their terminal states per
-spec v0.1.25.29 Rule 1:
+spec v0.1.25.31 Rule 1:
 
 | Owned type | Pre-close state | Post-cascade state | Wire-visible effect |
 |---|---|---|---|
@@ -210,13 +217,44 @@ spec v0.1.25.29 Rule 1:
 | `WebhookSubscription` | `ACTIVE` / `PAUSED` | `DISABLED` | Rule 2 prevents any re-enable — DISABLED is effectively-terminal for closed-owner subscriptions. |
 | `ApiKey` | `ACTIVE` | `REVOKED` | `revoked_at` stamped; reason `tenant_closed`. |
 
-The tenant flip happens BEFORE the cascade so spec v0.1.25.29 Rule 2
+The tenant flip happens BEFORE the cascade so spec v0.1.25.31 Rule 2
 (`TENANT_CLOSED` 409 on any mutating op against a CLOSED-owner object)
 is active during the cascade window. Concurrent admin PATCHes during
 a cascade 409 rather than racing to resurrect a just-terminated
 child. On partial cascade failure the tenant remains CLOSED — operator
 re-issues the close and remaining non-terminal children pick up (every
 cascade step is idempotent; already-terminal children are skipped).
+
+**Convergence mechanism (Rule 1(c) — MUST be documented).** Spec
+v0.1.25.31 Rule 1(c) requires a Mode B implementation to document
+how an interrupted cascade reaches terminal state in bounded time.
+For this server:
+
+- **Primary mechanism:** operator-issued re-close. `PATCH /v1/admin/tenants/{id} { "status": "CLOSED" }`
+  on an already-CLOSED tenant is a no-op at the tenant level but
+  re-runs the cascade against any non-terminal child. Every cascade
+  step is idempotent (see Rule 1(b)) — already-terminal children are
+  skipped without emitting duplicate audit/event rows.
+- **Bound:** operator-reaction-time. There is no background
+  reconciler and no startup sweep in this release. The bound is
+  whatever operator-alert → operator-action latency your ops
+  organization runs at — typically minutes under normal pager
+  response, hours in the worst case.
+- **Detection:** any budget/webhook/apikey that stays non-terminal
+  under a CLOSED tenant for longer than your pager SLO should be
+  treated as a cascade-incomplete incident. Query:
+  `GET /v1/admin/budgets?tenant_id={id}&status=FROZEN`, or equivalent
+  per-child-type `GET`. See the triage recipe below.
+- **Reads remain consistent (Rule 1(d)).** Non-terminal children of
+  a CLOSED tenant are observable via `GET` until the cascade reaches
+  them. Clients and dashboards should treat the combination "tenant
+  CLOSED + child non-terminal" as a transient state that converges,
+  not a permanent inconsistency.
+
+A background reconciler / startup sweep is a potential future
+addition if operator re-issue proves insufficient at higher tenant-
+close rates; the spec permits it under Rule 1(c) without a wire
+change.
 
 **Correlation.** Every audit entry and event emitted in one cascade
 shares:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Runcycles Admin Server
 
-Administrative API for the Complete Budget Governance System, aligned with [Cycles Protocol v0.1.25.29](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml).
+Administrative API for the Complete Budget Governance System, aligned with [Cycles Protocol v0.1.25.31](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml).
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

Retroactive conformance bump: server v0.1.25.36 (PR #136) implements **Mode B (flip-first-with-guarded-cascade)** of the two cascade modes now permitted by spec [v0.1.25.31](https://github.com/runcycles/cycles-protocol/pull/72). No code change, no version bump — this is pure documentation.

## What changed

| File | Change |
|---|---|
| `README.md` | Spec-pointer row `v0.1.25.29 → v0.1.25.31`. |
| `AUDIT.md` | Version header + info.version reference bumped to `v0.1.25.31`; v0.1.25.36 conformance-posture table retitled to "vs. spec v0.1.25.31"; added Mode B invariants (a)–(d) mapping to how this server satisfies each, plus client-contract consequences. |
| `OPERATIONS.md` | Tenant-close cascade section leads with "Mode: Mode B" callout; spec-pointer bump; new "Convergence mechanism (Rule 1(c) — MUST be documented)" subsection per spec requirement. |

## Why

Spec v0.1.25.31 Rule 1(c) requires a Mode B implementation to document its convergence mechanism. Primary mechanism here is operator-issued re-close (idempotent); bound is operator-reaction-time. No background reconciler in this release; spec permits adding one later without wire change.

## Out of scope

- No admin code change (v0.1.25.36 implementation already conformant to Mode B).
- No dashboard change.
- Background-reconciler work (potential future addition).

## Test plan

- [x] Spec-pointer updated in all three doc locations
- [x] Mode B invariants (a)–(d) mapped to implementation
- [x] Convergence mechanism documented per Rule 1(c)
- [ ] Reviewer sanity-check: Mode B mapping matches actual `TenantCloseCascadeService` behavior