### PR TITLE
fix(cascade): wire Rule 1(c) bounded-convergence into close paths (v0.1.25.37)

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,9 +1,81 @@
-# Complete Budget Governance v0.1.25.36 — Admin Server Audit
+# Complete Budget Governance v0.1.25.37 — Admin Server Audit
 
-**Server version:** 0.1.25.36 (2026-04-20 — spec v0.1.25.31 CASCADE SEMANTICS; Mode B flip-first-with-guarded-cascade conformant; Rule 2 guard coverage complete across all admin-mutating endpoints)
-**Date:** 2026-04-20 (v0.1.25.36 Rule 2 guard expansion: policies + api-keys + webhook-admin create/update/delete/test/replay + budgets and webhooks bulk-action per-row + webhook-tenant delete/test), 2026-04-20 (v0.1.25.35 cascade + TENANT_CLOSED guard), 2026-04-19 (v0.1.25.34 commons-lang3 CVE pin), 2026-04-19 (v0.1.25.33 Spring Boot / Tomcat CVE bump), 2026-04-18 (v0.1.25.32 cross-plane read tolerance hardening), 2026-04-18 (v0.1.25.31 trace_id cross-surface correlation), 2026-04-18 (v0.1.25.30 bulk-action audit enrichment), 2026-04-18 (v0.1.25.29 budget bulk-action), 2026-04-17 (v0.1.25.28 audit sentinel split), 2026-04-17 (v0.1.25.27 audit filter DSL upgrade), 2026-04-17 (v0.1.25.26 bulk-action endpoints), 2026-04-17 (v0.1.25.25 search on six list endpoints), 2026-04-16 (v0.1.25.24 server-side sort — six admin list endpoints), 2026-04-16 (v0.1.25.23 BudgetLedger tenant_id on wire), 2026-04-16 (v0.1.25.22 cross-tenant list + filters), 2026-04-16 (v0.1.25.21 nightly CI), 2026-04-16 (v0.1.25.20 audit-on-failure), 2026-04-16 (v0.1.25.19 introspect dual-auth + operator docs), 2026-04-15 (v0.1.25.18 RESET_SPENT operation), 2026-04-14 (v0.1.25.17 cjson round-trip sweep: apikey + policy + tenant), 2026-04-13 (v0.1.25.16 webhooks dual-auth), 2026-04-13 (v0.1.25.15 ScopeValidator), 2026-04-13 (v0.1.25.14 admin-on-behalf-of dual-auth), 2026-04-13 (v0.1.25.13 CORS PUT fix), 2026-04-12 (v0.1.25.12 spec-compliance hardening + observability), 2026-04-12 (v0.1.25.11 contract-testing default ON), 2026-04-12 (v0.1.25.10 spec-compliance hardening), 2026-04-10 (v0.1.25.9 release), 2026-04-10 (CORS hardening + prod config), 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
+**Server version:** 0.1.25.37 (2026-04-21 — spec v0.1.25.31 CASCADE SEMANTICS; Mode B flip-first-with-guarded-cascade conformant; Rule 1(c) bounded-convergence wired into PATCH and bulk-action close paths; Rule 2 guard coverage complete across all admin-mutating endpoints)
+**Date:** 2026-04-21 (v0.1.25.37 Rule 1(c) bounded-convergence: PATCH /tenants/{id} and bulk-action CLOSE re-run cascade on already-CLOSED tenants for straggler convergence), 2026-04-20 (v0.1.25.36 Rule 2 guard expansion: policies + api-keys + webhook-admin create/update/delete/test/replay + budgets and webhooks bulk-action per-row + webhook-tenant delete/test), 2026-04-20 (v0.1.25.35 cascade + TENANT_CLOSED guard), 2026-04-19 (v0.1.25.34 commons-lang3 CVE pin), 2026-04-19 (v0.1.25.33 Spring Boot / Tomcat CVE bump), 2026-04-18 (v0.1.25.32 cross-plane read tolerance hardening), 2026-04-18 (v0.1.25.31 trace_id cross-surface correlation), 2026-04-18 (v0.1.25.30 bulk-action audit enrichment), 2026-04-18 (v0.1.25.29 budget bulk-action), 2026-04-17 (v0.1.25.28 audit sentinel split), 2026-04-17 (v0.1.25.27 audit filter DSL upgrade), 2026-04-17 (v0.1.25.26 bulk-action endpoints), 2026-04-17 (v0.1.25.25 search on six list endpoints), 2026-04-16 (v0.1.25.24 server-side sort — six admin list endpoints), 2026-04-16 (v0.1.25.23 BudgetLedger tenant_id on wire), 2026-04-16 (v0.1.25.22 cross-tenant list + filters), 2026-04-16 (v0.1.25.21 nightly CI), 2026-04-16 (v0.1.25.20 audit-on-failure), 2026-04-16 (v0.1.25.19 introspect dual-auth + operator docs), 2026-04-15 (v0.1.25.18 RESET_SPENT operation), 2026-04-14 (v0.1.25.17 cjson round-trip sweep: apikey + policy + tenant), 2026-04-13 (v0.1.25.16 webhooks dual-auth), 2026-04-13 (v0.1.25.15 ScopeValidator), 2026-04-13 (v0.1.25.14 admin-on-behalf-of dual-auth), 2026-04-13 (v0.1.25.13 CORS PUT fix), 2026-04-12 (v0.1.25.12 spec-compliance hardening + observability), 2026-04-12 (v0.1.25.11 contract-testing default ON), 2026-04-12 (v0.1.25.10 spec-compliance hardening), 2026-04-10 (v0.1.25.9 release), 2026-04-10 (CORS hardening + prod config), 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
 **Spec:** [`cycles-governance-admin-v0.1.25.yaml`](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml) (OpenAPI 3.1.0, info.version `0.1.25.31`; adds CASCADE SEMANTICS — Rule 1 `POST /admin/tenants/{id}` PATCH→CLOSED cascades owned budgets (→CLOSED), webhook subscriptions (→DISABLED), and API keys (→REVOKED) under a shared correlation_id — Rule 1 permits **Mode A (atomic)** or **Mode B (flip-first-with-guarded-cascade)** as of v0.1.25.31, and Rule 2 rejects any mutating operation against an object whose owning tenant is CLOSED with 409 `TENANT_CLOSED`; adds the `TENANT_CLOSED` error code to the shared enum and the four `*_via_tenant_cascade` event kinds: `budget.closed_via_tenant_cascade`, `webhook.disabled_via_tenant_cascade`, `api_key.revoked_via_tenant_cascade`, `reservation.released_via_tenant_cascade`) in [cycles-protocol](https://github.com/runcycles/cycles-protocol)
 **Server:** Spring Boot 3.5.13 / Java 21 / Redis · Tomcat 10.1.54 pin · commons-lang3 3.18.0 pin
+
+### 2026-04-21 — v0.1.25.37: Rule 1(c) bounded-convergence wired into close paths (spec v0.1.25.31 MUST)
+
+**Motivation.** A code-review against `OPERATIONS.md` §"Tenant-close
+cascade" and spec v0.1.25.31 Rule 1(c) found the controller code
+contradicted the server's own operator documentation. The
+`OPERATIONS.md` triage recipe instructs operators to recover from a
+partial cascade by re-issuing `PATCH /v1/admin/tenants/{id}` with
+`status=CLOSED`, promising the cascade would "pick up stragglers."
+In practice both entry points silently short-circuited on an
+already-CLOSED tenant:
+
+- **PATCH path** — `TenantController.update()` gated the cascade
+  behind `isFreshClose = prior.getStatus() != CLOSED`. A retry saw
+  the tenant was already CLOSED, set `isFreshClose=false`, and
+  **never re-invoked the cascade service**. Stragglers stayed
+  non-terminal.
+- **Bulk-action path** — `applyTenantAction()` short-circuited
+  `current == target` into the `skipped` bucket with
+  `reason="ALREADY_IN_TARGET_STATE"` **before** reaching the cascade
+  call, even for `action=CLOSE`.
+
+The cascade service itself (`TenantCloseCascadeService`) was already
+idempotent — the repository `cascadeClose` / `cascadeDisable` /
+`cascadeRevoke` queries filter by non-terminal status and the Lua
+budget script returns `ALREADY_CLOSED` for terminal rows. But with
+no controller-level entry point re-invoking it, that idempotency was
+unreachable from the public API. Spec v0.1.25.31 Rule 1(c) requires
+Mode B implementations to both document **and implement** a bounded
+convergence mechanism; before this release, the server documented
+the recovery path but did not implement it.
+
+**Scope of this release.**
+
+| Controller path | Before | After |
+|---|---|---|
+| `PATCH /v1/admin/tenants/{id}` with `status=CLOSED` | cascade runs only on freshwire transition | cascade runs on **every** CLOSE request; already-CLOSED → parent event falls through to `tenant.updated` (no duplicate `tenant.closed`); straggler child events still fire via cascade service |
+| `POST /v1/admin/tenants/bulk-action` with `action=CLOSE` | `current == target` short-circuited to `skipped` without calling cascade | `current == target` skips redundant `repo.update` but **still calls cascade**; bucketed `succeeded` if any child transitioned, `skipped` (with `reason=ALREADY_IN_TARGET_STATE`) if cascade was a full no-op |
+
+**No wire change, no DTO change.** `ErrorCode`, `EventType`,
+`OpenApiContractDiffTest`, the spec-coverage report, and the cascade
+service's public contract are all unchanged. Only controller-level
+gates were adjusted.
+
+**Test coverage.**
+
+- `TenantControllerTest.updateTenant_priorStatusAlreadyClosed_rerunsCascadeForConvergence`
+  asserts PATCH retry re-invokes cascade and emits `tenant.updated`
+  (not a duplicate `tenant.closed`).
+- `TenantControllerTest.bulkActionTenants_closeAgainstAlreadyClosed_withStragglers_rerunsCascadeAndSucceeds`
+  asserts bulk-action CLOSE on an already-CLOSED tenant with
+  stragglers → `succeeded`, cascade invoked, no redundant
+  `repo.update`.
+- `TenantControllerTest.bulkActionTenants_closeAgainstAlreadyClosed_fullyConverged_bucketsAsSkipped`
+  asserts bulk-action CLOSE on a fully-converged (no stragglers)
+  already-CLOSED tenant → `skipped` with
+  `reason=ALREADY_IN_TARGET_STATE`, cascade still invoked (proves
+  we didn't regress to the old short-circuit).
+- The pre-existing
+  `TenantControllerTest.updateTenant_priorStatusAlreadyClosed_skipsCascade`
+  asserted the old (broken) behavior; it has been renamed and
+  inverted to the new contract above.
+
+**Operator-visible effect.** The `OPERATIONS.md` §"Convergence
+mechanism (Rule 1(c))" and §"Triage recipe" steps now work as
+documented — an operator seeing a budget in `FROZEN` under a
+`CLOSED` tenant can re-issue the close via PATCH or bulk-action and
+the straggler will transition, with the cascade emitting its own
+audit + `*_via_tenant_cascade` events for the picked-up child under
+a fresh `correlation_id` (new `request_id`).
+
+---
 
 ### 2026-04-20 — v0.1.25.36: Rule 2 guard coverage completed (spec v0.1.25.29 MUST)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,39 @@ changes to request/response bodies or Lua-script semantics would require a
 minor bump. Additive fields (new optional response fields, new enum values,
 new optional request fields) are **not** considered breaking.
 
+## [0.1.25.37] — 2026-04-21
+
+### Fixed
+
+- **Tenant-close cascade now actually reconverges on retry** (spec
+  v0.1.25.31 Rule 1(c) bounded-convergence). Prior releases gated the
+  cascade behind `isFreshClose` in the PATCH path and
+  `ALREADY_IN_TARGET_STATE` in bulk-action: a mid-cascade crash left
+  the tenant CLOSED but any straggler children remained non-terminal,
+  and re-issuing the close was silently a no-op. The documented
+  recovery path in `OPERATIONS.md` (re-issue the close; cascade is
+  idempotent and picks up stragglers) now matches the code.
+
+  - `PATCH /v1/admin/tenants/{id}` with `status=CLOSED` re-invokes
+    the cascade on every request regardless of prior status. The
+    parent event falls through to `tenant.updated` (not
+    `tenant.closed`) on a retry so consumers don't see a duplicate
+    close event; child `*_via_tenant_cascade` events still fire for
+    any rows the retry actually transitions.
+  - `POST /v1/admin/tenants/bulk-action` with `action=CLOSE` skips
+    the redundant `repo.update` on already-CLOSED rows but still runs
+    the cascade. If any children transition, the row is bucketed as
+    `succeeded`; if the cascade is a full no-op, the row is bucketed
+    as `skipped` with `reason=ALREADY_IN_TARGET_STATE` — keeping the
+    bulk-action response honest about whether state changed.
+
+### Unchanged
+
+- No wire / OpenAPI / DTO contract change. Cascade service semantics
+  unchanged — already idempotent per-child (repository cascade
+  queries filter by non-terminal status). Only the controller-level
+  gates that prevented re-entry were removed.
+
 ## [0.1.25.36] — 2026-04-20
 
 ### Added

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/TenantController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/TenantController.java
@@ -110,24 +110,31 @@ public class TenantController {
     }
     @PatchMapping("/{tenant_id}") @Operation(operationId = "updateTenant")
     public ResponseEntity<Tenant> update(@PathVariable("tenant_id") String tenantId, @Valid @RequestBody TenantUpdateRequest request, HttpServletRequest httpRequest) {
-        // Spec v0.1.25.29 Rule 1: flip the tenant to CLOSED BEFORE cascading.
-        // This activates Rule 2's mutation guard during the cascade window so
-        // a concurrent admin PATCH on an owned budget/webhook/api-key 409s
-        // rather than racing against us to resurrect a just-terminated child.
-        // Cascade steps are idempotent (already-terminal children are
-        // skipped), so on partial failure an operator simply re-issues the
-        // close and the cascade picks up any stragglers. We only run the
-        // cascade on the freshwire transition — already-CLOSED PATCHes are
-        // no-ops at the repository level.
+        // Spec v0.1.25.29 Rule 1 + v0.1.25.31 Rule 1(c): flip the tenant to
+        // CLOSED BEFORE cascading. This activates Rule 2's mutation guard
+        // during the cascade window so a concurrent admin PATCH on an owned
+        // budget/webhook/api-key 409s rather than racing against us to
+        // resurrect a just-terminated child.
+        //
+        // Convergence (Rule 1(c)): cascade runs on EVERY `status=CLOSED`
+        // request, not only the freshwire transition. Cascade steps are
+        // idempotent (already-terminal children are skipped in the
+        // repository cascade queries), so a re-issued close against an
+        // already-CLOSED tenant is a tenant-level no-op but picks up any
+        // children left non-terminal by a prior partial failure. This is
+        // how this server satisfies spec v0.1.25.31 Rule 1(c)
+        // bounded-convergence for Mode B — operator-issued re-close is the
+        // documented recovery path in OPERATIONS.md.
         boolean isFreshClose = false;
-        if (request.getStatus() == TenantStatus.CLOSED) {
+        boolean isCloseRequest = request.getStatus() == TenantStatus.CLOSED;
+        if (isCloseRequest) {
             Tenant prior = repository.get(tenantId);
             isFreshClose = prior.getStatus() != TenantStatus.CLOSED;
         }
         Tenant updated = repository.update(tenantId, request);
         TenantCloseCascadeService.CascadeResult cascadeResult = null;
         String cascadeCorrelationId = null;
-        if (isFreshClose) {
+        if (isCloseRequest) {
             cascadeCorrelationId = TenantCloseCascadeService.correlationIdFor(tenantId, httpRequest);
             cascadeResult = tenantCloseCascadeService.cascade(tenantId, httpRequest);
         }
@@ -144,7 +151,17 @@ public class TenantController {
                 switch (request.getStatus()) {
                     case SUSPENDED: eventType = EventType.TENANT_SUSPENDED; break;
                     case ACTIVE: eventType = EventType.TENANT_REACTIVATED; break;
-                    case CLOSED: eventType = EventType.TENANT_CLOSED; break;
+                    case CLOSED:
+                        // Rule 1(c) convergence: emit TENANT_CLOSED only on
+                        // the freshwire transition. Retry PATCHes against an
+                        // already-CLOSED tenant re-run the cascade (to pick
+                        // up stragglers) but fall through to TENANT_UPDATED
+                        // at the parent event level — no duplicate
+                        // TENANT_CLOSED. Any stragglers picked up by the
+                        // retry still emit their own *_via_tenant_cascade
+                        // events via the cascade service.
+                        eventType = isFreshClose ? EventType.TENANT_CLOSED : EventType.TENANT_UPDATED;
+                        break;
                     default: break;
                 }
             }
@@ -351,7 +368,11 @@ public class TenantController {
         try {
             Tenant live = repository.get(id);
             TenantStatus current = live.getStatus() != null ? live.getStatus() : TenantStatus.ACTIVE;
-            if (current == target) {
+            // For non-CLOSE actions, already-in-target is a clean skip.
+            // CLOSE is special: re-issuing CLOSE against an already-CLOSED
+            // tenant must re-run the cascade (Rule 1(c) bounded-convergence)
+            // and classify by whether any stragglers were picked up.
+            if (current == target && action != TenantBulkAction.CLOSE) {
                 skipped.add(BulkActionRowOutcome.builder()
                     .id(id).reason("ALREADY_IN_TARGET_STATE").build());
                 return;
@@ -362,18 +383,34 @@ public class TenantController {
                     .message("Cannot transition from CLOSED").build());
                 return;
             }
-            // Spec v0.1.25.29 Rule 1: flip the tenant to CLOSED FIRST, then
-            // cascade. Flipping first activates Rule 2's mutation guard so
-            // races during cascade can't resurrect a just-terminated child.
-            // Cascade failure propagates to the catch below, which buckets
-            // this row as failed; the tenant is already CLOSED and a retry
-            // against the same row picks up any remaining non-terminal
-            // children (cascade is idempotent).
-            TenantUpdateRequest update = new TenantUpdateRequest();
-            update.setStatus(target);
-            repository.update(id, update);
+            // Spec v0.1.25.29 Rule 1 + v0.1.25.31 Rule 1(c): flip the tenant
+            // to CLOSED FIRST, then cascade. Flipping first activates Rule 2's
+            // mutation guard so races during cascade can't resurrect a
+            // just-terminated child. Cascade failure propagates to the catch
+            // below, which buckets this row as failed; the tenant is already
+            // CLOSED and a retry against the same row picks up any remaining
+            // non-terminal children (cascade is idempotent). Skip the
+            // redundant repo.update when the tenant is already in target
+            // state (retry path).
+            if (current != target) {
+                TenantUpdateRequest update = new TenantUpdateRequest();
+                update.setStatus(target);
+                repository.update(id, update);
+            }
             if (action == TenantBulkAction.CLOSE) {
-                tenantCloseCascadeService.cascade(id, httpRequest);
+                TenantCloseCascadeService.CascadeResult r =
+                    tenantCloseCascadeService.cascade(id, httpRequest);
+                if (current == target
+                        && r.budgetsClosed() == 0
+                        && r.webhooksDisabled() == 0
+                        && r.apiKeysRevoked() == 0) {
+                    // Already-CLOSED with nothing left to cascade: retry
+                    // converged to a full no-op. Report as skipped to keep
+                    // the bulk-action contract honest (no state change).
+                    skipped.add(BulkActionRowOutcome.builder()
+                        .id(id).reason("ALREADY_IN_TARGET_STATE").build());
+                    return;
+                }
             }
             succeeded.add(BulkActionRowOutcome.builder().id(id).build());
         } catch (GovernanceException e) {

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/TenantCloseCascadeService.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/TenantCloseCascadeService.java
@@ -39,8 +39,13 @@ import java.util.Map;
  * this service: flipping first activates Rule 2's mutation guard during
  * the cascade window so a concurrent user PATCH on an owned object 409s
  * rather than racing against the cascade. On partial cascade failure the
- * tenant remains CLOSED and an operator re-issues the close; each
- * cascade step is idempotent (already-terminal children are skipped).
+ * tenant remains CLOSED and an operator re-issues the close — as of
+ * v0.1.25.37 both {@code PATCH /v1/admin/tenants/{id}} with
+ * {@code status=CLOSED} and bulk-action {@code CLOSE} re-invoke this
+ * service on already-CLOSED tenants (spec v0.1.25.31 Rule 1(c)
+ * bounded-convergence). Each cascade step is idempotent — the repository
+ * cascade queries filter by non-terminal status so already-terminal
+ * children are skipped and no duplicate audit/event rows are emitted.
  *
  * <p>Audit: every mutated owned object gets one {@code AuditLogEntry} with
  * {@code operation = "tenant_close_cascade"} and resource_type /

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/TenantControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/TenantControllerTest.java
@@ -557,15 +557,23 @@ class TenantControllerTest {
     }
 
     @Test
-    void updateTenant_priorStatusAlreadyClosed_skipsCascade() throws Exception {
-        // Re-close must be a no-op: cascade is not re-run when the tenant is
-        // already CLOSED. TenantRepository's idempotent short-circuit handles
-        // the status-flip side; the controller must avoid redundant child
-        // writes.
+    void updateTenant_priorStatusAlreadyClosed_rerunsCascadeForConvergence() throws Exception {
+        // Spec v0.1.25.31 Rule 1(c) bounded-convergence: a re-issued close
+        // against an already-CLOSED tenant MUST re-invoke the cascade so any
+        // children left non-terminal by a prior partial failure reach
+        // terminal state. The cascade service's per-child filtering makes
+        // this idempotent — already-terminal children are skipped and no
+        // duplicate child events are emitted. The parent-level event falls
+        // through to TENANT_UPDATED (not TENANT_CLOSED) since the status
+        // didn't change.
         Tenant prior = Tenant.builder()
                 .tenantId("tenant-1").name("Test").status(TenantStatus.CLOSED).createdAt(Instant.now()).build();
         when(tenantRepository.get("tenant-1")).thenReturn(prior);
         when(tenantRepository.update(eq("tenant-1"), any())).thenReturn(prior);
+        // Simulate one straggler picked up by the retry (e.g. a budget left
+        // in FROZEN by a prior crash mid-cascade).
+        when(tenantCloseCascadeService.cascade(eq("tenant-1"), any()))
+                .thenReturn(new TenantCloseCascadeService.CascadeResult(1, 0, 0, 0L));
 
         mockMvc.perform(patch("/v1/admin/tenants/tenant-1")
                         .header("X-Admin-API-Key", ADMIN_KEY)
@@ -573,7 +581,14 @@ class TenantControllerTest {
                         .content("{\"status\":\"CLOSED\"}"))
                 .andExpect(status().isOk());
 
-        verify(tenantCloseCascadeService, org.mockito.Mockito.never()).cascade(any(), any());
+        // Cascade MUST be invoked on the retry — this is the recovery path.
+        verify(tenantCloseCascadeService).cascade(eq("tenant-1"), any());
+        // No duplicate TENANT_CLOSED event on the retry.
+        verify(eventService, org.mockito.Mockito.never()).emit(eq(EventType.TENANT_CLOSED),
+                any(), any(), any(), any(), any(), any(), any());
+        // Instead, the parent event falls through to TENANT_UPDATED.
+        verify(eventService).emit(eq(EventType.TENANT_UPDATED), eq("tenant-1"),
+                any(), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -939,6 +954,60 @@ class TenantControllerTest {
         org.mockito.InOrder order = org.mockito.Mockito.inOrder(tenantRepository, tenantCloseCascadeService);
         order.verify(tenantRepository).update(eq("t1"), any());
         order.verify(tenantCloseCascadeService).cascade(eq("t1"), any());
+    }
+
+    @Test
+    void bulkActionTenants_closeAgainstAlreadyClosed_withStragglers_rerunsCascadeAndSucceeds() throws Exception {
+        // Spec v0.1.25.31 Rule 1(c) bounded-convergence via bulk-action:
+        // re-issuing CLOSE against an already-CLOSED tenant skips the no-op
+        // repo.update but MUST re-run the cascade and, if any stragglers
+        // transition, classify the row as succeeded (state changed).
+        when(idempotencyStore.lookup(anyString(), anyString(), eq(TenantBulkActionResponse.class)))
+                .thenReturn(java.util.Optional.empty());
+        when(tenantRepository.matchForBulk(any(), any(), any(), eq(500)))
+                .thenReturn(List.of(tenantRow("t1", TenantStatus.CLOSED)));
+        when(tenantRepository.get("t1")).thenReturn(tenantRow("t1", TenantStatus.CLOSED));
+        when(tenantCloseCascadeService.cascade(eq("t1"), any()))
+                .thenReturn(new TenantCloseCascadeService.CascadeResult(1, 0, 0, 0L));
+
+        mockMvc.perform(post("/v1/admin/tenants/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"filter\":{\"status\":\"CLOSED\"},\"action\":\"CLOSE\",\"idempotency_key\":\"k1\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.succeeded[0].id").value("t1"))
+                .andExpect(jsonPath("$.skipped.length()").value(0));
+
+        // Cascade invoked; repo.update skipped (tenant already CLOSED).
+        verify(tenantCloseCascadeService).cascade(eq("t1"), any());
+        verify(tenantRepository, never()).update(anyString(), any());
+    }
+
+    @Test
+    void bulkActionTenants_closeAgainstAlreadyClosed_fullyConverged_bucketsAsSkipped() throws Exception {
+        // Spec v0.1.25.31 Rule 1(c): re-issuing CLOSE against a tenant that
+        // is already CLOSED AND has no non-terminal children → cascade is a
+        // complete no-op → row bucketed as skipped (ALREADY_IN_TARGET_STATE)
+        // so the bulk-action response honestly reports no state change.
+        when(idempotencyStore.lookup(anyString(), anyString(), eq(TenantBulkActionResponse.class)))
+                .thenReturn(java.util.Optional.empty());
+        when(tenantRepository.matchForBulk(any(), any(), any(), eq(500)))
+                .thenReturn(List.of(tenantRow("t1", TenantStatus.CLOSED)));
+        when(tenantRepository.get("t1")).thenReturn(tenantRow("t1", TenantStatus.CLOSED));
+        when(tenantCloseCascadeService.cascade(eq("t1"), any()))
+                .thenReturn(TenantCloseCascadeService.CascadeResult.empty());
+
+        mockMvc.perform(post("/v1/admin/tenants/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"filter\":{\"status\":\"CLOSED\"},\"action\":\"CLOSE\",\"idempotency_key\":\"k1\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.skipped[0].id").value("t1"))
+                .andExpect(jsonPath("$.skipped[0].reason").value("ALREADY_IN_TARGET_STATE"))
+                .andExpect(jsonPath("$.succeeded.length()").value(0));
+
+        verify(tenantCloseCascadeService).cascade(eq("t1"), any());
+        verify(tenantRepository, never()).update(anyString(), any());
     }
 
     @Test

--- a/cycles-admin-service/pom.xml
+++ b/cycles-admin-service/pom.xml
@@ -18,7 +18,7 @@
         <module>cycles-admin-service-api</module>
     </modules>
     <properties>
-        <revision>0.1.25.36</revision>
+        <revision>0.1.25.37</revision>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>


### PR DESCRIPTION
## Summary

Closes a spec-conformance gap identified in a code-review against `OPERATIONS.md` §"Tenant-close cascade" and spec v0.1.25.31 Rule 1(c).

The `OPERATIONS.md` triage recipe instructs operators to recover from a partial cascade by re-issuing the close via `PATCH /v1/admin/tenants/{id}` with `status=CLOSED` (or bulk-action CLOSE), promising the cascade would "pick up stragglers." In practice both entry points short-circuited on already-CLOSED tenants — the `TenantCloseCascadeService` is idempotent at the repository layer, but that idempotency was unreachable from the public API.

## Changes

**`TenantController.update()` (PATCH):**
- Cascade runs on every `status=CLOSED` request regardless of prior status (was gated behind `isFreshClose`).
- On a retry (prior was already CLOSED), parent event falls through to `tenant.updated` — no duplicate `tenant.closed`. Straggler children still emit their own `*_via_tenant_cascade` events via the cascade service.

**`TenantController.applyTenantAction()` (bulk-action):**
- For `action=CLOSE` with `current == target == CLOSED`, skips the redundant `repo.update` but still calls the cascade.
- Bucketing: `succeeded` if any child transitioned; `skipped` (`reason=ALREADY_IN_TARGET_STATE`) if cascade was a full no-op. Non-CLOSE actions retain existing `ALREADY_IN_TARGET_STATE` short-circuit behavior.

**Tests:**
- Inverted `updateTenant_priorStatusAlreadyClosed_skipsCascade` (which pinned the old broken behavior) → `updateTenant_priorStatusAlreadyClosed_rerunsCascadeForConvergence`.
- New: `bulkActionTenants_closeAgainstAlreadyClosed_withStragglers_rerunsCascadeAndSucceeds`.
- New: `bulkActionTenants_closeAgainstAlreadyClosed_fullyConverged_bucketsAsSkipped`.

**Docs:**
- `AUDIT.md` v0.1.25.37 entry with before/after, spec citation, test coverage.
- `CHANGELOG.md` v0.1.25.37 downstream-facing summary.
- `TenantCloseCascadeService` Javadoc updated to describe the new entry-point contract.

**Unchanged:**
- No wire/OpenAPI/DTO change.
- Cascade service semantics unchanged.
- Spec-coverage report `declared=46 covered=46 missing=0`.

## Test plan

- [x] `mvn verify` — 749 tests, 0 failures, 0 errors.
- [x] Jacoco 95% line-coverage gate passes (BUILD SUCCESS).
- [x] `OpenApiContractDiffTest` passes — no wire drift.
- [x] `SpecCoverageReportTest` reports `declared=46 covered=46 missing=0`.
- [x] Existing cascade + Rule 2 tests remain green.

## Recovery behavior after this change

Operator sees a budget in `FROZEN` under a `CLOSED` tenant (partial cascade). Re-issues `PATCH /v1/admin/tenants/{id} { "status": "CLOSED" }`:
- Cascade is re-invoked.
- Repository `cascadeClose` filters by non-terminal status → only the straggler transitions.
- One `budget.closed_via_tenant_cascade` event emitted for the straggler; no duplicate audit/event rows for already-terminal children.
- Parent event: `tenant.updated` (not a duplicate `tenant.closed`).
- New `correlation_id = tenant_close_cascade:<tenant_id>:<new_request_id>` for the retry.