### PR TITLE
feat: bulk-action event parity on budgets + tenants (v0.1.25.38)

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,9 +1,94 @@
-# Complete Budget Governance v0.1.25.37 — Admin Server Audit
+# Complete Budget Governance v0.1.25.38 — Admin Server Audit
 
-**Server version:** 0.1.25.37 (2026-04-21 — spec v0.1.25.31 CASCADE SEMANTICS; Mode B flip-first-with-guarded-cascade conformant; Rule 1(c) bounded-convergence wired into PATCH and bulk-action close paths; Rule 2 guard coverage complete across all admin-mutating endpoints)
-**Date:** 2026-04-21 (v0.1.25.37 Rule 1(c) bounded-convergence: PATCH /tenants/{id} and bulk-action CLOSE re-run cascade on already-CLOSED tenants for straggler convergence), 2026-04-20 (v0.1.25.36 Rule 2 guard expansion: policies + api-keys + webhook-admin create/update/delete/test/replay + budgets and webhooks bulk-action per-row + webhook-tenant delete/test), 2026-04-20 (v0.1.25.35 cascade + TENANT_CLOSED guard), 2026-04-19 (v0.1.25.34 commons-lang3 CVE pin), 2026-04-19 (v0.1.25.33 Spring Boot / Tomcat CVE bump), 2026-04-18 (v0.1.25.32 cross-plane read tolerance hardening), 2026-04-18 (v0.1.25.31 trace_id cross-surface correlation), 2026-04-18 (v0.1.25.30 bulk-action audit enrichment), 2026-04-18 (v0.1.25.29 budget bulk-action), 2026-04-17 (v0.1.25.28 audit sentinel split), 2026-04-17 (v0.1.25.27 audit filter DSL upgrade), 2026-04-17 (v0.1.25.26 bulk-action endpoints), 2026-04-17 (v0.1.25.25 search on six list endpoints), 2026-04-16 (v0.1.25.24 server-side sort — six admin list endpoints), 2026-04-16 (v0.1.25.23 BudgetLedger tenant_id on wire), 2026-04-16 (v0.1.25.22 cross-tenant list + filters), 2026-04-16 (v0.1.25.21 nightly CI), 2026-04-16 (v0.1.25.20 audit-on-failure), 2026-04-16 (v0.1.25.19 introspect dual-auth + operator docs), 2026-04-15 (v0.1.25.18 RESET_SPENT operation), 2026-04-14 (v0.1.25.17 cjson round-trip sweep: apikey + policy + tenant), 2026-04-13 (v0.1.25.16 webhooks dual-auth), 2026-04-13 (v0.1.25.15 ScopeValidator), 2026-04-13 (v0.1.25.14 admin-on-behalf-of dual-auth), 2026-04-13 (v0.1.25.13 CORS PUT fix), 2026-04-12 (v0.1.25.12 spec-compliance hardening + observability), 2026-04-12 (v0.1.25.11 contract-testing default ON), 2026-04-12 (v0.1.25.10 spec-compliance hardening), 2026-04-10 (v0.1.25.9 release), 2026-04-10 (CORS hardening + prod config), 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
+**Server version:** 0.1.25.38 (2026-04-22 — spec v0.1.25.32 bulk-action event parity; per-row Events emitted on `bulkActionBudgets` + `bulkActionTenants` with resource-scoped `*_bulk_action:<action>:<request_id>` correlation_id; aggregate `AuditLogEntry` and cascade semantics unchanged)
+**Date:** 2026-04-22 (v0.1.25.38 bulk-action event parity: per-row Events on budget + tenant bulk paths), 2026-04-21 (v0.1.25.37 Rule 1(c) bounded-convergence: PATCH /tenants/{id} and bulk-action CLOSE re-run cascade on already-CLOSED tenants for straggler convergence), 2026-04-20 (v0.1.25.36 Rule 2 guard expansion: policies + api-keys + webhook-admin create/update/delete/test/replay + budgets and webhooks bulk-action per-row + webhook-tenant delete/test), 2026-04-20 (v0.1.25.35 cascade + TENANT_CLOSED guard), 2026-04-19 (v0.1.25.34 commons-lang3 CVE pin), 2026-04-19 (v0.1.25.33 Spring Boot / Tomcat CVE bump), 2026-04-18 (v0.1.25.32 cross-plane read tolerance hardening), 2026-04-18 (v0.1.25.31 trace_id cross-surface correlation), 2026-04-18 (v0.1.25.30 bulk-action audit enrichment), 2026-04-18 (v0.1.25.29 budget bulk-action), 2026-04-17 (v0.1.25.28 audit sentinel split), 2026-04-17 (v0.1.25.27 audit filter DSL upgrade), 2026-04-17 (v0.1.25.26 bulk-action endpoints), 2026-04-17 (v0.1.25.25 search on six list endpoints), 2026-04-16 (v0.1.25.24 server-side sort — six admin list endpoints), 2026-04-16 (v0.1.25.23 BudgetLedger tenant_id on wire), 2026-04-16 (v0.1.25.22 cross-tenant list + filters), 2026-04-16 (v0.1.25.21 nightly CI), 2026-04-16 (v0.1.25.20 audit-on-failure), 2026-04-16 (v0.1.25.19 introspect dual-auth + operator docs), 2026-04-15 (v0.1.25.18 RESET_SPENT operation), 2026-04-14 (v0.1.25.17 cjson round-trip sweep: apikey + policy + tenant), 2026-04-13 (v0.1.25.16 webhooks dual-auth), 2026-04-13 (v0.1.25.15 ScopeValidator), 2026-04-13 (v0.1.25.14 admin-on-behalf-of dual-auth), 2026-04-13 (v0.1.25.13 CORS PUT fix), 2026-04-12 (v0.1.25.12 spec-compliance hardening + observability), 2026-04-12 (v0.1.25.11 contract-testing default ON), 2026-04-12 (v0.1.25.10 spec-compliance hardening), 2026-04-10 (v0.1.25.9 release), 2026-04-10 (CORS hardening + prod config), 2026-04-10 (observability: prometheus metrics + k8s probes), 2026-04-10 (v0.1.25.8 spec alignment), 2026-04-09 (v0.1.25.7 admin wildcard fallback), 2026-04-08 (v0.1.25.6 freeze/unfreeze + admin fund), 2026-04-08 (v0.1.25.5 dashboard support release), 2026-04-06 (v0.1.25.4 spec compliance + replay lock), 2026-04-01 (spec compliance review), 2026-04-01 (TTL retention + release prep), 2026-04-01 (integration audit + encryption), 2026-03-31 (v0.1.25 Pillar 4: Events & Webhooks spec), 2026-03-31 (dynamic version), 2026-03-24 (Round 6: spec compliance audit), 2026-03-24 (Round 5: pre-release audit), 2026-03-24 (v0.1.24 update), 2026-03-23 (updated), 2026-03-14 (initial)
 **Spec:** [`cycles-governance-admin-v0.1.25.yaml`](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml) (OpenAPI 3.1.0, info.version `0.1.25.31`; adds CASCADE SEMANTICS — Rule 1 `POST /admin/tenants/{id}` PATCH→CLOSED cascades owned budgets (→CLOSED), webhook subscriptions (→DISABLED), and API keys (→REVOKED) under a shared correlation_id — Rule 1 permits **Mode A (atomic)** or **Mode B (flip-first-with-guarded-cascade)** as of v0.1.25.31, and Rule 2 rejects any mutating operation against an object whose owning tenant is CLOSED with 409 `TENANT_CLOSED`; adds the `TENANT_CLOSED` error code to the shared enum and the four `*_via_tenant_cascade` event kinds: `budget.closed_via_tenant_cascade`, `webhook.disabled_via_tenant_cascade`, `api_key.revoked_via_tenant_cascade`, `reservation.released_via_tenant_cascade`) in [cycles-protocol](https://github.com/runcycles/cycles-protocol)
 **Server:** Spring Boot 3.5.13 / Java 21 / Redis · Tomcat 10.1.54 pin · commons-lang3 3.18.0 pin
+
+### 2026-04-22 — v0.1.25.38: Bulk-action event parity (spec v0.1.25.32)
+
+**Motivation.** An operator observability review found that single-op
+budget-fund and tenant-lifecycle endpoints emitted first-class Events
+(`budget.funded`, `tenant.closed`, etc.) while the matching bulk-action
+paths emitted **only** a single aggregate `AuditLogEntry` per invocation.
+Operators watching `listEvents` to track funding or lifecycle activity
+had a blind spot whenever the same logical operation went through the
+bulk path. Spec was silent on bulk event emission but the existing
+`EventType` enum already defined the per-op kinds as first-class, and
+the tenant-close cascade (spec v0.1.25.29) had already set the
+precedent of per-row Events with a shared correlation_id on a multi-row
+op. Cycles-protocol spec v0.1.25.32 formalizes the emission contract
+on both endpoints; this server release implements it.
+
+**Scope.** `POST /v1/admin/budgets/bulk-action` +
+`POST /v1/admin/tenants/bulk-action`. `bulkActionWebhooks` is out of
+scope — webhook lifecycle events (`webhook.enabled` /
+`webhook.disabled` / `webhook.deleted`) do not exist in the `EventType`
+enum today (only `WEBHOOK_DISABLED_VIA_TENANT_CASCADE` for cascade
+fan-out). Adding them is a separate spec RFC; the bulk-action path
+can't emit kinds the spec doesn't define.
+
+**What changed.**
+- `BudgetController.applyBudgetAction` now captures the
+  `BudgetFundingResponse` from `repository.fund(...)` and emits
+  `budget.funded` / `budget.debited` / `budget.reset` /
+  `budget.reset_spent` / `budget.debt_repaid` keyed off the
+  FundingOperation (same mapping as single-op `fundBudget` at
+  `BudgetController.java:328-335`). Correlation_id shape:
+  `budget_bulk_action:<action>:<request_id>`.
+- `TenantController.applyTenantAction` now emits `tenant.suspended` /
+  `tenant.reactivated` / `tenant.closed` after each successful mutation.
+  For action=CLOSE the cascade call was hoisted so its result is
+  attached to the parent-event `cascade` summary (mirroring the single-
+  op PATCH at `TenantController.java:173-175`). Correlation_id shape:
+  `tenant_bulk_action:<action>:<request_id>`.
+
+**Correlation-id design.** Each bulk invocation now produces **two**
+correlation axes for CLOSE:
+- `tenant_bulk_action:close:<request_id>` stamped on the N parent
+  `tenant.closed` Events — one per row in the bulk op. Operators
+  tracing *this invocation* query by this id.
+- `tenant_close_cascade:<tenant_id>:<request_id>` stamped on each
+  tenant's cascade fan-out (unchanged v0.1.25.29 behavior). Operators
+  tracing *one specific tenant's close* query by this id.
+
+The two axes are complementary; neither was touched by the other.
+
+**Discipline — what does NOT emit.**
+- Skipped rows (`ALREADY_IN_TARGET_STATE`) emit no Event — matches
+  single-op behavior where a no-op doesn't write to the Event log.
+- Failed rows emit no Event — the bulk-action response's `failed[]`
+  bucket is the operator-facing signal; double-writing to the Event
+  log would produce false failure alerts.
+- Event emission failure is caught and logged (`LOG.warn`); it never
+  aborts the bulk op. Matches the single-op try/catch discipline.
+
+**Unchanged.**
+- Aggregate `AuditLogEntry` per invocation — spec v0.1.25.26 requires
+  "one AuditLogEntry per bulk-action invocation (not per row)" and
+  this release does not touch that.
+- `EventType` enum — existing per-op kinds reused, no new values.
+- Close-cascade service (`TenantCloseCascadeService`) — unchanged. The
+  bulk path now simply hoists its call so the `CascadeResult` can be
+  attached to the parent tenant Event, but the service's own semantics
+  and its `*_via_tenant_cascade` per-child emissions are untouched.
+
+**Tests.** Extended `BudgetControllerBulkActionTest` and
+`TenantControllerTest` (bulk-action slice) with per-action event
+verification — one `verify(eventService, times(n)).emit(...)` per
+success path plus negative assertions on skipped/failed rows.
+Coverage remains ≥95% on both controllers (jacoco).
+
+**Files touched.**
+- `cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/BudgetController.java`
+  — `bulkAction` computes once-per-invocation correlationId + requestId;
+  `applyBudgetAction` signature extended; new `emitBulkFundEvent` helper.
+- `cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/TenantController.java`
+  — `bulkAction` computes once-per-invocation correlationId + requestId;
+  `applyTenantAction` signature extended and cascade-call hoisted;
+  new `emitBulkTenantEvent` helper.
+- Tests extended in matching `*Test.java` files.
+- `cycles-admin-service/pom.xml` revision bump.
 
 ### 2026-04-21 — v0.1.25.37: Rule 1(c) bounded-convergence wired into close paths (spec v0.1.25.31 MUST)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,38 @@ changes to request/response bodies or Lua-script semantics would require a
 minor bump. Additive fields (new optional response fields, new enum values,
 new optional request fields) are **not** considered breaking.
 
+## [0.1.25.38] — 2026-04-22
+
+### Added
+
+- **Per-row Events on bulk-action endpoints** (spec v0.1.25.32). Previously,
+  `POST /v1/admin/budgets/bulk-action` and `POST /v1/admin/tenants/bulk-action`
+  wrote only a single aggregate `AuditLogEntry` per invocation; the matching
+  single-op endpoints (`POST /fund`, `PATCH /tenants/{id}`) emitted a per-op
+  lifecycle Event. Operators watching `listEvents` had a blind spot whenever
+  the same logical operation went through the bulk path.
+  - `bulkActionBudgets` now emits one Event per successfully-mutated row,
+    typed by action (`budget.funded` / `budget.debited` / `budget.reset` /
+    `budget.reset_spent` / `budget.debt_repaid`), with
+    `correlation_id = budget_bulk_action:<action>:<request_id>`.
+  - `bulkActionTenants` now emits one *parent* Event per successfully-mutated
+    row (`tenant.suspended` / `tenant.reactivated` / `tenant.closed`), with
+    `correlation_id = tenant_bulk_action:<action>:<request_id>`. For
+    action=CLOSE this is in addition to the existing
+    `tenant_close_cascade:<tenant_id>:<request_id>` cascade fan-out events,
+    which are unchanged (complementary correlation_ids — operators tracing
+    the bulk invocation query the bulk id; operators tracing a specific
+    tenant's close query the cascade id).
+  - Skipped rows (`ALREADY_IN_TARGET_STATE`) and failed rows emit no
+    Event — matching single-op discipline and avoiding false signal.
+
+### Unchanged
+
+- No wire / OpenAPI / DTO contract change; `EventType` enum unchanged
+  (existing kinds reused, no new enum values). Aggregate `AuditLogEntry`
+  per invocation unchanged — spec's "one audit entry per bulk op" rule
+  is preserved. Close-cascade semantics unchanged.
+
 ## [0.1.25.37] — 2026-04-21
 
 ### Fixed

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/BudgetController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/BudgetController.java
@@ -499,8 +499,17 @@ public class BudgetController {
         List<BulkActionRowOutcome> succeeded = new ArrayList<>();
         List<BulkActionRowOutcome> failed = new ArrayList<>();
         List<BulkActionRowOutcome> skipped = new ArrayList<>();
+        // Per-invocation correlation_id for every per-row Event emitted below.
+        // Spec v0.1.25.32: operators query listEvents?correlation_id=... to see
+        // every row a bulk op touched, tying per-row Events back to the single
+        // aggregate AuditLogEntry via the shared request_id.
+        String requestId = attr(httpRequest, RequestIdFilter.REQUEST_ID_ATTRIBUTE);
+        String correlationId = "budget_bulk_action:"
+            + request.getAction().name().toLowerCase() + ":"
+            + (requestId != null ? requestId : "none");
         for (BudgetLedger ledger : matched) {
-            applyBudgetAction(ledger, request, succeeded, failed, skipped);
+            applyBudgetAction(ledger, request, succeeded, failed, skipped,
+                httpRequest, correlationId, requestId);
         }
 
         BudgetBulkActionResponse response = BudgetBulkActionResponse.builder()
@@ -579,7 +588,10 @@ public class BudgetController {
     private void applyBudgetAction(BudgetLedger ledger, BudgetBulkActionRequest bulk,
                                     List<BulkActionRowOutcome> succeeded,
                                     List<BulkActionRowOutcome> failed,
-                                    List<BulkActionRowOutcome> skipped) {
+                                    List<BulkActionRowOutcome> skipped,
+                                    HttpServletRequest httpRequest,
+                                    String correlationId,
+                                    String requestId) {
         // Spec v0.1.25.26 BudgetBulkActionResponse.succeeded: "Per-row `id`
         // is the ledger_id." The ledger_id is the stable unique identifier;
         // scope is the routing/matching key passed to fund().
@@ -620,8 +632,11 @@ public class BudgetController {
         fundingRequest.setIdempotencyKey(bulk.getIdempotencyKey()
             + ":" + ledger.getScope() + ":" + ledger.getUnit().name());
         try {
-            repository.fund(ledger.getTenantId(), ledger.getScope(), ledger.getUnit(), fundingRequest);
+            BudgetFundingResponse fundResponse = repository.fund(
+                ledger.getTenantId(), ledger.getScope(), ledger.getUnit(), fundingRequest);
             succeeded.add(BulkActionRowOutcome.builder().id(id).build());
+            emitBulkFundEvent(ledger, bulk, fundResponse, httpRequest,
+                correlationId, requestId);
         } catch (GovernanceException e) {
             failed.add(BulkActionRowOutcome.builder()
                 .id(id)
@@ -631,6 +646,65 @@ public class BudgetController {
             LOG.warn("Bulk-action row failed for budget {}: {}", id, e.getMessage());
             failed.add(BulkActionRowOutcome.builder()
                 .id(id).errorCode("INTERNAL_ERROR").message("Internal error").build());
+        }
+    }
+
+    /**
+     * Per-row Event emission for bulk-action budgets (spec v0.1.25.32). Mirrors
+     * the single-op fund event at {@link #fund}: maps FundingOperation to the
+     * matching {@link EventType}, builds the pre/post {@link EventDataBudgetLifecycle}
+     * snapshot from the repository response, and stamps the envelope-scoped
+     * {@code budget_bulk_action:<action>:<request_id>} correlation_id so
+     * operators can query {@code listEvents?correlation_id=...} to see every
+     * row this invocation touched. Skipped and failed rows never reach this
+     * method. Event emission failure is caught and logged — it must not
+     * abort the bulk op (matching single-fund discipline).
+     */
+    private void emitBulkFundEvent(BudgetLedger ledger, BudgetBulkActionRequest bulk,
+                                    BudgetFundingResponse response,
+                                    HttpServletRequest httpRequest,
+                                    String correlationId, String requestId) {
+        if (response == null) return;
+        try {
+            EventType eventType;
+            switch (bulk.getAction()) {
+                case CREDIT: eventType = EventType.BUDGET_FUNDED; break;
+                case DEBIT: eventType = EventType.BUDGET_DEBITED; break;
+                case RESET: eventType = EventType.BUDGET_RESET; break;
+                case RESET_SPENT: eventType = EventType.BUDGET_RESET_SPENT; break;
+                case REPAY_DEBT: eventType = EventType.BUDGET_DEBT_REPAID; break;
+                default: eventType = EventType.BUDGET_FUNDED; break;
+            }
+            EventDataBudgetLifecycle.BudgetState previousState = EventDataBudgetLifecycle.BudgetState.builder()
+                .allocated(response.getPreviousAllocated() != null ? response.getPreviousAllocated().getAmount() : null)
+                .remaining(response.getPreviousRemaining() != null ? response.getPreviousRemaining().getAmount() : null)
+                .debt(response.getPreviousDebt() != null ? response.getPreviousDebt().getAmount() : null)
+                .spent(response.getPreviousSpent() != null ? response.getPreviousSpent().getAmount() : null)
+                .build();
+            EventDataBudgetLifecycle.BudgetState newState = EventDataBudgetLifecycle.BudgetState.builder()
+                .allocated(response.getNewAllocated() != null ? response.getNewAllocated().getAmount() : null)
+                .remaining(response.getNewRemaining() != null ? response.getNewRemaining().getAmount() : null)
+                .debt(response.getNewDebt() != null ? response.getNewDebt().getAmount() : null)
+                .spent(response.getNewSpent() != null ? response.getNewSpent().getAmount() : null)
+                .build();
+            EventDataBudgetLifecycle.EventDataBudgetLifecycleBuilder payloadBuilder =
+                EventDataBudgetLifecycle.builder()
+                    .scope(ledger.getScope()).unit(ledger.getUnit())
+                    .operation(BudgetOperation.valueOf(bulk.getAction().name()))
+                    .previousState(previousState)
+                    .newState(newState)
+                    .reason(bulk.getReason());
+            if (bulk.getAction() == FundingOperation.RESET_SPENT) {
+                payloadBuilder.spentOverrideProvided(bulk.getSpent() != null);
+            }
+            eventService.emit(eventType, ledger.getTenantId(), ledger.getScope(),
+                "cycles-admin",
+                Actor.builder().type(ActorType.ADMIN)
+                    .keyId((String) httpRequest.getAttribute("authenticated_key_id")).build(),
+                objectMapper.convertValue(payloadBuilder.build(), Map.class),
+                correlationId, requestId);
+        } catch (Exception e) {
+            LOG.warn("Failed to emit bulk-action event: {}", e.getMessage());
         }
     }
 

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/TenantController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/TenantController.java
@@ -317,8 +317,18 @@ public class TenantController {
         List<BulkActionRowOutcome> failed = new ArrayList<>();
         List<BulkActionRowOutcome> skipped = new ArrayList<>();
         TenantStatus target = targetStatus(request.getAction());
+        // Per-invocation correlation_id for every per-row Event emitted below.
+        // Spec v0.1.25.32: parent tenant event stamped here; the cascade fan-out
+        // (action=CLOSE) keeps its own `tenant_close_cascade:<tenant_id>:<request_id>`
+        // correlation_id unchanged so operators can trace the bulk invocation
+        // (this correlation_id) OR a specific tenant's cascade (cascade id).
+        String requestId = attr(httpRequest, RequestIdFilter.REQUEST_ID_ATTRIBUTE);
+        String correlationId = "tenant_bulk_action:"
+            + request.getAction().name().toLowerCase() + ":"
+            + (requestId != null ? requestId : "none");
         for (Tenant t : matched) {
-            applyTenantAction(t, request.getAction(), target, succeeded, failed, skipped, httpRequest);
+            applyTenantAction(t, request.getAction(), target, succeeded, failed, skipped,
+                httpRequest, correlationId, requestId);
         }
 
         TenantBulkActionResponse response = TenantBulkActionResponse.builder()
@@ -363,7 +373,9 @@ public class TenantController {
                                     List<BulkActionRowOutcome> succeeded,
                                     List<BulkActionRowOutcome> failed,
                                     List<BulkActionRowOutcome> skipped,
-                                    HttpServletRequest httpRequest) {
+                                    HttpServletRequest httpRequest,
+                                    String correlationId,
+                                    String requestId) {
         String id = matched.getTenantId();
         try {
             Tenant live = repository.get(id);
@@ -397,13 +409,13 @@ public class TenantController {
                 update.setStatus(target);
                 repository.update(id, update);
             }
+            TenantCloseCascadeService.CascadeResult cascadeResult = null;
             if (action == TenantBulkAction.CLOSE) {
-                TenantCloseCascadeService.CascadeResult r =
-                    tenantCloseCascadeService.cascade(id, httpRequest);
+                cascadeResult = tenantCloseCascadeService.cascade(id, httpRequest);
                 if (current == target
-                        && r.budgetsClosed() == 0
-                        && r.webhooksDisabled() == 0
-                        && r.apiKeysRevoked() == 0) {
+                        && cascadeResult.budgetsClosed() == 0
+                        && cascadeResult.webhooksDisabled() == 0
+                        && cascadeResult.apiKeysRevoked() == 0) {
                     // Already-CLOSED with nothing left to cascade: retry
                     // converged to a full no-op. Report as skipped to keep
                     // the bulk-action contract honest (no state change).
@@ -413,6 +425,8 @@ public class TenantController {
                 }
             }
             succeeded.add(BulkActionRowOutcome.builder().id(id).build());
+            emitBulkTenantEvent(id, action, cascadeResult, httpRequest,
+                correlationId, requestId);
         } catch (GovernanceException e) {
             failed.add(BulkActionRowOutcome.builder()
                 .id(id)
@@ -422,6 +436,56 @@ public class TenantController {
             LOG.warn("Bulk-action row failed for tenant {}: {}", id, e.getMessage());
             failed.add(BulkActionRowOutcome.builder()
                 .id(id).errorCode("INTERNAL_ERROR").message("Internal error").build());
+        }
+    }
+
+    /**
+     * Per-row Event emission for bulk-action tenants (spec v0.1.25.32). Maps
+     * TenantBulkAction to the matching {@link EventType} for the *parent*
+     * tenant lifecycle transition (SUSPEND → TENANT_SUSPENDED, REACTIVATE →
+     * TENANT_REACTIVATED, CLOSE → TENANT_CLOSED). The cascade fan-out events
+     * (action=CLOSE) retain their own {@code tenant_close_cascade:...}
+     * correlation_id and are emitted separately by {@link TenantCloseCascadeService}.
+     * Skipped and failed rows never reach this method.
+     */
+    private void emitBulkTenantEvent(String tenantId, TenantBulkAction action,
+                                      TenantCloseCascadeService.CascadeResult cascadeResult,
+                                      HttpServletRequest httpRequest,
+                                      String correlationId, String requestId) {
+        try {
+            EventType eventType;
+            TenantStatus newStatus;
+            switch (action) {
+                case SUSPEND:
+                    eventType = EventType.TENANT_SUSPENDED;
+                    newStatus = TenantStatus.SUSPENDED;
+                    break;
+                case REACTIVATE:
+                    eventType = EventType.TENANT_REACTIVATED;
+                    newStatus = TenantStatus.ACTIVE;
+                    break;
+                case CLOSE:
+                    eventType = EventType.TENANT_CLOSED;
+                    newStatus = TenantStatus.CLOSED;
+                    break;
+                default: return;
+            }
+            @SuppressWarnings("unchecked")
+            Map<String, Object> eventData = objectMapper.convertValue(
+                EventDataTenantLifecycle.builder()
+                    .tenantId(tenantId)
+                    .newStatus(newStatus)
+                    .changedFields(List.of()).build(), Map.class);
+            if (cascadeResult != null) {
+                eventData.put("cascade", cascadeSummaryMap(cascadeResult));
+            }
+            eventService.emit(eventType, tenantId, null, "cycles-admin",
+                Actor.builder().type(ActorType.ADMIN)
+                    .keyId((String) httpRequest.getAttribute("authenticated_key_id")).build(),
+                eventData,
+                correlationId, requestId);
+        } catch (Exception e) {
+            LOG.warn("Failed to emit bulk-action event: {}", e.getMessage());
         }
     }
 

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BudgetControllerBulkActionTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/BudgetControllerBulkActionTest.java
@@ -15,9 +15,11 @@ import io.runcycles.admin.model.audit.AuditLogEntry;
 import io.runcycles.admin.model.auth.ApiKeyValidationResponse;
 import io.runcycles.admin.model.budget.BudgetBulkActionResponse;
 import io.runcycles.admin.model.budget.BudgetFundingRequest;
+import io.runcycles.admin.model.budget.BudgetFundingResponse;
 import io.runcycles.admin.model.budget.BudgetLedger;
 import io.runcycles.admin.model.budget.BudgetStatus;
 import io.runcycles.admin.model.budget.FundingOperation;
+import io.runcycles.admin.model.event.EventType;
 import io.runcycles.admin.model.shared.Amount;
 import io.runcycles.admin.model.shared.BulkActionRowOutcome;
 import io.runcycles.admin.model.shared.ErrorCode;
@@ -607,6 +609,193 @@ class BudgetControllerBulkActionTest {
                 .andExpect(status().isUnauthorized());
 
         verify(budgetRepository, never()).matchForBulk(anyString(), any(), anyInt());
+    }
+
+    // -------- Per-row Event emission (spec v0.1.25.32) ------------------
+    // Each successfully-mutated row emits one Event typed by action with a
+    // shared `budget_bulk_action:<action>:<request_id>` correlation_id.
+    // Skipped/failed rows MUST NOT emit.
+
+    private static BudgetFundingResponse fundResponse() {
+        return BudgetFundingResponse.builder()
+                .previousAllocated(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
+                .newAllocated(new Amount(UnitEnum.USD_MICROCENTS, 1500L))
+                .previousRemaining(new Amount(UnitEnum.USD_MICROCENTS, 1000L))
+                .newRemaining(new Amount(UnitEnum.USD_MICROCENTS, 1500L))
+                .previousSpent(new Amount(UnitEnum.USD_MICROCENTS, 0L))
+                .newSpent(new Amount(UnitEnum.USD_MICROCENTS, 0L))
+                .build();
+    }
+
+    @Test
+    void bulkAction_credit_emitsBudgetFundedEventPerRow() throws Exception {
+        noReplay();
+        when(budgetRepository.matchForBulk(eq(TENANT), any(BudgetListFilters.class), eq(500)))
+                .thenReturn(List.of(ledger("tenant:acme/workspace:a"),
+                                    ledger("tenant:acme/workspace:b")));
+        when(budgetRepository.fund(eq(TENANT), anyString(), any(), any()))
+                .thenReturn(fundResponse());
+
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter(""), "CREDIT", "k_evt",
+                                "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":500}")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.succeeded.length()").value(2));
+
+        ArgumentCaptor<String> corr = ArgumentCaptor.forClass(String.class);
+        verify(eventService, times(2)).emit(eq(EventType.BUDGET_FUNDED),
+                eq(TENANT), anyString(), eq("cycles-admin"),
+                any(), any(), corr.capture(), any());
+        assertEquals(1, new java.util.HashSet<>(corr.getAllValues()).size());
+        assertThat(corr.getValue()).startsWith("budget_bulk_action:credit:");
+    }
+
+    @Test
+    void bulkAction_debit_emitsBudgetDebitedEvent() throws Exception {
+        noReplay();
+        when(budgetRepository.matchForBulk(eq(TENANT), any(BudgetListFilters.class), eq(500)))
+                .thenReturn(List.of(ledger("tenant:acme/workspace:eng", 1_000L, 100L, 0L)));
+        when(budgetRepository.fund(eq(TENANT), anyString(), any(), any()))
+                .thenReturn(fundResponse());
+
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter(""), "DEBIT", "k_d",
+                                "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":100}")))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<String> corr = ArgumentCaptor.forClass(String.class);
+        verify(eventService).emit(eq(EventType.BUDGET_DEBITED),
+                eq(TENANT), anyString(), eq("cycles-admin"),
+                any(), any(), corr.capture(), any());
+        assertThat(corr.getValue()).startsWith("budget_bulk_action:debit:");
+    }
+
+    @Test
+    void bulkAction_reset_emitsBudgetResetEvent() throws Exception {
+        noReplay();
+        when(budgetRepository.matchForBulk(eq(TENANT), any(BudgetListFilters.class), eq(500)))
+                .thenReturn(List.of(ledger("tenant:acme/workspace:eng")));
+        when(budgetRepository.fund(eq(TENANT), anyString(), any(), any()))
+                .thenReturn(fundResponse());
+
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter(""), "RESET", "k_r",
+                                "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":1000}")))
+                .andExpect(status().isOk());
+
+        verify(eventService).emit(eq(EventType.BUDGET_RESET),
+                eq(TENANT), anyString(), eq("cycles-admin"),
+                any(), any(), startsWith("budget_bulk_action:reset:"), any());
+    }
+
+    @Test
+    void bulkAction_resetSpent_emitsBudgetResetSpentEvent() throws Exception {
+        noReplay();
+        when(budgetRepository.matchForBulk(eq(TENANT), any(BudgetListFilters.class), eq(500)))
+                .thenReturn(List.of(ledger("tenant:acme/workspace:eng", 1_000L, 500L, 0L)));
+        when(budgetRepository.fund(eq(TENANT), anyString(), any(), any()))
+                .thenReturn(fundResponse());
+
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter(""), "RESET_SPENT", "k_rs",
+                                "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":1000},"
+                                        + "\"spent\":{\"unit\":\"USD_MICROCENTS\",\"amount\":0}")))
+                .andExpect(status().isOk());
+
+        verify(eventService).emit(eq(EventType.BUDGET_RESET_SPENT),
+                eq(TENANT), anyString(), eq("cycles-admin"),
+                any(), any(), startsWith("budget_bulk_action:reset_spent:"), any());
+    }
+
+    @Test
+    void bulkAction_repayDebt_emitsBudgetDebtRepaidEvent() throws Exception {
+        noReplay();
+        when(budgetRepository.matchForBulk(eq(TENANT), any(BudgetListFilters.class), eq(500)))
+                .thenReturn(List.of(ledger("tenant:acme/workspace:eng", 1_000L, 0L, 250L)));
+        when(budgetRepository.fund(eq(TENANT), anyString(), any(), any()))
+                .thenReturn(fundResponse());
+
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter(""), "REPAY_DEBT", "k_rp",
+                                "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":250}")))
+                .andExpect(status().isOk());
+
+        verify(eventService).emit(eq(EventType.BUDGET_DEBT_REPAID),
+                eq(TENANT), anyString(), eq("cycles-admin"),
+                any(), any(), startsWith("budget_bulk_action:repay_debt:"), any());
+    }
+
+    @Test
+    void bulkAction_skippedRow_noEventEmitted() throws Exception {
+        // REPAY_DEBT on a zero-debt ledger → skipped (ALREADY_IN_TARGET_STATE).
+        // No event should be emitted.
+        noReplay();
+        when(budgetRepository.matchForBulk(eq(TENANT), any(BudgetListFilters.class), eq(500)))
+                .thenReturn(List.of(ledger("tenant:acme/workspace:eng", 1_000L, 0L, 0L)));
+
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter(""), "REPAY_DEBT", "k_s",
+                                "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":100}")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.skipped.length()").value(1));
+
+        verify(eventService, never()).emit(any(EventType.class), anyString(), anyString(),
+                anyString(), any(), any(), anyString(), any());
+    }
+
+    @Test
+    void bulkAction_failedRow_noEventEmitted() throws Exception {
+        // fund() throws → row bucketed as failed; no event emitted.
+        noReplay();
+        when(budgetRepository.matchForBulk(eq(TENANT), any(BudgetListFilters.class), eq(500)))
+                .thenReturn(List.of(ledger("tenant:acme/workspace:eng")));
+        when(budgetRepository.fund(eq(TENANT), anyString(), any(), any()))
+                .thenThrow(new GovernanceException(ErrorCode.BUDGET_FROZEN, "frozen", 409));
+
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter(""), "CREDIT", "k_f",
+                                "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":500}")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.failed.length()").value(1));
+
+        verify(eventService, never()).emit(any(EventType.class), anyString(), anyString(),
+                anyString(), any(), any(), anyString(), any());
+    }
+
+    @Test
+    void bulkAction_emitFailure_doesNotAbortBulkOp() throws Exception {
+        // Spec v0.1.25.32: event emission failure is logged + swallowed; the
+        // row still succeeds (event log is observability, not correctness).
+        noReplay();
+        when(budgetRepository.matchForBulk(eq(TENANT), any(BudgetListFilters.class), eq(500)))
+                .thenReturn(List.of(ledger("tenant:acme/workspace:eng")));
+        when(budgetRepository.fund(eq(TENANT), anyString(), any(), any()))
+                .thenReturn(fundResponse());
+        doThrow(new RuntimeException("event-store-down"))
+                .when(eventService).emit(any(EventType.class), anyString(), anyString(),
+                        anyString(), any(), any(), anyString(), any());
+
+        mockMvc.perform(post("/v1/admin/budgets/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(filter(""), "CREDIT", "k_ef",
+                                "\"amount\":{\"unit\":\"USD_MICROCENTS\",\"amount\":500}")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.succeeded.length()").value(1));
     }
 
     // -------- Cascade Rule 2: closed-owner per-row rejection -----------

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/TenantControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/TenantControllerTest.java
@@ -1142,4 +1142,157 @@ class TenantControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.failed[0].error_code").value("INTERNAL_ERROR"));
     }
+
+    // -------- Per-row Event emission (spec v0.1.25.32) ------------------
+    // Each successfully-mutated row emits one parent tenant Event with a
+    // shared `tenant_bulk_action:<action>:<request_id>` correlation_id.
+    // Skipped/failed rows MUST NOT emit.
+
+    @Test
+    void bulkActionTenants_suspend_emitsTenantSuspendedEventPerRow() throws Exception {
+        when(idempotencyStore.lookup(eq("tenants-bulk"), anyString(), eq(TenantBulkActionResponse.class)))
+                .thenReturn(java.util.Optional.empty());
+        when(tenantRepository.matchForBulk(eq(TenantStatus.ACTIVE), isNull(), isNull(), eq(500)))
+                .thenReturn(List.of(tenantRow("t1", TenantStatus.ACTIVE), tenantRow("t2", TenantStatus.ACTIVE)));
+        when(tenantRepository.get("t1")).thenReturn(tenantRow("t1", TenantStatus.ACTIVE));
+        when(tenantRepository.get("t2")).thenReturn(tenantRow("t2", TenantStatus.ACTIVE));
+        when(tenantRepository.update(anyString(), any())).thenReturn(tenantRow("t1", TenantStatus.SUSPENDED));
+
+        mockMvc.perform(post("/v1/admin/tenants/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"filter\":{\"status\":\"ACTIVE\"},\"action\":\"SUSPEND\",\"idempotency_key\":\"k1\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.succeeded.length()").value(2));
+
+        org.mockito.ArgumentCaptor<String> corr = org.mockito.ArgumentCaptor.forClass(String.class);
+        verify(eventService, times(2)).emit(eq(EventType.TENANT_SUSPENDED),
+                anyString(), isNull(), eq("cycles-admin"), any(), any(), corr.capture(), any());
+        // Both rows must share the same correlation_id (one-per-invocation).
+        assertEquals(1, new java.util.HashSet<>(corr.getAllValues()).size());
+        org.assertj.core.api.Assertions.assertThat(corr.getValue())
+                .startsWith("tenant_bulk_action:suspend:");
+    }
+
+    @Test
+    void bulkActionTenants_reactivate_emitsTenantReactivatedEventPerRow() throws Exception {
+        when(idempotencyStore.lookup(eq("tenants-bulk"), anyString(), eq(TenantBulkActionResponse.class)))
+                .thenReturn(java.util.Optional.empty());
+        when(tenantRepository.matchForBulk(any(), any(), any(), eq(500)))
+                .thenReturn(List.of(tenantRow("t1", TenantStatus.SUSPENDED)));
+        when(tenantRepository.get("t1")).thenReturn(tenantRow("t1", TenantStatus.SUSPENDED));
+        when(tenantRepository.update(anyString(), any())).thenReturn(tenantRow("t1", TenantStatus.ACTIVE));
+
+        mockMvc.perform(post("/v1/admin/tenants/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"filter\":{\"status\":\"SUSPENDED\"},\"action\":\"REACTIVATE\",\"idempotency_key\":\"k1\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.succeeded.length()").value(1));
+
+        org.mockito.ArgumentCaptor<String> corr = org.mockito.ArgumentCaptor.forClass(String.class);
+        verify(eventService).emit(eq(EventType.TENANT_REACTIVATED),
+                anyString(), isNull(), eq("cycles-admin"), any(), any(), corr.capture(), any());
+        org.assertj.core.api.Assertions.assertThat(corr.getValue())
+                .startsWith("tenant_bulk_action:reactivate:");
+    }
+
+    @Test
+    void bulkActionTenants_close_emitsTenantClosedParentEvent_preservesCascadeCorrelationId() throws Exception {
+        // action=CLOSE emits TWO correlation-id axes:
+        //   - `tenant_bulk_action:close:<request_id>` on the parent tenant.closed event.
+        //   - `tenant_close_cascade:<tenant_id>:<request_id>` on each cascade
+        //     fan-out event (emitted inside TenantCloseCascadeService, mocked
+        //     here). This test verifies the PARENT event is correctly tagged
+        //     and that the cascade service is still invoked (its internal
+        //     correlation_id remains unchanged by this change).
+        when(idempotencyStore.lookup(eq("tenants-bulk"), anyString(), eq(TenantBulkActionResponse.class)))
+                .thenReturn(java.util.Optional.empty());
+        when(tenantRepository.matchForBulk(any(), any(), any(), eq(500)))
+                .thenReturn(List.of(tenantRow("t1", TenantStatus.ACTIVE)));
+        when(tenantRepository.get("t1")).thenReturn(tenantRow("t1", TenantStatus.ACTIVE));
+        when(tenantRepository.update(eq("t1"), any())).thenReturn(tenantRow("t1", TenantStatus.CLOSED));
+        when(tenantCloseCascadeService.cascade(eq("t1"), any()))
+                .thenReturn(new TenantCloseCascadeService.CascadeResult(2, 1, 0, 0L));
+
+        mockMvc.perform(post("/v1/admin/tenants/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"filter\":{\"status\":\"ACTIVE\"},\"action\":\"CLOSE\",\"idempotency_key\":\"k1\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.succeeded[0].id").value("t1"));
+
+        org.mockito.ArgumentCaptor<String> corr = org.mockito.ArgumentCaptor.forClass(String.class);
+        verify(eventService).emit(eq(EventType.TENANT_CLOSED),
+                eq("t1"), isNull(), eq("cycles-admin"), any(), any(), corr.capture(), any());
+        org.assertj.core.api.Assertions.assertThat(corr.getValue())
+                .startsWith("tenant_bulk_action:close:");
+        verify(tenantCloseCascadeService).cascade(eq("t1"), any());
+    }
+
+    @Test
+    void bulkActionTenants_skippedRow_noEventEmitted() throws Exception {
+        // ALREADY_IN_TARGET_STATE short-circuit before mutation → no event.
+        when(idempotencyStore.lookup(anyString(), anyString(), eq(TenantBulkActionResponse.class)))
+                .thenReturn(java.util.Optional.empty());
+        when(tenantRepository.matchForBulk(any(), any(), any(), eq(500)))
+                .thenReturn(List.of(tenantRow("t1", TenantStatus.SUSPENDED)));
+        when(tenantRepository.get("t1")).thenReturn(tenantRow("t1", TenantStatus.SUSPENDED));
+
+        mockMvc.perform(post("/v1/admin/tenants/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"filter\":{\"status\":\"SUSPENDED\"},\"action\":\"SUSPEND\",\"idempotency_key\":\"k1\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.skipped.length()").value(1));
+
+        verify(eventService, never()).emit(any(EventType.class), anyString(), any(), anyString(),
+                any(), any(), anyString(), any());
+    }
+
+    @Test
+    void bulkActionTenants_failedRow_noEventEmitted() throws Exception {
+        // Repository.update throws → row bucketed as failed; no event emitted.
+        when(idempotencyStore.lookup(anyString(), anyString(), eq(TenantBulkActionResponse.class)))
+                .thenReturn(java.util.Optional.empty());
+        when(tenantRepository.matchForBulk(any(), any(), any(), eq(500)))
+                .thenReturn(List.of(tenantRow("t1", TenantStatus.ACTIVE)));
+        when(tenantRepository.get("t1")).thenReturn(tenantRow("t1", TenantStatus.ACTIVE));
+        when(tenantRepository.update(eq("t1"), any()))
+                .thenThrow(new GovernanceException(ErrorCode.INSUFFICIENT_PERMISSIONS, "denied", 403));
+
+        mockMvc.perform(post("/v1/admin/tenants/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"filter\":{\"status\":\"ACTIVE\"},\"action\":\"SUSPEND\",\"idempotency_key\":\"k1\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.failed.length()").value(1));
+
+        verify(eventService, never()).emit(any(EventType.class), anyString(), any(), anyString(),
+                any(), any(), anyString(), any());
+    }
+
+    @Test
+    void bulkActionTenants_emitFailure_doesNotAbortBulkOp() throws Exception {
+        // Spec v0.1.25.32: event emission failure must be logged and swallowed;
+        // the row still succeeds (event log is an observability surface, not
+        // a correctness gate). This mirrors the single-op discipline at
+        // TenantController.update.
+        when(idempotencyStore.lookup(anyString(), anyString(), eq(TenantBulkActionResponse.class)))
+                .thenReturn(java.util.Optional.empty());
+        when(tenantRepository.matchForBulk(any(), any(), any(), eq(500)))
+                .thenReturn(List.of(tenantRow("t1", TenantStatus.ACTIVE)));
+        when(tenantRepository.get("t1")).thenReturn(tenantRow("t1", TenantStatus.ACTIVE));
+        when(tenantRepository.update(eq("t1"), any())).thenReturn(tenantRow("t1", TenantStatus.SUSPENDED));
+        doThrow(new RuntimeException("event-store-down"))
+                .when(eventService).emit(any(EventType.class), anyString(), any(), anyString(),
+                        any(), any(), anyString(), any());
+
+        mockMvc.perform(post("/v1/admin/tenants/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"filter\":{\"status\":\"ACTIVE\"},\"action\":\"SUSPEND\",\"idempotency_key\":\"k1\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.succeeded.length()").value(1));
+    }
 }

--- a/cycles-admin-service/pom.xml
+++ b/cycles-admin-service/pom.xml
@@ -18,7 +18,7 @@
         <module>cycles-admin-service-api</module>
     </modules>
     <properties>
-        <revision>0.1.25.37</revision>
+        <revision>0.1.25.38</revision>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>


### PR DESCRIPTION
## Summary

Spec v0.1.25.32 (cycles-protocol [PR #74](https://github.com/runcycles/cycles-protocol/pull/74), merged) closes the observability gap where `bulkActionBudgets` and `bulkActionTenants` emitted only an aggregate `AuditLogEntry` per invocation while the matching single-op endpoints emitted per-op lifecycle Events. This PR implements the per-row event emission contract on both endpoints.

- **Budgets:** `bulkActionBudgets` now emits `budget.funded` / `budget.debited` / `budget.reset` / `budget.reset_spent` / `budget.debt_repaid` per successfully-mutated row, with `correlation_id = budget_bulk_action:<action>:<request_id>`.
- **Tenants:** `bulkActionTenants` now emits `tenant.suspended` / `tenant.reactivated` / `tenant.closed` per successfully-mutated row, with `correlation_id = tenant_bulk_action:<action>:<request_id>`. For action=CLOSE the cascade fan-out retains its own `tenant_close_cascade:<tenant_id>:<request_id>` correlation_id (complementary, unchanged).
- Skipped rows (`ALREADY_IN_TARGET_STATE`) and failed rows emit no Event, matching single-op discipline. Emit failures are caught + logged, never abort the bulk op.

Webhook bulk-action is explicitly out of scope — webhook lifecycle events don't exist in the `EventType` enum today (only `WEBHOOK_DISABLED_VIA_TENANT_CASCADE`). Adding them is a separate spec RFC.

## Unchanged

- No wire / OpenAPI / DTO contract change.
- `EventType` enum unchanged (existing per-op kinds reused).
- Aggregate `AuditLogEntry` per invocation unchanged.
- `TenantCloseCascadeService` semantics unchanged.

## Test plan

- [x] `mvn verify` — 763 tests green
- [x] Jacoco line coverage ≥95% gate passes
- [x] Spec coverage report 46/46
- [x] New tests: `BudgetControllerBulkActionTest` adds 8 per-action / skipped / failed / emit-failure cases; `TenantControllerTest` adds 5 SUSPEND / REACTIVATE / CLOSE (preserving cascade correlation_id) / skipped / failed / emit-failure cases

## Spec reference

cycles-protocol PR #74 (merged to main as d081a9a): documents the EVENTS contract on `bulkActionBudgets` and `bulkActionTenants`, bumps spec `info.version` `0.1.25.31` → `0.1.25.32`, regenerates merged artifact.