### PR TITLE
chore(compose): bump cycles images to latest (admin .38, server .17, events .10)

### DIFF
--- a/docker-compose.full-stack.prod.yml
+++ b/docker-compose.full-stack.prod.yml
@@ -13,7 +13,7 @@ services:
       retries: 5
 
   cycles-admin:
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.35
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.38
     restart: unless-stopped
     ports:
       - "7979:7979"
@@ -40,7 +40,7 @@ services:
         condition: service_healthy
 
   cycles-server:
-    image: ghcr.io/runcycles/cycles-server:0.1.25.8
+    image: ghcr.io/runcycles/cycles-server:0.1.25.17
     restart: unless-stopped
     ports:
       - "7878:7878"
@@ -60,7 +60,7 @@ services:
         condition: service_healthy
 
   cycles-events:
-    image: ghcr.io/runcycles/cycles-server-events:0.1.25.5
+    image: ghcr.io/runcycles/cycles-server-events:0.1.25.10
     restart: unless-stopped
     ports:
       - "7980:7980"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,7 +13,7 @@ services:
       retries: 5
 
   cycles-admin:
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.35
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.38
     restart: unless-stopped
     ports:
       - "7979:7979"


### PR DESCRIPTION
## Summary
- `cycles-server-admin`: `0.1.25.35` → `0.1.25.38` (prod + full-stack)
- `cycles-server`: `0.1.25.8` → `0.1.25.17` (full-stack)
- `cycles-server-events`: `0.1.25.5` → `0.1.25.10` (full-stack)

Aligns the standalone prod compose and the full-stack reference compose with the current published image tags.

## Test plan
- [x] v0.1.25.38 admin image built locally and verified healthy on port 7979
- [x] CI green on this branch
- [x] Smoke-test full-stack compose locally