### PR TITLE
chore(deps): bump redis.clients:jedis from 6.2.0 to 7.5.0

### DIFF
--- a/cycles-admin-service/pom.xml
+++ b/cycles-admin-service/pom.xml
@@ -33,7 +33,7 @@
             <dependency>
                 <groupId>redis.clients</groupId>
                 <artifactId>jedis</artifactId>
-                <version>6.2.0</version>
+                <version>7.5.0</version>
             </dependency>
             <dependency>
                 <groupId>org.springdoc</groupId>


### PR DESCRIPTION
## Summary

Final piece of the cross-repo Jedis 7 alignment. cycles-server (#136) and cycles-server-events (#46) both shipped 7.5.0 today; this PR brings cycles-server-admin in line.

Straight version bump in `cycles-admin-service/pom.xml`'s `<dependencyManagement>` — no source code changes. Jedis 7's API surface is binary-compatible with this repo's `JedisPool` / `Jedis` / `SetParams` / `ScanParams` / `JedisConnectionException` usage.

## Smoke test

Local `mvn -B verify --file cycles-admin-service/pom.xml`:

- **782 tests pass** (unit + integration + Testcontainers Redis)
- **JaCoCo coverage gate met** (95% line floor)
- **BUILD SUCCESS**

Integration tests run by default in this repo — no \`-Pintegration-tests\` profile activation needed.

## Cross-repo Jedis state after this merge

| Repo | Jedis |
|------|-------|
| cycles-server | 7.5.0 (#136) |
| cycles-server-events | 7.5.0 (#46) |
| **cycles-server-admin** | **6.2.0 → 7.5.0 (this PR)** |

All three server repos aligned on Jedis 7.5.0.

## Test plan

- [x] mvn -B verify passes locally with Jedis 7.5.0 + Testcontainers Redis
- [x] All 782 tests pass
- [x] JaCoCo 95% line coverage floor met
- [ ] CI green
- [ ] AUDIT.md / CHANGELOG.md update will land with next release-prep commit (consistent with this repo's dependabot bump pattern)