### PR TITLE
docs(readme): front-load search keywords in hook for GitHub discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 [![Coverage](https://img.shields.io/badge/coverage-95%25+-brightgreen)](https://github.com/runcycles/cycles-server-admin/actions)
 
-# Runcycles Admin Server
+# Cycles Admin Server — Multi-tenant management for AI agent governance
 
-Administrative API for the Complete Budget Governance System, aligned with [Cycles Protocol v0.1.25.33](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml).
+**Administrative API for managing tenants, budgets, API keys, and policies in a Cycles deployment.** Configures the AI agent budget and action enforcement that the [Cycles Server](https://github.com/runcycles/cycles-server) applies at runtime.
+
+Multi-tenant by default, with four integrated planes: tenant lifecycle and budget ledgers, API key authentication and permission enforcement, runtime reservation control, and event/webhook delivery for observability. Aligned with [Cycles Protocol v0.1.25.33](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml).
 
 ## Documentation
 


### PR DESCRIPTION
## What

Rewrites the H1 + opening paragraph of `README.md` so the GitHub search excerpt front-loads search-friendly phrases.

**Before** (line 5): `# Runcycles Admin Server`
**After**: `# Cycles Admin Server — Multi-tenant management for AI agent governance`

The single-line tagline becomes a 2-paragraph keyword-rich summary that names the four governance planes (tenant lifecycle, API key auth, runtime reservation control, event/webhook delivery). Cycles Protocol link is preserved, just relocated.

## Why

GitHub repo search ranks and excerpts on the top of the README. "Runcycles Admin Server" + "Complete Budget Governance System" doesn't match what a developer searching GitHub for "multi-tenant AI agent management API" or "agent governance admin" would type.

## Scope

- 1 file changed: `README.md`
- 3 lines edited (5, 7), 2 new lines added
- No removed examples, links, or sections below line 8

Part of an SEO/discoverability pass across the runcycles org. Sibling PRs: cycles-protocol#78, cycles-server#140.
