### PR TITLE
ops: tighten workflow token permissions (Scorecard PR B)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,14 +2,18 @@ name: Dependabot auto-merge
 
 on: pull_request
 
-permissions:
-  contents: write
-  pull-requests: write
+# Default to read-all at top level; the automerge job below escalates only the
+# narrow scopes it actually needs. Per OpenSSF Scorecard's Token-Permissions
+# criterion: avoid blanket write at the workflow level.
+permissions: read-all
 
 jobs:
   automerge:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]'
+    permissions:
+      contents: write          # required to enable auto-merge
+      pull-requests: write     # required to mark the PR as auto-merge
     steps:
       - name: Fetch Dependabot metadata
         id: meta

--- a/.github/workflows/nightly-audit-soak.yml
+++ b/.github/workflows/nightly-audit-soak.yml
@@ -40,6 +40,8 @@ on:
         required: false
         default: '500'
 
+permissions: read-all
+
 jobs:
   audit-soak:
     name: Sustained failure-flood stability

--- a/.github/workflows/nightly-property-tests.yml
+++ b/.github/workflows/nightly-property-tests.yml
@@ -27,6 +27,8 @@ on:
     - cron: '0 6 * * *'   # 06:00 UTC daily (runs before the soak workflow)
   workflow_dispatch: {}    # manual trigger
 
+permissions: read-all
+
 jobs:
   property-tests:
     name: Property-based audit-coverage invariants

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions: read-all
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Same pattern as [cycles-server#144](https://github.com/runcycles/cycles-server/pull/144). Adds top-level read-all to nightly-audit-soak, nightly-property-tests, release workflows; rewrites dependabot-auto-merge.yml. Addresses **Token-Permissions** in OpenSSF Scorecard.