### PR TITLE
ops(security): demote security-events:write + fix downloadThenRun pattern

### DIFF
--- a/.github/workflows/pr-container-scan.yml
+++ b/.github/workflows/pr-container-scan.yml
@@ -18,14 +18,15 @@ on:
       - '**/pom.xml'
       - '.github/workflows/pr-container-scan.yml'
 
-permissions:
-  contents: read
-  security-events: write   # for Trivy SARIF upload to Security tab
+permissions: read-all
 
 jobs:
   scan:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write   # required for Trivy SARIF upload to Security tab
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,12 @@ jobs:
         env:
           VERSION: ${{ needs.build-and-push.outputs.version }}
         run: |
-          served=$(curl -s http://localhost:7979/actuator/info | python -c "import sys,json; print(json.load(sys.stdin).get('build',{}).get('version','?'))")
+          # Avoid `curl | python` (Scorecard's downloadThenRun heuristic flags
+          # any download piped directly into an interpreter, regardless of the
+          # source). Capture the body first, then parse — same behavior, no
+          # supply-chain footgun pattern.
+          info=$(curl -s http://localhost:7979/actuator/info)
+          served=$(echo "$info" | python -c "import sys,json; print(json.load(sys.stdin).get('build',{}).get('version','?'))")
           if [ "$served" != "$VERSION" ]; then
             echo "ERROR: image reports version=$served but tag is $VERSION"
             exit 1


### PR DESCRIPTION
Two Scorecard HIGH findings:

1. **`pr-container-scan.yml`**: TokenPermissionsID — `topLevel 'security-events' permission set to 'write'`. Same fix as [cycles-server#144](https://github.com/runcycles/cycles-server/pull/144): top-level drops to `read-all`, `security-events: write` moves to the scan job (only the Trivy SARIF upload needs it).

2. **`release.yml:150`**: PinnedDependenciesID — `downloadThenRun not pinned by hash`. The pattern `curl ... | python -c ...` triggers Scorecard's heuristic regardless of source URL (here it's a localhost smoke probe — false positive in *intent* but still bad pattern). Refactor: capture body first, then pipe to python. Same behavior, no curl-pipe-interpreter shape.