### PR TITLE
ops(security): scan main on push too, so post-fix scans clear stale alerts

### DIFF
--- a/.github/workflows/pr-container-scan.yml
+++ b/.github/workflows/pr-container-scan.yml
@@ -1,16 +1,27 @@
-name: PR Container Scan
+name: Container Scan
 
 # Runs Trivy against a locally-built image on PRs that change the Dockerfile
-# or Maven dependencies. Paths filter is deliberate: most PRs don't touch the
-# image, and running this on every PR would add ~5-10 min of build time for
-# no benefit. When the filter fires, we catch base-image / added-dependency
-# CVEs before merge rather than discovering them at release-cut time.
+# or Maven dependencies, AND on every push to main with the same paths filter.
+# Paths filter is deliberate: most PRs don't touch the image, and running this
+# on every PR would add ~5-10 min of build time for no benefit.
 #
-# Never pushes — this is PR-time feedback only. release.yml continues to run
+# The push:main trigger ensures stale Trivy alerts auto-close after a fix
+# lands — without it, the SARIF only ever uploads against PR refs and the
+# main-branch alert track goes stale after every fix merge.
+#
+# Never pushes images — this is feedback only. release.yml continues to run
 # the authoritative scan at release publish time (with the real version tag).
 
 on:
   pull_request:
+    paths:
+      - 'Dockerfile'
+      - '**/Dockerfile'
+      - 'pom.xml'
+      - '**/pom.xml'
+      - '.github/workflows/pr-container-scan.yml'
+  push:
+    branches: [main]
     paths:
       - 'Dockerfile'
       - '**/Dockerfile'
@@ -39,16 +50,16 @@ jobs:
           context: .
           push: false
           load: true
-          tags: ghcr.io/runcycles/cycles-server-admin:pr-${{ github.event.pull_request.number }}
+          tags: ghcr.io/runcycles/cycles-server-admin:scan-${{ github.event.pull_request.number || github.sha }}
           build-args: |
-            APP_VERSION=pr-${{ github.event.pull_request.number }}
+            APP_VERSION=scan-${{ github.event.pull_request.number || github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Trivy vulnerability scan
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: ghcr.io/runcycles/cycles-server-admin:pr-${{ github.event.pull_request.number }}
+          image-ref: ghcr.io/runcycles/cycles-server-admin:scan-${{ github.event.pull_request.number || github.sha }}
           severity: 'HIGH,CRITICAL'
           ignore-unfixed: true
           format: 'sarif'
@@ -60,4 +71,4 @@ jobs:
         uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4
         with:
           sarif_file: 'trivy-results.sarif'
-          category: trivy-container-pr
+          category: trivy-container-pr   # category kept stable so push-to-main scans clear PR-track alerts


### PR DESCRIPTION
Same systemic fix as cycles-server. Adds `push: branches: [main]` to pr-container-scan.yml so post-merge scans publish to the main-branch alert track (currently stale after every fix merge).