### PR TITLE
fix(ci): no-cache + pull on container scan

### DIFF
--- a/.github/workflows/pr-container-scan.yml
+++ b/.github/workflows/pr-container-scan.yml
@@ -53,8 +53,13 @@ jobs:
           tags: ghcr.io/runcycles/cycles-server-admin:scan-${{ github.event.pull_request.number || github.sha }}
           build-args: |
             APP_VERSION=scan-${{ github.event.pull_request.number || github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # no-cache + pull are critical for security scans: cached layers
+          # (especially `apk upgrade`) keep reporting old packages even
+          # after a base-image bump. Witnessed in cycles-dashboard PR #157
+          # / #158 — FROM bump didn't take effect because cached layer
+          # served months-old apk state. Always build fresh for scans.
+          no-cache: true
+          pull: true
 
       - name: Trivy vulnerability scan
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0


### PR DESCRIPTION
Same fix as [cycles-dashboard#158](https://github.com/runcycles/cycles-dashboard/pull/158). Cached `apk upgrade` layers make Trivy scan stale package state. `no-cache: true` + `pull: true` ensures every scan runs against what would actually be built today.