### PR TITLE
chore: org-wide hygiene bundle (#60 + #62 + #63)

### DIFF
--- a/.claude/session-start-global-deny.sh
+++ b/.claude/session-start-global-deny.sh
@@ -12,13 +12,18 @@ set -e
 
 GLOBAL_SETTINGS="$HOME/.claude/settings.json"
 
-if ! [ -f "$GLOBAL_SETTINGS" ] || ! grep -q "mcp__github__push_files" "$GLOBAL_SETTINGS" 2>/dev/null; then
-  mkdir -p "$HOME/.claude"
+# The previous version of this block only ran the merge when push_files was
+# missing, which silently left the policy incomplete if push_files happened to
+# exist while one of the other two rules had been removed. The python3 merge
+# is idempotent (skips rules already present), so we now always run it on
+# session start to guarantee all three deny rules are in place.
+# Tracked org-wide at runcycles/.github#63.
+mkdir -p "$HOME/.claude"
 
-  if [ -f "$GLOBAL_SETTINGS" ]; then
-    TMP_SETTINGS=$(mktemp)
-    if command -v python3 &>/dev/null; then
-      python3 -c "
+if [ -f "$GLOBAL_SETTINGS" ]; then
+  TMP_SETTINGS=$(mktemp)
+  if command -v python3 &>/dev/null; then
+    python3 -c "
 import json
 with open('$GLOBAL_SETTINGS') as f:
     settings = json.load(f)
@@ -37,11 +42,11 @@ with open('$TMP_SETTINGS', 'w') as f:
     json.dump(settings, f, indent=2)
     f.write('\n')
 " && mv "$TMP_SETTINGS" "$GLOBAL_SETTINGS"
-    else
-      rm -f "$TMP_SETTINGS"
-    fi
   else
-    cat > "$GLOBAL_SETTINGS" << 'EOF'
+    rm -f "$TMP_SETTINGS"
+  fi
+else
+  cat > "$GLOBAL_SETTINGS" << 'EOF'
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
@@ -53,10 +58,19 @@ with open('$TMP_SETTINGS', 'w') as f:
   }
 }
 EOF
-  fi
 fi
 
 # --- Part 2: Fix git remote URLs to use local proxy ---
+# NOTE: This block intentionally rewrites the `origin` remote on EVERY sibling
+# repo under /home/user/* with a github.com remote, not just this one. Claude
+# Code remote sessions clone multiple repos and all need the local git proxy.
+# To opt out (e.g., when running outside that environment, or when you want
+# unrelated checkouts left alone), set CYCLES_CLAUDE_SKIP_REMOTE_REWRITE=1.
+# Tracked org-wide at runcycles/.github#63.
+if [ -n "$CYCLES_CLAUDE_SKIP_REMOTE_REWRITE" ]; then
+  exit 0
+fi
+
 # Some sessions clone repos via github.com directly, which lacks push credentials.
 # If the local git proxy is running, rewrite remote URLs to use it.
 

--- a/.claude/session-start-maven-proxy.sh
+++ b/.claude/session-start-maven-proxy.sh
@@ -22,9 +22,16 @@ if [ -z "$PROXY_USER" ] || [ -z "$PROXY_PASS" ]; then
   exit 0
 fi
 
-# Create Maven settings.xml with proxy config
+# Create Maven settings.xml with proxy config — defensively skip if a user-
+# managed settings.xml already exists, so we don't wipe pre-existing mirrors,
+# credentials, or alternate proxy configs. Tracked org-wide at runcycles/.github#62.
 mkdir -p ~/.m2
-cat > ~/.m2/settings.xml << XMLEOF
+if [ -f ~/.m2/settings.xml ]; then
+  echo "[cycles] ~/.m2/settings.xml already exists; not overwriting." >&2
+  echo "[cycles] If Maven proxy access fails, merge the <proxies> block from" >&2
+  echo "[cycles] .claude/session-start-maven-proxy.sh into your existing settings.xml." >&2
+else
+  cat > ~/.m2/settings.xml << XMLEOF
 <settings>
   <proxies>
     <proxy>
@@ -48,6 +55,7 @@ cat > ~/.m2/settings.xml << XMLEOF
   </proxies>
 </settings>
 XMLEOF
+fi
 
 # Install mvn-proxy wrapper that fixes JAVA_TOOL_OPTIONS interference
 MVN_BIN=$(which mvn 2>/dev/null || echo "/opt/maven/bin/mvn")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   unit:
     name: Unit & Contract
-    uses: runcycles/.github/.github/workflows/ci-java.yml@main
+    uses: runcycles/.github/.github/workflows/ci-java.yml@v1
     with:
       pom-file: cycles-admin-service/pom.xml
       maven-args: "-Dtest=!*IntegrationTest -Dsurefire.failIfNoSpecifiedTests=false"


### PR DESCRIPTION
Propagation from [cycles-spring-boot-starter#64](https://github.com/runcycles/cycles-spring-boot-starter/pull/64).

- [#60](https://github.com/runcycles/.github/issues/60) ci-java.yml @main → @v1
- [#62](https://github.com/runcycles/.github/issues/62) Maven proxy defensive check
- [#63](https://github.com/runcycles/.github/issues/63) Global deny hardening + opt-out

3 files, +36/-14. No Java touched.