### PR TITLE
ci(automerge): AUTOMERGE_PAT with GITHUB_TOKEN fallback

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -23,4 +23,8 @@ jobs:
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # AUTOMERGE_PAT (repo+workflow scope) lets auto-merge work on PRs that
+          # touch .github/workflows/** (e.g. github-actions bumps); the default
+          # GITHUB_TOKEN is forbidden by GitHub from doing so. Falls back to
+          # GITHUB_TOKEN when the secret is absent (unchanged behavior).
+          GH_TOKEN: ${{ secrets.AUTOMERGE_PAT || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Wire the Dependabot auto-merge workflow to use an optional `AUTOMERGE_PAT`
secret, falling back to `GITHUB_TOKEN`:

```yaml
GH_TOKEN: ${{ secrets.AUTOMERGE_PAT || secrets.GITHUB_TOKEN }}
```

The default `GITHUB_TOKEN` is forbidden by GitHub from enabling auto-merge on
PRs that modify `.github/workflows/**`, so `github/codeql-action` / `actions/*`
Dependabot bumps stall and need a manual/admin merge. A PAT (or App token) with
`repo` + `workflow` scope stored as `AUTOMERGE_PAT` lets those auto-merge. The
`||` fallback keeps current behavior until the secret exists, so this is safe
on its own.
