### PR TITLE
docs: changelog + audit for v0.1.25.42 release boundary

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -65,6 +65,22 @@ BOM manages 10.1.55+.
   manages 3.17.0).
 - Code change of any kind. This is a deps-only release.
 
+**Release-boundary addendum (2026-06-24).** The "Not in scope" notes above
+describe the original Tomcat-only PR #179 (2026-05-25). By the time v0.1.25.42
+was actually cut, the same unreleased `revision` had also absorbed two further
+dependency bumps that landed on `main` after v0.1.25.41; both are deps-only
+with no code or wire change:
+- **Jedis 6.2.0 → 7.5.0** (major, #154, 2026-04-28). Redis-client major
+  bump; all call sites use stable APIs and CI's full 782+-test suite passes
+  on 7.5.0.
+- **Spring Boot 3.5.14 → 3.5.15** (patch, #186, 2026-06-14). Supersedes the
+  "SB 3.5.14 stays" note above. The `commons-lang3 3.18.0` override is still
+  required — SB 3.5.15's BOM continues to manage 3.17.0 (CVE-2025-48924
+  unfixed there) — and the `tomcat 10.1.55` override is likewise retained
+  (revisit whether SB 3.5.15's BOM makes it redundant on the next bump).
+- **Container log rotation** (#189, 2026-06-23): `json-file` driver with
+  `max-size: 10m` / `max-file: 5` across all four compose files. Ops-only.
+
 
 
 ### 2026-04-23 — v0.1.25.39: Webhook lifecycle events (spec v0.1.25.33)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,40 @@ changes to request/response bodies or Lua-script semantics would require a
 minor bump. Additive fields (new optional response fields, new enum values,
 new optional request fields) are **not** considered breaking.
 
+## [0.1.25.42] — 2026-06-24
+
+Security and dependency-hygiene rollup accumulated since v0.1.25.41. No code
+or wire-format changes — pom, CI, and ops only. The headline is the Apache
+Tomcat CVE patch; the same release boundary also rolls up a Jedis major bump,
+a Spring Boot patch, and supply-chain/CI hardening.
+
+### Changed
+
+- **Tomcat 10.1.54 → 10.1.55** (security). Re-introduced the
+  `<tomcat.version>10.1.55</tomcat.version>` override to close 3 CRITICAL +
+  3 HIGH + 1 LOW `tomcat-embed-core` CVEs (CVE-2026-43515 / -43512 / -41293
+  CRITICAL; -43513 / -42498 / -41284 HIGH; -43514 LOW) that Trivy flagged
+  against Spring Boot 3.5.14's managed 10.1.54. Same override pattern as the
+  retained `commons-lang3` pin; remove once Spring Boot's BOM manages
+  10.1.55+. Full CVE breakdown in [`AUDIT.md`](AUDIT.md).
+- **Jedis 6.2.0 → 7.5.0** (major). Redis-client major bump aligning the
+  admin service with the rest of the fleet. All call sites use stable APIs;
+  CI's full suite (782+ tests) passes on 7.5.0.
+- **Spring Boot 3.5.14 → 3.5.15** (patch). Upstream patch release. The
+  `commons-lang3 3.18.0` override is retained — SB 3.5.15's BOM still manages
+  3.17.0, where CVE-2025-48924 is unfixed.
+- **Container log rotation.** All four `docker-compose*.yml` files gain a
+  shared `json-file` logging anchor (`max-size: 10m`, `max-file: 5`), capping
+  each container at 50 MB to prevent unbounded `*-json.log` growth on
+  long-running deployments.
+
+### Security / CI
+
+- Supply-chain hardening: OpenSSF Scorecard workflow, all third-party GitHub
+  Action SHAs pinned, workflow token permissions tightened, Alpine `gnutls`
+  CVE-2026-33845 patched in the image, and a two-phase Trivy-gated release
+  build (scan before push).
+
 ## [0.1.25.41] — 2026-04-26
 
 Dependency hygiene aligning all three Cycles services (events / server /


### PR DESCRIPTION
## Summary

The `revision` was bumped to `0.1.25.42` back in PR #179 (Apache Tomcat
`10.1.55` CVE pin) but the **release was never cut** — latest released tag is
`v0.1.25.41`. Since then the same unreleased `.42` revision has absorbed
additional dependency/ops changes on `main` that the CHANGELOG and AUDIT `.42`
note never captured.

This PR makes the docs match what will actually ship, ahead of tagging and
publishing `v0.1.25.42`.

## What `.42` actually bundles (delta since v0.1.25.41)

All deps / CI / ops — **no code or wire-format change**:

- **Tomcat `10.1.54 → 10.1.55`** — CVE pin (3 CRITICAL + 3 HIGH + 1 LOW), #179
- **Jedis `6.2.0 → 7.5.0`** — Redis-client major bump, #154
- **Spring Boot `3.5.14 → 3.5.15`** — patch, #186
- **json-file log rotation** across all four compose files, #189
- Supply-chain / CI hardening: OpenSSF Scorecard, pinned action SHAs,
  tightened token perms, Alpine gnutls CVE patch, Trivy-gated release build

## Changes in this PR

- `CHANGELOG.md`: new `[0.1.25.42]` downstream-facing entry
- `AUDIT.md`: release-boundary addendum on the existing `.42` note, correcting
  the now-stale "SB 3.5.14 stays" / "deps-only Tomcat" scope lines

## After merge

Tag `v0.1.25.42` on `main` and publish the GitHub Release, which triggers
`release.yml` (build → Trivy HIGH/CRITICAL gate → push `:0.1.25.42` + `:latest`
→ smoke-test the published image).
