### PR TITLE
fix(ci): scope Trivy gate to HIGH,CRITICAL to unblock v0.1.25.42 image

### DIFF
--- a/.github/workflows/pr-container-scan.yml
+++ b/.github/workflows/pr-container-scan.yml
@@ -70,6 +70,13 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           exit-code: '1'
+          # In `format: sarif` mode the action builds an all-severities report
+          # by default, so `exit-code: 1` trips on ANY fixable finding and the
+          # `severity` filter above is ignored for gating. Limit the SARIF to
+          # the declared severities so the gate (and the Security-tab report)
+          # honor HIGH,CRITICAL only — a fixable MEDIUM should not block a PR.
+          # See AUDIT.md (v0.1.25.42 jackson-databind CVE-2026-54515).
+          limit-severities-for-sarif: true
 
       - name: Upload Trivy SARIF to Security tab
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,13 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           exit-code: '1'
+          # In `format: sarif` mode the action builds an all-severities report
+          # by default, so `exit-code: 1` trips on ANY fixable finding and the
+          # `severity` filter above is ignored for gating. Limit the SARIF to
+          # the declared severities so the gate (and the Security-tab report)
+          # honor HIGH,CRITICAL only — a fixable MEDIUM should not block the
+          # release. See AUDIT.md (v0.1.25.42 jackson-databind CVE-2026-54515).
+          limit-severities-for-sarif: true
 
       - name: Upload Trivy SARIF to Security tab
         if: always()

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -80,6 +80,16 @@ with no code or wire change:
   (revisit whether SB 3.5.15's BOM makes it redundant on the next bump).
 - **Container log rotation** (#189, 2026-06-23): `json-file` driver with
   `max-size: 10m` / `max-file: 5` across all four compose files. Ops-only.
+- **jackson-databind 2.21.4 → 2.21.5** (CVE-2026-54515). Surfaced when the
+  first v0.1.25.42 release build's Trivy gate flagged the only fixable
+  finding in the image. Although NVD rates it MEDIUM (CVSS 5.3), the
+  release pipeline runs `aquasecurity/trivy-action` in `format: sarif`
+  mode, where `exit-code: 1` trips on any finding regardless of the
+  `severity: HIGH,CRITICAL` input — so the effective gate is "no fixable
+  vulns." Pinned via `<jackson-bom.version>2.21.5</jackson-bom.version>`
+  (drives all `com.fasterxml.jackson.*` modules); v0.1.25.42 was re-cut in
+  place on top of this fix since no image had been published. Deps-only,
+  no code or wire change.
 
 
 

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -80,16 +80,31 @@ with no code or wire change:
   (revisit whether SB 3.5.15's BOM makes it redundant on the next bump).
 - **Container log rotation** (#189, 2026-06-23): `json-file` driver with
   `max-size: 10m` / `max-file: 5` across all four compose files. Ops-only.
-- **jackson-databind 2.21.4 → 2.21.5** (CVE-2026-54515). Surfaced when the
-  first v0.1.25.42 release build's Trivy gate flagged the only fixable
-  finding in the image. Although NVD rates it MEDIUM (CVSS 5.3), the
-  release pipeline runs `aquasecurity/trivy-action` in `format: sarif`
-  mode, where `exit-code: 1` trips on any finding regardless of the
-  `severity: HIGH,CRITICAL` input — so the effective gate is "no fixable
-  vulns." Pinned via `<jackson-bom.version>2.21.5</jackson-bom.version>`
-  (drives all `com.fasterxml.jackson.*` modules); v0.1.25.42 was re-cut in
-  place on top of this fix since no image had been published. Deps-only,
-  no code or wire change.
+- **Trivy gate scoping for jackson-databind CVE-2026-54515.** The first
+  v0.1.25.42 release build failed its Trivy gate on the only fixable finding
+  in the image: `jackson-databind` 2.21.4 (CVE-2026-54515), pulled in
+  transitively via the Spring web stack and managed by SB 3.5.15's BOM.
+
+  Two facts shaped the fix:
+  1. **No fix is publishable yet.** The advisory lists fixed versions 3.1.4
+     / 2.18.9 / 2.21.5. For the SB 2.21 line the only forward fix is 2.21.5,
+     and jackson 2.x ships `jackson-bom` + `jackson-core` + `jackson-databind`
+     together — `jackson-bom:2.21.5` is absent from Maven Central, so 2.21.5
+     is not yet released (Trivy's "Fixed Version" is ahead of the artifact).
+     2.18.9 is a downgrade; 3.1.4 is jackson 3.x, incompatible with SB 3.5.x.
+     A `<jackson-bom.version>2.21.5</jackson-bom.version>` override was tried
+     and fails to resolve (`Non-resolvable import POM`).
+  2. **The CVE is MEDIUM (CVSS 5.3)** and the gate is declared for
+     `severity: HIGH,CRITICAL`. The block was an `aquasecurity/trivy-action`
+     quirk: in `format: sarif` mode it builds an all-severities report and
+     `exit-code: 1` trips on any finding, ignoring the `severity` filter.
+
+  **Fix.** Set `limit-severities-for-sarif: true` on the trivy-action in both
+  `release.yml` and `pr-container-scan.yml` so the SARIF — and therefore the
+  gate — honors `HIGH,CRITICAL`. A fixable MEDIUM no longer blocks publish;
+  HIGH/CRITICAL still fail. CVE-2026-54515 is tracked in the pom (bump jackson
+  once 2.21.5 ships). v0.1.25.42 was re-cut in place on this fix since no
+  image had been published. Workflow/config only — no code or wire change.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ a Spring Boot patch, and supply-chain/CI hardening.
 - **Spring Boot 3.5.14 → 3.5.15** (patch). Upstream patch release. The
   `commons-lang3 3.18.0` override is retained — SB 3.5.15's BOM still manages
   3.17.0, where CVE-2025-48924 is unfixed.
+- **jackson-databind 2.21.4 → 2.21.5** (security). `<jackson-bom.version>`
+  override picking up the CVE-2026-54515 fix; jackson enters the image
+  transitively via the Spring web stack. Rated MEDIUM, but the release
+  pipeline's Trivy gate fails on any fixable finding. Retire once SB's BOM
+  manages 2.21.5+.
 - **Container log rotation.** All four `docker-compose*.yml` files gain a
   shared `json-file` logging anchor (`max-size: 10m`, `max-file: 5`), capping
   each container at 50 MB to prevent unbounded `*-json.log` growth on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,11 +36,6 @@ a Spring Boot patch, and supply-chain/CI hardening.
 - **Spring Boot 3.5.14 → 3.5.15** (patch). Upstream patch release. The
   `commons-lang3 3.18.0` override is retained — SB 3.5.15's BOM still manages
   3.17.0, where CVE-2025-48924 is unfixed.
-- **jackson-databind 2.21.4 → 2.21.5** (security). `<jackson-bom.version>`
-  override picking up the CVE-2026-54515 fix; jackson enters the image
-  transitively via the Spring web stack. Rated MEDIUM, but the release
-  pipeline's Trivy gate fails on any fixable finding. Retire once SB's BOM
-  manages 2.21.5+.
 - **Container log rotation.** All four `docker-compose*.yml` files gain a
   shared `json-file` logging anchor (`max-size: 10m`, `max-file: 5`), capping
   each container at 50 MB to prevent unbounded `*-json.log` growth on
@@ -52,6 +47,12 @@ a Spring Boot patch, and supply-chain/CI hardening.
   Action SHAs pinned, workflow token permissions tightened, Alpine `gnutls`
   CVE-2026-33845 patched in the image, and a two-phase Trivy-gated release
   build (scan before push).
+- Trivy container gates (release + PR) now set `limit-severities-for-sarif:
+  true` so `exit-code` honors the declared `HIGH,CRITICAL` severity. In
+  `format: sarif` mode the action otherwise gates on any fixable finding of
+  any severity. A known fixable MEDIUM (`jackson-databind` CVE-2026-54515,
+  fix awaiting the unreleased jackson 2.21.5) is reported but no longer
+  blocks publish; HIGH/CRITICAL still fail the gate.
 
 ## [0.1.25.41] — 2026-04-26
 

--- a/cycles-admin-service/pom.xml
+++ b/cycles-admin-service/pom.xml
@@ -39,6 +39,14 @@
                CVE-2026-43514 LOW      — Observable timing in AJP secret compare
              Remove once Spring Boot ships with 10.1.55+ as its managed version. -->
         <tomcat.version>10.1.55</tomcat.version>
+        <!-- Override Spring Boot 3.5.15's managed jackson-databind 2.21.4 to
+             pick up the fix in 2.21.5 for CVE-2026-54515 (Trivy-flagged;
+             jackson enters the image transitively via the Spring web stack).
+             Rated MEDIUM, but the release pipeline's SARIF-mode Trivy gate
+             fails on any fixable finding, so this blocks image publish.
+             jackson-bom.version drives all com.fasterxml.jackson.* modules.
+             Remove once Spring Boot ships with 2.21.5+ as its managed version. -->
+        <jackson-bom.version>2.21.5</jackson-bom.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/cycles-admin-service/pom.xml
+++ b/cycles-admin-service/pom.xml
@@ -39,14 +39,12 @@
                CVE-2026-43514 LOW      — Observable timing in AJP secret compare
              Remove once Spring Boot ships with 10.1.55+ as its managed version. -->
         <tomcat.version>10.1.55</tomcat.version>
-        <!-- Override Spring Boot 3.5.15's managed jackson-databind 2.21.4 to
-             pick up the fix in 2.21.5 for CVE-2026-54515 (Trivy-flagged;
-             jackson enters the image transitively via the Spring web stack).
-             Rated MEDIUM, but the release pipeline's SARIF-mode Trivy gate
-             fails on any fixable finding, so this blocks image publish.
-             jackson-bom.version drives all com.fasterxml.jackson.* modules.
-             Remove once Spring Boot ships with 2.21.5+ as its managed version. -->
-        <jackson-bom.version>2.21.5</jackson-bom.version>
+        <!-- NOTE: jackson-databind 2.21.4 carries CVE-2026-54515 (MEDIUM,
+             CVE fix lands in jackson 2.21.5, not yet published to Central as
+             of this release). No override is possible until 2.21.5 ships;
+             the release/PR Trivy gates are scoped to HIGH,CRITICAL so a
+             fixable MEDIUM does not block publish. Bump jackson here once
+             Spring Boot's BOM manages 2.21.5+. -->
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
## Summary

The first `v0.1.25.42` release build failed its Trivy gate on the **only**
fixable finding in the image: `jackson-databind` 2.21.4 (**CVE-2026-54515**),
transitive via the Spring web stack and managed by Spring Boot 3.5.15's BOM.

### Why not just bump jackson?

No fix is publishable yet:
- Jackson 2.x ships `jackson-bom` + `jackson-core` + `jackson-databind`
  together, and **`jackson-bom:2.21.5` is absent from Maven Central** —
  Trivy's "Fixed Version: 2.21.5" is ahead of the actual release. A
  `<jackson-bom.version>2.21.5</jackson-bom.version>` override fails with
  `Non-resolvable import POM` (this is what the first push of this PR hit).
- `2.18.9` is a downgrade from 2.21.4; `3.1.4` is jackson 3.x, incompatible
  with Spring Boot 3.5.x.

### Why it blocked at all (it's a MEDIUM)

CVE-2026-54515 is **MEDIUM** (CVSS 5.3) and the gate is declared
`severity: HIGH,CRITICAL`. The block is an `aquasecurity/trivy-action` quirk:
in `format: sarif` mode it builds an **all-severities** report, so
`exit-code: 1` trips on any fixable finding and the `severity` filter is
ignored for gating.

## Fix

Set **`limit-severities-for-sarif: true`** on the trivy-action in both
`release.yml` and `pr-container-scan.yml` so the SARIF — and therefore the
gate — honors `HIGH,CRITICAL`. A fixable MEDIUM no longer blocks publish;
HIGH/CRITICAL still fail. CVE-2026-54515 is tracked in the pom to bump jackson
once 2.21.5 ships.

Workflow/config only — **no code or wire change.** `revision` stays
`0.1.25.42`; the tag + release are re-cut in place (no image was ever
published). CHANGELOG + AUDIT updated.

## Note

This also fixes this PR's own `scan` check, which failed on the same MEDIUM
before the gate was scoped.
