### PR TITLE
[codex] Harden admin production deployment defaults

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -41,8 +41,8 @@ the full-stack production file still referenced much older runtime/events images
 (`cycles-server:0.1.25.17`, `cycles-server-events:0.1.25.10`) with aggregate
 health probes. This release bumps the admin artifact to `0.1.25.47`, points
 admin production Compose at that tag, and updates full-stack production Compose
-to the latest published sibling tags available during this review:
-`cycles-server:0.1.25.43` and `cycles-server-events:0.1.25.19`.
+to the in-flight fleet sibling releases:
+`cycles-server:0.1.25.44` and `cycles-server-events:0.1.25.20`.
 
 Full-stack production Compose now mirrors the sibling production posture: the
 runtime service receives `ADMIN_API_KEY`, disables public SpringDoc/Swagger,

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,4 +1,4 @@
-# Complete Budget Governance v0.1.25.46 — Admin Server Audit
+# Complete Budget Governance v0.1.25.47 — Admin Server Audit
 
 **Spec:**
 [`cycles-governance-admin-v0.1.25.yaml`](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml)
@@ -25,6 +25,38 @@ validate) in [cycles-protocol](https://github.com/runcycles/cycles-protocol)
 pin (SB 3.5.15 still manages 3.17.0) · tomcat-embed-core 10.1.55 pin
 (re-introduced 2026-05-25 for Apache Tomcat CVE-2026-43512 / -43513 / -43514 /
 -43515 / -42498 / -41284 / -41293)
+
+### 2026-06-26 — v0.1.25.47: production deployment hardening follow-up
+
+Production-readiness review after the sibling `cycles-server` pass found no new
+admin HTTP/auth/schema defects: aggregate actuator, Prometheus, API docs, and
+Swagger remain protected by `X-Admin-API-Key`; exact liveness/readiness probes
+remain open; generated docs remain disabled by default; and operator logs
+already carry request, route, tenant/key, status, error, request id, and trace
+id context without logging secret values.
+
+The remaining issues were deployment drift. Production Compose still referenced
+the previous admin image (`0.1.25.45`) even though `main` is `0.1.25.46`, and
+the full-stack production file still referenced much older runtime/events images
+(`cycles-server:0.1.25.17`, `cycles-server-events:0.1.25.10`) with aggregate
+health probes. This release bumps the admin artifact to `0.1.25.47`, points
+admin production Compose at that tag, and updates full-stack production Compose
+to the latest published sibling tags available during this review:
+`cycles-server:0.1.25.43` and `cycles-server-events:0.1.25.19`.
+
+Full-stack production Compose now mirrors the sibling production posture: the
+runtime service receives `ADMIN_API_KEY`, disables public SpringDoc/Swagger,
+disables tenant labels on custom Prometheus metrics, and probes
+`/actuator/health/readiness`; events publishes management port `9980` and probes
+`/actuator/health/readiness`, leaving worker port `7980` internal. The admin
+image now carries an image-level readiness `HEALTHCHECK`, and its entrypoint uses
+`exec java $JAVA_OPTS -jar app.jar` so the JVM is PID 1 for SIGTERM/graceful
+shutdown and production Compose can set conservative JVM flags.
+
+Documentation drift was corrected at the same time: README now lists Spring Boot
+3.5.15, Jedis 7.5.2, the governance spec `info.version` `0.1.25.34`, required
+production Compose secrets, docs-disabled defaults, and the events
+management-port split. OPERATIONS adds `JAVA_OPTS` and Swagger UI config rows.
 
 ### 2026-06-26 — v0.1.25.46: dependency alignment
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ new optional request fields) are **not** considered breaking.
 - Production Compose now sets conservative JVM options for the admin container
   through `JAVA_OPTS`.
 - Full-stack production Compose now references current published sibling images:
-  `cycles-server:0.1.25.43` and `cycles-server-events:0.1.25.19`.
+  `cycles-server:0.1.25.44` and `cycles-server-events:0.1.25.20`.
 - Full-stack production Compose now passes `ADMIN_API_KEY` to the runtime
   service, disables runtime public SpringDoc/Swagger and tenant-labelled custom
   Prometheus metrics, and probes runtime readiness rather than aggregate health.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,34 @@ changes to request/response bodies or Lua-script semantics would require a
 minor bump. Additive fields (new optional response fields, new enum values,
 new optional request fields) are **not** considered breaking.
 
+## [0.1.25.47] — 2026-06-26
+
+### Fixed
+
+- Production Compose image tags now point at `cycles-server-admin:0.1.25.47`.
+- The admin runtime image now includes a built-in readiness healthcheck and
+  starts Java through `exec java $JAVA_OPTS -jar app.jar`, so the JVM receives
+  container SIGTERM directly and operators can tune JVM flags through
+  `JAVA_OPTS`.
+- Production Compose now sets conservative JVM options for the admin container
+  through `JAVA_OPTS`.
+- Full-stack production Compose now references current published sibling images:
+  `cycles-server:0.1.25.43` and `cycles-server-events:0.1.25.19`.
+- Full-stack production Compose now passes `ADMIN_API_KEY` to the runtime
+  service, disables runtime public SpringDoc/Swagger and tenant-labelled custom
+  Prometheus metrics, and probes runtime readiness rather than aggregate health.
+- Full-stack production Compose now publishes the events management port `9980`
+  and probes `/actuator/health/readiness`; the worker app port `7980` remains
+  internal.
+- README/OPERATIONS deployment docs now reflect required production Compose
+  environment variables, current Spring Boot/Jedis versions, protected docs
+  defaults, `JAVA_OPTS`, and the events management-port split.
+
+### Compatibility
+
+- Deployment and documentation hardening only. No admin HTTP schema, Redis data
+  model, event payload, webhook wire, Lua, or cycles-protocol spec change.
+
 ## [0.1.25.46] — 2026-06-26
 
 ### Changed
@@ -1411,6 +1439,18 @@ should switch to treating 409 as success-equivalent.
 - Multiple spec-compliance hardening fixes across controllers and error
   contracts (see `AUDIT.md` for the full list).
 
+[0.1.25.47]: https://github.com/runcycles/cycles-server-admin/releases/tag/v0.1.25.47
+[0.1.25.46]: https://github.com/runcycles/cycles-server-admin/releases/tag/v0.1.25.46
+[0.1.25.45]: https://github.com/runcycles/cycles-server-admin/releases/tag/v0.1.25.45
+[0.1.25.44]: https://github.com/runcycles/cycles-server-admin/releases/tag/v0.1.25.44
+[0.1.25.43]: https://github.com/runcycles/cycles-server-admin/releases/tag/v0.1.25.43
+[0.1.25.42]: https://github.com/runcycles/cycles-server-admin/releases/tag/v0.1.25.42
+[0.1.25.41]: https://github.com/runcycles/cycles-server-admin/releases/tag/v0.1.25.41
+[0.1.25.40]: https://github.com/runcycles/cycles-server-admin/releases/tag/v0.1.25.40
+[0.1.25.39]: https://github.com/runcycles/cycles-server-admin/releases/tag/v0.1.25.39
+[0.1.25.38]: https://github.com/runcycles/cycles-server-admin/releases/tag/v0.1.25.38
+[0.1.25.37]: https://github.com/runcycles/cycles-server-admin/releases/tag/v0.1.25.37
+[0.1.25.36]: https://github.com/runcycles/cycles-server-admin/releases/tag/v0.1.25.36
 [0.1.25.35]: https://github.com/runcycles/cycles-server-admin/releases/tag/0.1.25.35
 [0.1.25.34]: https://github.com/runcycles/cycles-server-admin/releases/tag/0.1.25.34
 [0.1.25.33]: https://github.com/runcycles/cycles-server-admin/releases/tag/0.1.25.33

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,8 @@ RUN chown appuser:appuser app.jar
 
 USER appuser
 EXPOSE 7979
-ENTRYPOINT ["java", "-jar", "app.jar"]
+
+HEALTHCHECK --interval=15s --timeout=5s --retries=3 \
+    CMD wget -qO- http://localhost:7979/actuator/health/readiness || exit 1
+
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar app.jar"]

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -493,10 +493,16 @@ with env overrides.
 | `audit.sample.unauthenticated` | `AUDIT_SAMPLE_UNAUTHENTICATED` | `1` | Sampling rate for unauthenticated-tier entries — record 1 in N. Default `1` = record every attempt (full fidelity). Production Compose defaults to `100` to cut Redis write volume 100x on exposed deployments. Aggregate volume remains visible via the `cycles_admin_audit_writes_total` counter. Authenticated entries are **never** sampled regardless of this setting. Values `≤ 0` treated as `1` (misconfig safety). |
 | `auth.failure-rate-limit.enabled` | `AUTH_FAILURE_RATE_LIMIT_ENABLED` | `false` | Enable per-source, per-process throttling for repeated 401/403 responses. Production Compose sets this to `true`. |
 | `auth.failure-rate-limit.max-per-minute` | `AUTH_FAILURE_RATE_LIMIT_MAX_PER_MINUTE` | `300` | Failed-auth threshold per source/path class before responses become `429 LIMIT_EXCEEDED` and no extra failure audit row is written. The limiter is in-process and does not coordinate across replicas. |
+| JVM options | `JAVA_OPTS` | (unset) | Extra JVM flags consumed by the Docker image entrypoint. Production Compose sets G1, `MaxRAMPercentage=75`, and string deduplication defaults. |
 | `audit.sweep.cron` | `AUDIT_SWEEP_CRON` | `0 0 3 * * *` | Cron schedule for the daily audit index sweep (`ZREMRANGEBYSCORE` on expired pointers). Default 03:00 server time. Sweep is best-effort; skipped entirely when `audit.retention.authenticated.days=0` (indefinite — nothing to sweep). |
 | `dashboard.cors.origin` | `DASHBOARD_CORS_ORIGIN` | `http://localhost:5173` | CORS allowed origin(s). Comma-separated. **In production, set to your dashboard URL** — the default only works against the local Vite dev server. |
 | `springdoc.api-docs.enabled` | `API_DOCS_ENABLED` | `false` | Enable generated OpenAPI JSON. When enabled, `/api-docs`, `/v3/api-docs`, and Swagger paths require `X-Admin-API-Key`. |
+| `springdoc.swagger-ui.enabled` | `SWAGGER_ENABLED` | `false` | Enable Swagger UI. When enabled, Swagger paths require `X-Admin-API-Key`. |
 | `contract.validation.enabled` | `CONTRACT_VALIDATION_ENABLED` | `true` (tests) / `false` (runtime) | Fetch and validate against the live admin spec at build time. Disable for offline / air-gapped builds. Does not affect runtime — enforcement happens only in the test harness. |
+
+In `docker-compose.full-stack.prod.yml`, the events service exposes management
+port `9980` for health/readiness. Do not publish its internal worker port
+`7980` on ingress.
 
 ### Audit retention tuning
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Administrative API for managing tenants, budgets, API keys, and policies in a Cycles deployment.** Configures the AI agent budget and action enforcement that the [Cycles Server](https://github.com/runcycles/cycles-server) applies at runtime.
 
-Multi-tenant by default, with four integrated planes: tenant lifecycle and budget ledgers, API key authentication and permission enforcement, runtime reservation control, and event/webhook delivery for observability. Aligned with [Cycles Protocol v0.1.25.33](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml).
+Multi-tenant by default, with four integrated planes: tenant lifecycle and budget ledgers, API key authentication and permission enforcement, runtime reservation control, and event/webhook delivery for observability. Aligned with [Cycles Protocol v0.1.25.34](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml).
 
 ## Documentation
 
@@ -35,9 +35,9 @@ cycles-admin-service/
 ```
 
 - **Language:** Java 21
-- **Framework:** Spring Boot 3.5.11
-- **Data Store:** Redis (via Jedis 5.2.0)
-- **API Docs:** SpringDoc OpenAPI (Swagger UI)
+- **Framework:** Spring Boot 3.5.15
+- **Data Store:** Redis (via Jedis 7.5.2)
+- **API Docs:** SpringDoc OpenAPI (disabled by default; enable behind `X-Admin-API-Key` protection)
 - **Testing:** JUnit 5 + TestContainers (Redis)
 
 ## Quick Start with Docker
@@ -46,15 +46,23 @@ The fastest way to run the admin server — no Java or Maven required:
 
 ```bash
 # Using pre-built image from GHCR
+export REDIS_PASSWORD=$(openssl rand -base64 32)
+export ADMIN_API_KEY=$(openssl rand -base64 32)
+export WEBHOOK_SECRET_ENCRYPTION_KEY=$(openssl rand -base64 32)
 docker compose -f docker-compose.prod.yml up -d
 ```
 
-The server starts at `http://localhost:7979`. Swagger UI: http://localhost:7979/swagger-ui.html
+The server starts at `http://localhost:7979`. Generated API docs and Swagger UI
+are disabled by default in production; set `API_DOCS_ENABLED=true` and
+`SWAGGER_ENABLED=true` only behind trusted access. When enabled, docs endpoints
+require `X-Admin-API-Key`.
 
 To run the full stack (Admin + Runtime + Events + Redis):
 
 ```bash
 # Generate encryption key for webhook signing secrets (shared across all services)
+export REDIS_PASSWORD=$(openssl rand -base64 32)
+export ADMIN_API_KEY=$(openssl rand -base64 32)
 export WEBHOOK_SECRET_ENCRYPTION_KEY=$(openssl rand -base64 32)
 
 # Development (builds from source)
@@ -69,7 +77,7 @@ docker compose -f docker-compose.full-stack.prod.yml up -d
 | Redis | 6379 | Shared state store |
 | Admin (`cycles-server-admin`) | 7979 | Tenant/budget/webhook CRUD, event persistence |
 | Runtime (`cycles-server`) | 7878 | Reserve/commit/release, sub-10ms enforcement |
-| Events (`cycles-server-events`) | 7980 | Async webhook delivery with HMAC signing |
+| Events (`cycles-server-events`) | 9980 in production full-stack | Management/readiness surface for async webhook delivery; worker port `7980` remains internal |
 
 The events service is optional — if not deployed, admin and runtime continue operating normally. Events and deliveries accumulate in Redis (with TTL) until the events service is started.
 
@@ -97,7 +105,8 @@ cd cycles-admin-service/cycles-admin-service-api
 mvn spring-boot:run
 ```
 
-The server starts at `http://localhost:7979`. Swagger UI is available at `/swagger-ui.html`.
+The server starts at `http://localhost:7979`. Swagger UI is disabled by default;
+enable it with `SWAGGER_ENABLED=true` when needed.
 
 ### Run with Integration Tests
 
@@ -141,8 +150,9 @@ API keys use the format `cyc_live_{random}` (production) or `cyc_test_{random}` 
 | `WEBHOOK_SECRET_ENCRYPTION_KEY` | Yes in prod | (empty) | AES-256-GCM encryption key for webhook signing secrets at rest. Base64-encoded 32 bytes. If empty and encryption is not required, secrets are stored in plaintext for dev mode. |
 | `WEBHOOK_SECRET_ENCRYPTION_REQUIRED` | No | `false` | Set `true` in production to fail startup when `WEBHOOK_SECRET_ENCRYPTION_KEY` is missing. |
 | `LOG_LEVEL` | No | `INFO` | Application logging level (`DEBUG`, `INFO`, `WARN`, `ERROR`) |
+| `JAVA_OPTS` | No | (empty) | JVM options consumed by the Docker image entrypoint. Production Compose sets conservative G1/heap-percentage defaults. |
 | `API_DOCS_ENABLED` | No | `false` | Enable generated OpenAPI JSON at `/api-docs`; protected by `X-Admin-API-Key` when enabled. |
-| `SWAGGER_ENABLED` | No | `false` | Enable Swagger UI at `/swagger-ui.html` |
+| `SWAGGER_ENABLED` | No | `false` | Enable Swagger UI at `/swagger-ui.html`; protected by `X-Admin-API-Key` when enabled. |
 | `EVENT_TTL_DAYS` | No | `90` | Event retention in Redis (days) |
 | `DELIVERY_TTL_DAYS` | No | `14` | Webhook delivery retention in Redis (days) |
 | `AUTH_FAILURE_RATE_LIMIT_ENABLED` | No | `false` | Enable per-source, per-process throttling for repeated 401/403 responses. Production Compose enables it. |
@@ -534,7 +544,7 @@ All errors return a standard `ErrorResponse`:
 |-------|-------------|
 | **Single-service** | All four pillars in one deployment |
 | **Split-plane** | Admin + events separate from runtime enforcement |
-| **Full stack** | Admin (7979) + Runtime (7878) + Events (7980) + Redis |
+| **Full stack** | Admin (7979) + Runtime (7878) + Events management/readiness (9980 in production) + Redis |
 
 ## Observability
 

--- a/cycles-admin-service/pom.xml
+++ b/cycles-admin-service/pom.xml
@@ -18,7 +18,7 @@
         <module>cycles-admin-service-api</module>
     </modules>
     <properties>
-        <revision>0.1.25.46</revision>
+        <revision>0.1.25.47</revision>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/docker-compose.full-stack.prod.yml
+++ b/docker-compose.full-stack.prod.yml
@@ -22,7 +22,7 @@ services:
 
   cycles-admin:
     logging: *default-logging
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.45
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.47
     restart: unless-stopped
     ports:
       - "7979:7979"
@@ -38,6 +38,7 @@ services:
       AUDIT_SAMPLE_UNAUTHENTICATED: ${AUDIT_SAMPLE_UNAUTHENTICATED:-100}
       AUTH_FAILURE_RATE_LIMIT_ENABLED: "true"
       AUTH_FAILURE_RATE_LIMIT_MAX_PER_MINUTE: ${AUTH_FAILURE_RATE_LIMIT_MAX_PER_MINUTE:-300}
+      JAVA_OPTS: "-XX:MaxRAMPercentage=75 -XX:+UseG1GC -XX:+UseStringDeduplication"
       # Dashboard CORS origin(s). Comma-separated list. Set to your production
       # dashboard URL, e.g. https://dash.example.com. Default localhost:5173 is
       # the Vite dev server and will NOT work in production.
@@ -54,7 +55,7 @@ services:
 
   cycles-server:
     logging: *default-logging
-    image: ghcr.io/runcycles/cycles-server:0.1.25.17
+    image: ghcr.io/runcycles/cycles-server:0.1.25.43
     restart: unless-stopped
     ports:
       - "7878:7878"
@@ -62,9 +63,14 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       REDIS_PASSWORD: ${REDIS_PASSWORD:?REDIS_PASSWORD must be set}
+      ADMIN_API_KEY: ${ADMIN_API_KEY:?ADMIN_API_KEY must be set}
       WEBHOOK_SECRET_ENCRYPTION_KEY: ${WEBHOOK_SECRET_ENCRYPTION_KEY:?WEBHOOK_SECRET_ENCRYPTION_KEY must be set}
+      CYCLES_METRICS_TENANT_TAG_ENABLED: "false"
+      SPRINGDOC_API_DOCS_ENABLED: "false"
+      SPRINGDOC_SWAGGER_UI_ENABLED: "false"
+      JAVA_OPTS: "-XX:MaxRAMPercentage=75 -XX:+UseG1GC -XX:+UseStringDeduplication"
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:7878/actuator/health"]
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:7878/actuator/health/readiness"]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -75,17 +81,18 @@ services:
 
   cycles-events:
     logging: *default-logging
-    image: ghcr.io/runcycles/cycles-server-events:0.1.25.10
+    image: ghcr.io/runcycles/cycles-server-events:0.1.25.19
     restart: unless-stopped
     ports:
-      - "7980:7980"
+      - "9980:9980"
     environment:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       REDIS_PASSWORD: ${REDIS_PASSWORD:?REDIS_PASSWORD must be set}
+      MANAGEMENT_PORT: 9980
       WEBHOOK_SECRET_ENCRYPTION_KEY: ${WEBHOOK_SECRET_ENCRYPTION_KEY:?WEBHOOK_SECRET_ENCRYPTION_KEY must be set}
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:7980/actuator/health"]
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:9980/actuator/health/readiness"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/docker-compose.full-stack.prod.yml
+++ b/docker-compose.full-stack.prod.yml
@@ -55,7 +55,7 @@ services:
 
   cycles-server:
     logging: *default-logging
-    image: ghcr.io/runcycles/cycles-server:0.1.25.43
+    image: ghcr.io/runcycles/cycles-server:0.1.25.44
     restart: unless-stopped
     ports:
       - "7878:7878"
@@ -81,7 +81,7 @@ services:
 
   cycles-events:
     logging: *default-logging
-    image: ghcr.io/runcycles/cycles-server-events:0.1.25.19
+    image: ghcr.io/runcycles/cycles-server-events:0.1.25.20
     restart: unless-stopped
     ports:
       - "9980:9980"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -22,7 +22,7 @@ services:
 
   cycles-admin:
     logging: *default-logging
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.45
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.47
     restart: unless-stopped
     ports:
       - "7979:7979"
@@ -38,6 +38,7 @@ services:
       AUDIT_SAMPLE_UNAUTHENTICATED: ${AUDIT_SAMPLE_UNAUTHENTICATED:-100}
       AUTH_FAILURE_RATE_LIMIT_ENABLED: "true"
       AUTH_FAILURE_RATE_LIMIT_MAX_PER_MINUTE: ${AUTH_FAILURE_RATE_LIMIT_MAX_PER_MINUTE:-300}
+      JAVA_OPTS: "-XX:MaxRAMPercentage=75 -XX:+UseG1GC -XX:+UseStringDeduplication"
       # Dashboard CORS origin(s). Comma-separated list. Set to your production
       # dashboard URL, e.g. https://dash.example.com. Default localhost:5173 is
       # the Vite dev server and will NOT work in production.


### PR DESCRIPTION
## Summary
- bump cycles-server-admin to `0.1.25.47`
- add an image-level readiness healthcheck and make the Docker entrypoint use `exec java $JAVA_OPTS -jar app.jar`
- set conservative `JAVA_OPTS` in production Compose
- update production Compose admin image tags to `0.1.25.47`
- align full-stack production Compose with current published sibling images: `cycles-server:0.1.25.43` and `cycles-server-events:0.1.25.19`
- harden full-stack runtime/events wiring: runtime readiness, runtime `ADMIN_API_KEY`, disabled runtime public docs/Swagger, disabled tenant-labelled custom metrics, events management port `9980`, and readiness probes
- update `AUDIT.md`, `CHANGELOG.md`, `README.md`, and `OPERATIONS.md`

## Findings Addressed
- Admin production Compose lagged the repo version: `0.1.25.45` while `main` was already `0.1.25.46`.
- Full-stack production Compose still referenced very old runtime/events images and aggregate health probes.
- Full-stack production Compose published the events worker app port `7980`; the current production health/ops surface is management port `9980`.
- Runtime full-stack config was missing `ADMIN_API_KEY` and the production hardening flags for public docs/Swagger and tenant-labelled custom metrics.
- The admin image had no built-in healthcheck and did not expose a `JAVA_OPTS` path for JVM tuning.
- README/OPERATIONS had stale production guidance: old Spring Boot/Jedis versions, a prod Compose command without required secrets, Swagger implied as always available, and old events-port wording.

## Review Notes
- No new admin HTTP/auth/schema defect found. Aggregate actuator, Prometheus, API docs, and Swagger remain protected by `X-Admin-API-Key`; exact liveness/readiness probes remain open; generated docs remain disabled by default; operator logs already include useful context without logging secret values.

## Validation
- `docker compose -f docker-compose.prod.yml config --quiet`
- `docker compose -f docker-compose.full-stack.prod.yml config --quiet`
- `mvn -B -pl cycles-admin-service-api,cycles-admin-service-data -am "-Dtest=OperationalEndpointAuthFilterTest,RedisHealthIndicatorTest,WebConfigTest,CryptoServiceTest" "-Dsurefire.failIfNoSpecifiedTests=false" test`
- `mvn -B -pl cycles-admin-service-api -am -DskipTests clean compile`
- `docker build --build-arg APP_VERSION=0.1.25.47 -t cycles-server-admin:prod-hardening-test .`
- `docker image inspect cycles-server-admin:prod-hardening-test --format '{{json .Config.Entrypoint}} {{json .Config.Healthcheck.Test}}'`
- `git diff --check`