### PR TITLE
test(contract): honor file:// spec pins + record spec-conformance audit (46/46 conformant)

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -26,6 +26,31 @@ pin (SB 3.5.15 still manages 3.17.0) · tomcat-embed-core 10.1.55 pin
 (re-introduced 2026-05-25 for Apache Tomcat CVE-2026-43512 / -43513 / -43514 /
 -43515 / -42498 / -41284 / -41293)
 
+### 2026-07-03 — spec-conformance audit vs cycles-governance-admin v0.1.25.34/.35 + ContractSpecLoader file:// fix (test-only, no version change)
+
+End-to-end audit of the admin API surface against the governance spec at
+`cycles-protocol@main` found the server conformant across all 46 operations —
+endpoints, status codes (incl. 201/200 idempotent create, 204 deletes, 202
+replay), DTO constraints, `limit` bounds, the 29-value ErrorCode enum, dual-auth
+allowlists, audit sentinels, and cascade Rules 1/2. Full suite green:
+`mvn verify -Pintegration-tests` — 802 tests, spec coverage 46/46, JaCoCo ≥95%.
+
+Two findings, neither a server-code change:
+
+1. **Spec gap (fixed upstream, runcycles/cycles-protocol#121 → spec
+   v0.1.25.35):** the four `*_via_tenant_cascade` kinds this server has emitted
+   as `Event.event_type` since v0.1.25.35 (see the cascade entry below) were
+   never added to the spec's closed `EventType` enum — same defect class as the
+   v0.1.25.34 `EventCategory`/`webhook` gap. Cascade Events in `listEvents`
+   responses failed contract validation until the enum re-opened. No server
+   change needed; contract tests verified green against spec v0.1.25.35.
+2. **`ContractSpecLoader` could not load a local spec** despite its own error
+   message advertising `-Dcontract.spec.url=file:///…`: `fetch()` passed every
+   URL to `java.net.http.HttpClient` (http/https only), and a fresh on-disk
+   cache shadowed an explicit override. Fixed to mirror the runtime repo's
+   loader: `file:` URLs read via `Files.readString`, and an explicit override
+   always wins over the cache. Test-infra only — no production code touched.
+
 ### 2026-06-26 — v0.1.25.47: production deployment hardening follow-up
 
 Production-readiness review after the sibling `cycles-server` pass found no new

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -2,7 +2,7 @@
 
 **Spec:**
 [`cycles-governance-admin-v0.1.25.yaml`](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml)
-(OpenAPI 3.1.0, info.version `0.1.25.34`; adds CASCADE SEMANTICS — Rule 1 `POST
+(OpenAPI 3.1.0, info.version `0.1.25.35`; adds CASCADE SEMANTICS — Rule 1 `POST
 /admin/tenants/{id}` PATCH→CLOSED cascades owned budgets (→CLOSED), webhook
 subscriptions (→DISABLED), and API keys (→REVOKED) under a shared correlation_id
 — Rule 1 permits **Mode A (atomic)** or **Mode B
@@ -19,7 +19,9 @@ introduces six webhook lifecycle EventTypes (`webhook.created` / `.updated` /
 `bulkActionWebhooks` + the three single-op webhook operations + the dispatcher
 auto-disable path; v0.1.25.34 closes a same-release enum gap by adding `webhook`
 to the `EventCategory` enum so Event responses carrying the new EventTypes
-validate) in [cycles-protocol](https://github.com/runcycles/cycles-protocol)
+validate; v0.1.25.35 closes the sibling cascade enum gap by adding the four
+`*_via_tenant_cascade` values to `EventType` so cascade Events validate) in
+[cycles-protocol](https://github.com/runcycles/cycles-protocol)
 
 **Server:** Spring Boot 3.5.15 / Java 21 / Jedis 7.5.2 · commons-lang3 3.18.0
 pin (SB 3.5.15 still manages 3.17.0) · tomcat-embed-core 10.1.55 pin

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/contract/ContractSpecLoader.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/contract/ContractSpecLoader.java
@@ -39,12 +39,19 @@ public final class ContractSpecLoader {
     public static synchronized String loadSpec() {
         if (cached != null) return cached;
         try {
+            // An explicit override always wins over the on-disk cache — a developer
+            // pinning a local spec must not be shadowed by a fresh cached download.
+            // Matches the runtime repo's ContractSpecLoader precedence.
+            String specUrl = System.getProperty("contract.spec.url");
+            if (specUrl != null) {
+                cached = fetch(specUrl);
+                return cached;
+            }
             if (isCacheFresh()) {
                 cached = Files.readString(CACHE_PATH);
                 return cached;
             }
-            String specUrl = System.getProperty("contract.spec.url", DEFAULT_SPEC_URL);
-            cached = fetch(specUrl);
+            cached = fetch(DEFAULT_SPEC_URL);
             Files.createDirectories(CACHE_PATH.getParent());
             Files.writeString(CACHE_PATH, cached,
                     StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
@@ -63,6 +70,11 @@ public final class ContractSpecLoader {
     }
 
     private static String fetch(String url) throws IOException, InterruptedException {
+        // java.net.http.HttpClient supports only http/https — read file: URLs
+        // directly so the documented file:/// override actually works.
+        if (url.startsWith("file:")) {
+            return Files.readString(Path.of(URI.create(url)));
+        }
         HttpClient client = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(15))
                 .build();

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/contract/ContractSpecLoaderTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/contract/ContractSpecLoaderTest.java
@@ -1,0 +1,87 @@
+package io.runcycles.admin.api.contract;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.FileTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ContractSpecLoaderTest {
+
+    private static final Path CACHE_PATH = Path.of("target", "contract", "spec.yaml");
+
+    private String previousSpecUrl;
+    private boolean hadCache;
+    private String previousCacheContent;
+    private FileTime previousCacheMtime;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        previousSpecUrl = System.getProperty("contract.spec.url");
+        hadCache = Files.exists(CACHE_PATH);
+        if (hadCache) {
+            previousCacheContent = Files.readString(CACHE_PATH);
+            previousCacheMtime = Files.getLastModifiedTime(CACHE_PATH);
+        }
+        System.clearProperty("contract.spec.url");
+        clearInMemoryCache();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (previousSpecUrl == null) {
+            System.clearProperty("contract.spec.url");
+        } else {
+            System.setProperty("contract.spec.url", previousSpecUrl);
+        }
+        clearInMemoryCache();
+        restoreCacheFile();
+    }
+
+    @Test
+    void fileUrlOverrideLoadsLocalSpec(@TempDir Path tempDir) throws Exception {
+        Path spec = tempDir.resolve("spec.yaml");
+        Files.writeString(spec, "local-spec");
+
+        System.setProperty("contract.spec.url", spec.toUri().toString());
+
+        assertEquals("local-spec", ContractSpecLoader.loadSpec());
+    }
+
+    @Test
+    void explicitOverrideWinsOverFreshOnDiskCache(@TempDir Path tempDir) throws Exception {
+        Files.createDirectories(CACHE_PATH.getParent());
+        Files.writeString(CACHE_PATH, "cached-spec",
+                StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+
+        Path spec = tempDir.resolve("spec.yaml");
+        Files.writeString(spec, "override-spec");
+        System.setProperty("contract.spec.url", spec.toUri().toString());
+
+        assertEquals("override-spec", ContractSpecLoader.loadSpec());
+    }
+
+    private static void clearInMemoryCache() throws Exception {
+        Field cached = ContractSpecLoader.class.getDeclaredField("cached");
+        cached.setAccessible(true);
+        cached.set(null, null);
+    }
+
+    private void restoreCacheFile() throws Exception {
+        if (hadCache) {
+            Files.createDirectories(CACHE_PATH.getParent());
+            Files.writeString(CACHE_PATH, previousCacheContent,
+                    StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+            Files.setLastModifiedTime(CACHE_PATH, previousCacheMtime);
+        } else {
+            Files.deleteIfExists(CACHE_PATH);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Records the 2026-07-03 spec-conformance audit of the admin server against `cycles-governance-admin-v0.1.25.yaml` (`cycles-protocol@main`), and fixes the one test-infrastructure bug the audit tripped over. **No production code or version change.**

## Audit result: conformant across all 46 operations

- Endpoints, methods, and status codes (incl. 201/200 idempotent `createTenant`, 204 deletes, 202 `replayEvents`, bulk 409 `COUNT_MISMATCH` / 400 `LIMIT_EXCEEDED`) match the spec exactly
- 29-value `ErrorCode` enum and throw-site status mappings, `EventCategory` (7 incl. `webhook`), DTO field names/constraints, `limit` bounds (1–100 default 50), dual-auth allowlists, audit `__admin__`/`__unauth__` sentinels, correlation headers, cascade Rules 1/2 — all verified
- Full suite green: `mvn verify -Pintegration-tests` — **802 tests, 0 failures, spec coverage 46/46, JaCoCo ≥95% met**

One wire-level gap was found and is fixed **spec-side** (runcycles/cycles-protocol#121 → spec v0.1.25.35): the four `*_via_tenant_cascade` EventTypes this server has deliberately emitted since v0.1.25.35 (April) were missing from the spec's closed `EventType` enum — the same defect class spec v0.1.25.34 fixed for `EventCategory`/`webhook`. Contract tests verified green against the new spec revision; no server change needed.

## Test-infra fix: `ContractSpecLoader` file:// support

The loader's own error message advertises `-Dcontract.spec.url=file:///path/to/spec.yaml`, but `fetch()` passed every URL to `java.net.http.HttpClient` (http/https only) — a `file://` pin threw, cascading into 447 context failures. A fresh `target/contract/spec.yaml` cache also shadowed explicit overrides. Both fixed to mirror the runtime repo's loader:

- `file:` URLs read via `Files.readString`
- explicit `contract.spec.url` override always wins over the on-disk cache

## Verification

- Full suite with local spec pin: 802 tests green, 46/46 coverage, JaCoCo gate met
- Contract tests re-run green against spec v0.1.25.35 (the cascade-EventTypes revision)
