### PR TITLE
feat(events): typed EventDataTenantCascade payload mapping (v0.1.25.48)

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,4 +1,4 @@
-# Complete Budget Governance v0.1.25.47 — Admin Server Audit
+# Complete Budget Governance v0.1.25.48 — Admin Server Audit
 
 **Spec:**
 [`cycles-governance-admin-v0.1.25.yaml`](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml)
@@ -27,6 +27,21 @@ validate; v0.1.25.35 closes the sibling cascade enum gap by adding the four
 pin (SB 3.5.15 still manages 3.17.0) · tomcat-embed-core 10.1.55 pin
 (re-introduced 2026-05-25 for Apache Tomcat CVE-2026-43512 / -43513 / -43514 /
 -43515 / -42498 / -41284 / -41293)
+
+### 2026-07-04 — v0.1.25.48: EventDataTenantCascade payload mapping
+
+Follow-up from the 2026-07-03 audit. The four cascade EventTypes were mapped
+in `EventPayloadTypeMapping` to nearest-fit lifecycle classes with a comment
+promising a typed back-fill; the spec has since defined the
+`EventDataTenantCascade` schema (v0.1.25.35) matching what
+`TenantCloseCascadeService` actually emits. Added the matching model class
+(statuses as strings — the transition spans three status vocabularies;
+`released_amount` on the ledger-level reservation aggregate) and remapped
+all four kinds. Side benefit: the strict `convertValue` round-trip in the
+payload-shape validator no longer flags every cascade emission as a shape
+warning, since the emitted flat map now has a class it actually fits.
+`EventPayloadContractTest` covers the new mapping automatically; full suite
+green. No wire change.
 
 ### 2026-07-03 — spec-conformance audit vs cycles-governance-admin v0.1.25.34/.35 + ContractSpecLoader file:// fix (test-only, no version change)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,26 @@ changes to request/response bodies or Lua-script semantics would require a
 minor bump. Additive fields (new optional response fields, new enum values,
 new optional request fields) are **not** considered breaking.
 
+## [0.1.25.48] — 2026-07-04
+
+### Fixed
+
+- **Cascade event payloads now map to their own typed class.** The four
+  `*_via_tenant_cascade` EventTypes were registered in
+  `EventPayloadTypeMapping` against nearest-fit lifecycle classes
+  (`EventDataBudgetLifecycle` / `EventDataSystem` / `EventDataApiKey`), but
+  the payload `TenantCloseCascadeService` actually emits (flat
+  `prior_status` / `new_status` / `cascade_reason` + object identity) fits
+  none of them — so the warn-only payload-shape validator flagged every
+  cascade emission. New `EventDataTenantCascade` model class mirrors the
+  spec schema of the same name (governance spec v0.1.25.35); all four kinds
+  remap to it. No wire change — `Event.data` was and remains the same
+  emitted map; only the internal validation/registry class changed.
+
+### Compatibility
+
+- No HTTP request/response, Redis, event-wire, or spec-surface change.
+
 ## [0.1.25.47] — 2026-06-26
 
 ### Fixed

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventDataTenantCascade.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventDataTenantCascade.java
@@ -1,0 +1,69 @@
+package io.runcycles.admin.model.event;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.runcycles.admin.model.shared.UnitEnum;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Payload for the four {@code *_via_tenant_cascade} events emitted by the
+ * tenant-close cascade (spec CASCADE SEMANTICS Rule 1; schema
+ * {@code EventDataTenantCascade}, governance spec v0.1.25.35). One shared
+ * shape for all four kinds — each event identifies the owned object it
+ * transitioned (exactly one of {@code ledger_id} / {@code subscription_id} /
+ * {@code key_id} is present, matching the event's category), the status
+ * transition, and the cascade provenance.
+ *
+ * <p>{@code reservation.released_via_tenant_cascade} is a LEDGER-LEVEL
+ * AGGREGATE: reservation objects live on the runtime plane, so the admin
+ * plane emits one event per closed budget whose {@code reserved > 0} at
+ * close time, carrying the drained amount as {@code released_amount} — it
+ * identifies the budget via {@code ledger_id}, not an individual
+ * reservation, and carries no {@code new_status} of its own.
+ *
+ * <p>Statuses are strings (not a shared enum) because the transition spans
+ * three different status vocabularies: BudgetStatus → CLOSED,
+ * WebhookStatus → DISABLED, ApiKeyStatus → REVOKED.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = false)
+public class EventDataTenantCascade {
+
+    @JsonProperty("ledger_id")
+    private String ledgerId;
+
+    @JsonProperty("subscription_id")
+    private String subscriptionId;
+
+    @JsonProperty("key_id")
+    private String keyId;
+
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("scope")
+    private String scope;
+
+    @JsonProperty("unit")
+    private UnitEnum unit;
+
+    @JsonProperty("prior_status")
+    private String priorStatus;
+
+    @JsonProperty("new_status")
+    private String newStatus;
+
+    @JsonProperty("released_amount")
+    private Long releasedAmount;
+
+    @JsonProperty("cascade_reason")
+    private String cascadeReason;
+}

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventPayloadTypeMapping.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventPayloadTypeMapping.java
@@ -91,17 +91,17 @@ public final class EventPayloadTypeMapping {
         m.put(EventType.POLICY_UPDATED, EventDataPolicy.class);
         m.put(EventType.POLICY_DELETED, EventDataPolicy.class);
 
-        // Cascade events — spec v0.1.25.29 Rule 1. Each carries a
-        // Map-shaped payload (ledger_id / subscription_id / key_id + prior/
-        // new status + cascade_reason) emitted by TenantCloseCascadeService.
-        // No dedicated DTO today — matches the inline-Map pattern used by
-        // other EventService.emit call sites; a typed class can be
-        // back-filled alongside EventService producer-boundary validation
-        // without a wire break.
-        m.put(EventType.BUDGET_CLOSED_VIA_TENANT_CASCADE, EventDataBudgetLifecycle.class);
-        m.put(EventType.RESERVATION_RELEASED_VIA_TENANT_CASCADE, EventDataBudgetLifecycle.class);
-        m.put(EventType.WEBHOOK_DISABLED_VIA_TENANT_CASCADE, EventDataSystem.class);
-        m.put(EventType.API_KEY_REVOKED_VIA_TENANT_CASCADE, EventDataApiKey.class);
+        // Cascade events — spec Rule 1; payload schema EventDataTenantCascade
+        // (governance spec v0.1.25.35). One shared shape for all four kinds,
+        // matching exactly what TenantCloseCascadeService emits. Previously
+        // mapped to the nearest-fit lifecycle classes, which strict
+        // convertValue round-tripping in the payload validator flagged as
+        // shape warnings on every cascade (the emitted flat prior_status /
+        // new_status / cascade_reason fields fit none of them).
+        m.put(EventType.BUDGET_CLOSED_VIA_TENANT_CASCADE, EventDataTenantCascade.class);
+        m.put(EventType.RESERVATION_RELEASED_VIA_TENANT_CASCADE, EventDataTenantCascade.class);
+        m.put(EventType.WEBHOOK_DISABLED_VIA_TENANT_CASCADE, EventDataTenantCascade.class);
+        m.put(EventType.API_KEY_REVOKED_VIA_TENANT_CASCADE, EventDataTenantCascade.class);
 
         // System
         m.put(EventType.SYSTEM_STORE_CONNECTION_LOST, EventDataSystem.class);

--- a/cycles-admin-service/pom.xml
+++ b/cycles-admin-service/pom.xml
@@ -18,7 +18,7 @@
         <module>cycles-admin-service-api</module>
     </modules>
     <properties>
-        <revision>0.1.25.47</revision>
+        <revision>0.1.25.48</revision>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>


### PR DESCRIPTION
Back-fills the typed payload class the cascade mapping comment promised: new \EventDataTenantCascade\ model mirrors the spec schema of the same name (governance v0.1.25.35, runcycles/cycles-protocol#121), and all four \*_via_tenant_cascade\ kinds remap to it in \EventPayloadTypeMapping\. Side benefit: the strict \convertValue\ round-trip in the warn-only payload-shape validator stops flagging every cascade emission (the emitted flat \prior_status\/\
ew_status\/\cascade_reason\ map fit none of the old nearest-fit classes). No wire change — \Event.data\ remains the same emitted map. Full suite green: **804 tests, spec coverage 46/46, JaCoCo ≥95%** (contract tests pinned to the local spec incl. the pending v0.1.25.36 revision). AUDIT.md + CHANGELOG.md updated; revision → 0.1.25.48.