### PR TITLE
chore(compose): stop host-publishing the events worker's management port

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -28,6 +28,17 @@ pin (SB 3.5.15 still manages 3.17.0) · tomcat-embed-core 10.1.55 pin
 (re-introduced 2026-05-25 for Apache Tomcat CVE-2026-43512 / -43513 / -43514 /
 -43515 / -42498 / -41284 / -41293)
 
+### 2026-07-04 — full-stack prod compose: stop host-publishing events management port (no version bump)
+
+`docker-compose.full-stack.prod.yml` published the events worker's 9980 to
+the host — an unauthenticated actuator surface (health + Prometheus), the
+exposure class this server's own operational-endpoint hardening closed. The
+events worker's isolation mechanism is its separate management port on an
+internal network (see cycles-server-events OPERATIONS.md); the container
+healthcheck probes in-container and Prometheus scrapes over the compose
+network, so the publish served nothing. Removed, with an inline comment
+recording the posture.
+
 ### 2026-07-03 — spec-conformance audit vs cycles-governance-admin v0.1.25.34/.35 + ContractSpecLoader file:// fix (test-only, no version change)
 
 End-to-end audit of the admin API surface against the governance spec at

--- a/docker-compose.full-stack.prod.yml
+++ b/docker-compose.full-stack.prod.yml
@@ -83,8 +83,11 @@ services:
     logging: *default-logging
     image: ghcr.io/runcycles/cycles-server-events:0.1.25.20
     restart: unless-stopped
-    ports:
-      - "9980:9980"
+    # Management port 9980 (health + Prometheus) is deliberately NOT published
+    # to the host: the events worker's actuator is unauthenticated by design
+    # (the separate management port is its isolation mechanism - see
+    # cycles-server-events OPERATIONS.md). Prometheus scrapes over the compose
+    # network; the container healthcheck probes in-container.
     environment:
       REDIS_HOST: redis
       REDIS_PORT: 6379


### PR DESCRIPTION
chore(compose): stop host-publishing the events worker's management port

The full-stack prod compose published the events worker's 9980 to the
host — an unauthenticated actuator surface (health + Prometheus), the
same exposure class the operational-endpoint hardening closed for the
API servers' own actuators. The events worker's isolation mechanism is
its separate management port on an internal network (see
cycles-server-events OPERATIONS.md, v0.1.25.22 posture note); the
container healthcheck probes in-container and Prometheus scrapes over
the compose network, so the host publish served nothing.

Removed, with an inline comment recording the posture. AUDIT.md updated;
compose parses clean. No version bump (compose/doc-only, matching
precedent). Companion change in the sibling repo's full-stack prod
compose.
