### PR TITLE
chore(release): v0.1.25.48 compose pins (self .48, server .46, events .22)

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -52,7 +52,9 @@ all four kinds. Side benefit: the strict `convertValue` round-trip in the
 payload-shape validator no longer flags every cascade emission as a shape
 warning, since the emitted flat map now has a class it actually fits.
 `EventPayloadContractTest` covers the new mapping automatically; full suite
-green. No wire change.
+green. No wire change. Release prep (same version): prod compose self-pin
+→ `.48`; bundled full-stack pins → server `.46` / events `.22` (the
+2026-07-04 security releases).
 
 ### 2026-07-03 — spec-conformance audit vs cycles-governance-admin v0.1.25.34/.35 + ContractSpecLoader file:// fix (test-only, no version change)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ new optional request fields) are **not** considered breaking.
 ### Compatibility
 
 - No HTTP request/response, Redis, event-wire, or spec-surface change.
+- Release prep: prod compose self-pin → `0.1.25.48`; bundled full-stack
+  pins bumped to the 2026-07-04 security releases (`cycles-server`
+  `0.1.25.46` — public-endpoint 429 rate limiting; `cycles-server-events`
+  `0.1.25.22` — delivery-time SSRF guard; see those releases' notes for
+  the `allow_http`/CIDR operator note on webhook targets).
 
 ## [0.1.25.47] — 2026-06-26
 

--- a/docker-compose.full-stack.prod.yml
+++ b/docker-compose.full-stack.prod.yml
@@ -22,7 +22,7 @@ services:
 
   cycles-admin:
     logging: *default-logging
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.47
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.48
     restart: unless-stopped
     ports:
       - "7979:7979"
@@ -55,7 +55,7 @@ services:
 
   cycles-server:
     logging: *default-logging
-    image: ghcr.io/runcycles/cycles-server:0.1.25.44
+    image: ghcr.io/runcycles/cycles-server:0.1.25.46
     restart: unless-stopped
     ports:
       - "7878:7878"
@@ -81,7 +81,7 @@ services:
 
   cycles-events:
     logging: *default-logging
-    image: ghcr.io/runcycles/cycles-server-events:0.1.25.20
+    image: ghcr.io/runcycles/cycles-server-events:0.1.25.22
     restart: unless-stopped
     # Management port 9980 (health + Prometheus) is deliberately NOT published
     # to the host: the events worker's actuator is unauthenticated by design

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -22,7 +22,7 @@ services:
 
   cycles-admin:
     logging: *default-logging
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.47
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.48
     restart: unless-stopped
     ports:
       - "7979:7979"


### PR DESCRIPTION
Release prep for cutting **v0.1.25.48**: the prod compose self-pin still said \.47\, and the bundled full-stack pins were on pre-security-release versions. Bumps: self-pin → \