### PR TITLE
fix: spec-conformant webhook scope-filter matching + replay filtering [BEHAVIOR CHANGE]

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -28,6 +28,49 @@ pin (SB 3.5.15 still manages 3.17.0) · tomcat-embed-core 10.1.55 pin
 (re-introduced 2026-05-25 for Apache Tomcat CVE-2026-43512 / -43513 / -43514 /
 -43515 / -42498 / -41284 / -41293)
 
+### 2026-07-09 — webhook scope_filter matcher brought to spec (wildcard semantics; unreleased)
+
+Spec-conformance fix. `WebhookRepository.matchesScope` implemented literal
+prefix matching (`scope.startsWith(scope_filter)`, bare `"*"` special-cased,
+null event scope matched every filter), while the governance spec's
+`scope_filter` description defines wildcard semantics: *"Optional scope
+pattern to narrow event matching. Supports wildcards: "tenant:acme-corp/*"
+matches all scopes under acme-corp. If omitted, matches all scopes within the
+tenant."* (verified verbatim against `cycles-governance-admin-v0.1.25.yaml`
+at cycles-protocol@main, info.version 0.1.25.36 — spec is the authority).
+Three user-visible consequences of the old matcher: spec-style trailing-`/*`
+filters matched nothing (the `*` was compared literally), a filter without
+`*` acted as an unbounded character-wise prefix (`tenant:acme-corp` also
+matched `tenant:acme-corpX`), and unscoped (null-scope) events were delivered
+to scope-filtered subscriptions.
+
+New semantics (javadoc on `matchesScope` records them and flags the behavior
+change): null/blank filter matches everything including null-scope events;
+bare `"*"` matches any event that has a scope but excludes null-scope events;
+a trailing `*` strips to a prefix match ("all scopes **under**" — children
+only, the bare base scope does not match `base/*`); otherwise exact match
+with any non-trailing `*` literal; a non-blank filter never matches a
+null-scope event. Two decisions the spec sentence leaves open, resolved per
+the spec-normative docs page (cycles-docs `protocol/webhook-scope-filter-syntax.md`):
+bare `"*"` (undefined by the spec) keeps its match-everything-scoped intent
+but stops matching null-scope events, and `base/*` excludes the exact base
+scope (the docs' table says "scopes starting with `tenant:acme-corp/`").
+
+Method visibility widened from `private` to package-private static (same
+convention as `webhookComparator`) for direct unit testing. Rewrote the two
+`WebhookRepositoryTest` cases that encoded the old behavior
+(`findMatchingSubscriptions_scopeFilterMatching` now uses the `/*` form;
+`findMatchingSubscriptions_nullScopeWithScopeFilter_matches` →
+`_excluded`, asserting exclusion) and added eleven direct `matchesScope`
+tests covering null/blank filters, bare `*` incl. null-scope exclusion,
+trailing-`*` children/base/sibling-prefix/null-scope cases, exact-match
+boundaries, and mid-string-`*` literalness. Full suite green:
+`mvn verify` — data module 555 tests, api module 797 tests
+(`-Dcontract.spec.url=file://` local spec pin, network-restricted
+environment); JaCoCo ≥95% met (data 95.52% line, `WebhookRepository`
+98.39%). CHANGELOG carries the BEHAVIOR CHANGE + migration note
+(prefix-style filters must be rewritten `base` → `base/*`).
+
 ### 2026-07-04 — full-stack prod compose: stop host-publishing events management port (no version bump)
 
 `docker-compose.full-stack.prod.yml` published the events worker's 9980 to

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -3113,3 +3113,11 @@ The admin server is **fully compliant** with the Complete Budget Governance spec
 ## Audit History
 
 For historical audit rounds 1-4 against spec v0.1.23 (19 issues found and fixed), see [AUDIT-history.md](./AUDIT-history.md).
+
+### Compose healthcheck port fix (2026-07-09, same PR)
+
+`docker-compose.full-stack.yml` healthchecked the events service at
+`7980/actuator/health`; actuators moved to the management port (9980)
+in cycles-server-events v0.1.25.9, so the check could never pass.
+Updated to `9980/actuator/health`. Found by the cycles-docs
+deployment-docs audit.

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -56,20 +56,51 @@ bare `"*"` (undefined by the spec) keeps its match-everything-scoped intent
 but stops matching null-scope events, and `base/*` excludes the exact base
 scope (the docs' table says "scopes starting with `tenant:acme-corp/`").
 
-Method visibility widened from `private` to package-private static (same
-convention as `webhookComparator`) for direct unit testing. Rewrote the two
-`WebhookRepositoryTest` cases that encoded the old behavior
-(`findMatchingSubscriptions_scopeFilterMatching` now uses the `/*` form;
-`findMatchingSubscriptions_nullScopeWithScopeFilter_matches` →
-`_excluded`, asserting exclusion) and added eleven direct `matchesScope`
-tests covering null/blank filters, bare `*` incl. null-scope exclusion,
-trailing-`*` children/base/sibling-prefix/null-scope cases, exact-match
-boundaries, and mid-string-`*` literalness. Full suite green:
-`mvn verify` — data module 555 tests, api module 797 tests
+External review (codex, REVISE-MINOR) tightened the first cut in three ways,
+all applied:
+
+1. **Blank scope = unscoped.** A blank (`""`/whitespace) event scope is now
+   rejected on every filtered path — previously only `null` was; in
+   particular bare `"*"` no longer matches `scope=""`. (Supersedes the docs
+   page's earlier "empty string scope is not treated as missing" edge note.)
+2. **Trailing-`*` requires a non-empty remainder.** `tenant:a/*` no longer
+   matches the degenerate scope `tenant:a/` (empty child segment):
+   the prefix match additionally requires
+   `scope.length() > prefix.length()`.
+3. **Replay path conformance (the substantive find).** `WebhookService.replay`
+   queued every event in the requested window (after the request's
+   `event_types` filter) straight to `dispatchToSubscription`, bypassing
+   `scope_filter` entirely — a pre-existing bug that became a spec violation
+   once the matcher went spec-conformant, and a drift risk (live vs replayed
+   deliveries disagreeing). Fix: `matchesScope` widened from package-private
+   to **`public static` on `WebhookRepository`** (the api module already
+   depends on the data module and on this class; a new shared utility class
+   would have added surface for a 10-line matcher) and the replay path now
+   filters events through it before dispatch. Replay `event_types` behavior
+   is unchanged.
+
+Tests: rewrote the two `WebhookRepositoryTest` cases that encoded the old
+behavior (`findMatchingSubscriptions_scopeFilterMatching` now uses the `/*`
+form; `findMatchingSubscriptions_nullScopeWithScopeFilter_matches` →
+`_excluded`, asserting exclusion); added seventeen direct `matchesScope`
+tests (null/blank filters, bare `*` incl. null- and blank-scope exclusion,
+trailing-`*` children/base/empty-child/sibling-prefix/null-scope, `/*`
+remainder rule, trailing-slash-no-star exact-only, exact-match boundaries,
+case sensitivity, mid-string-`*` literalness) and five `WebhookServiceTest`
+replay tests (scoped-filter subscription delivers only matching scopes;
+null-scope event excluded from filtered subscription; bare-`*` subscription
+delivers scoped but not unscoped; no-filter subscription delivers both;
+scope filter composes with the request's `event_types` filter). Full suite
+green: `mvn verify` — data module 561 tests, api module 802 tests
 (`-Dcontract.spec.url=file://` local spec pin, network-restricted
-environment); JaCoCo ≥95% met (data 95.52% line, `WebhookRepository`
-98.39%). CHANGELOG carries the BEHAVIOR CHANGE + migration note
-(prefix-style filters must be rewritten `base` → `base/*`).
+environment); JaCoCo ≥95% met (data 95.52% line, `WebhookRepository` 98.39%;
+api 95.39%). CHANGELOG carries the BEHAVIOR CHANGE with a four-part
+migration note — descendants-only rewrites (`base` → `base/*`), the
+base+descendants trap (old prefix matching also matched the exact base
+scope, so `base/*` alone drops base-scope events; a single filter cannot
+express both — use two subscriptions, exact + wildcard), accidental
+sibling-prefix matches (`tenant:acme-corpX`) now needing explicit filters,
+and unscoped-event delivery — plus a Fixed entry for the replay path.
 
 ### 2026-07-04 — full-stack prod compose: stop host-publishing events management port (no version bump)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,45 @@ changes to request/response bodies or Lua-script semantics would require a
 minor bump. Additive fields (new optional response fields, new enum values,
 new optional request fields) are **not** considered breaking.
 
+## [Unreleased]
+
+### Changed
+
+- **BEHAVIOR CHANGE — webhook `scope_filter` matching is now spec-conformant
+  (wildcard semantics).** `WebhookRepository.matchesScope` previously did
+  literal prefix matching: any event scope that `startsWith(scope_filter)`
+  matched, a spec-style trailing-`/*` filter matched nothing (the `*` was
+  compared literally), and events with a **null** scope matched every filter.
+  The admin OpenAPI spec (`scope_filter`: *"Optional scope pattern to narrow
+  event matching. Supports wildcards: "tenant:acme-corp/*" matches all scopes
+  under acme-corp. If omitted, matches all scopes within the tenant."*) is the
+  authority, so the matcher now implements:
+  - null/blank filter — matches every event, including null-scope events
+    (unchanged);
+  - bare `*` — matches every event that **has** a scope; null-scope events are
+    excluded;
+  - trailing `*` (e.g. `tenant:acme-corp/*`) — prefix match on the filter
+    minus the `*`; matches all scopes **under** the base (children only — the
+    bare base scope `tenant:acme-corp` itself does not match);
+  - no trailing `*` — **exact** match only; child scopes no longer match; any
+    non-trailing `*` is a literal character;
+  - non-blank filter + null event scope — **not** delivered.
+
+  **Migration:** prefix-style filters written for the old matcher, such as
+  `tenant:acme-corp` or `tenant:acme-corp/`, must be rewritten as
+  `tenant:acme-corp/*` to keep matching child scopes — without the wildcard
+  they now match only an exactly-equal event scope. Subscriptions that relied
+  on receiving **unscoped** (null-scope) events despite having a `scope_filter`
+  must drop the filter (or add a second, unfiltered subscription) to keep
+  receiving them.
+
+### Compatibility
+
+- No HTTP request/response schema, Redis data model, or Lua change. The
+  change is in event→subscription matching at delivery time only
+  (`findMatchingSubscriptions`); which subscriptions receive a given event can
+  change as described above.
+
 ## [0.1.25.48] — 2026-07-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,29 +29,56 @@ new optional request fields) are **not** considered breaking.
   authority, so the matcher now implements:
   - null/blank filter — matches every event, including null-scope events
     (unchanged);
-  - bare `*` — matches every event that **has** a scope; null-scope events are
-    excluded;
+  - bare `*` — matches every event that **has** a scope; null-scope and
+    blank-scope events are excluded;
   - trailing `*` (e.g. `tenant:acme-corp/*`) — prefix match on the filter
     minus the `*`; matches all scopes **under** the base (children only — the
-    bare base scope `tenant:acme-corp` itself does not match);
-  - no trailing `*` — **exact** match only; child scopes no longer match; any
-    non-trailing `*` is a literal character;
-  - non-blank filter + null event scope — **not** delivered.
+    bare base scope `tenant:acme-corp` does not match, nor does the degenerate
+    `tenant:acme-corp/` with an empty child segment);
+  - no trailing `*` — **exact** match only (case-sensitive); child scopes no
+    longer match; any non-trailing `*` is a literal character;
+  - non-blank filter + null **or blank** event scope — **not** delivered
+    (a blank scope is treated as unscoped).
 
-  **Migration:** prefix-style filters written for the old matcher, such as
-  `tenant:acme-corp` or `tenant:acme-corp/`, must be rewritten as
-  `tenant:acme-corp/*` to keep matching child scopes — without the wildcard
-  they now match only an exactly-equal event scope. Subscriptions that relied
-  on receiving **unscoped** (null-scope) events despite having a `scope_filter`
-  must drop the filter (or add a second, unfiltered subscription) to keep
-  receiving them.
+  **Migration:**
+  - *Descendants only:* a prefix-style filter such as `tenant:acme-corp` or
+    `tenant:acme-corp/` must be rewritten as `tenant:acme-corp/*` to keep
+    matching child scopes — without the wildcard it now matches only an
+    exactly-equal event scope.
+  - *Base scope + descendants:* the old prefix matcher **also matched the
+    exact base scope** (`tenant:acme-corp` matched an event scoped exactly
+    `tenant:acme-corp`), so migrating to `tenant:acme-corp/*` alone **drops
+    base-scope events**. A single `scope_filter` cannot express "base plus
+    descendants" — to preserve the old coverage, create **two**
+    subscriptions: one with the exact filter `tenant:acme-corp` and one with
+    the wildcard `tenant:acme-corp/*`.
+  - *Sibling prefixes:* the old character-wise matching also caught
+    lexical-sibling scopes such as `tenant:acme-corpX` or
+    `tenant:acme-corp-eu`. Those matches were accidental; anyone relying on
+    them must now add explicit filters (exact or `…/*`) for each such scope.
+  - *Unscoped events:* subscriptions that relied on receiving **unscoped**
+    (null-scope) events despite having a `scope_filter` must drop the filter
+    (or add a second, unfiltered subscription) to keep receiving them.
+
+### Fixed
+
+- **Webhook replay now honors `scope_filter`.** `POST
+  /v1/admin/webhooks/{subscription_id}/replay` queued every event in the
+  requested time range (after the request's `event_types` filter) directly to
+  the subscription, bypassing scope matching entirely — a replay could
+  deliver events the subscription would never have received live. Replay now
+  applies the same spec-conformant matcher as live dispatch
+  (`WebhookRepository.matchesScope`, exposed publicly for exactly this reuse)
+  before queuing; the replay request's `event_types` filtering behavior is
+  unchanged.
 
 ### Compatibility
 
 - No HTTP request/response schema, Redis data model, or Lua change. The
-  change is in event→subscription matching at delivery time only
-  (`findMatchingSubscriptions`); which subscriptions receive a given event can
-  change as described above.
+  changes are in event→subscription matching at delivery time
+  (`findMatchingSubscriptions`) and in replay event selection; which
+  subscriptions receive a given event (live or replayed) can change as
+  described above.
 
 ## [0.1.25.48] — 2026-07-04
 

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookService.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookService.java
@@ -296,6 +296,13 @@ public class WebhookService {
                     .filter(e -> request.getEventTypes().contains(e.getEventType()))
                     .toList();
             }
+            // Apply the subscription's scope_filter — same matcher as live
+            // dispatch (WebhookRepository.findMatchingSubscriptions), so a
+            // replay never delivers events the subscription would not have
+            // received live.
+            events = events.stream()
+                .filter(e -> WebhookRepository.matchesScope(sub, e.getScope()))
+                .toList();
             // Queue each matching event for re-delivery to this subscription
             int queued = 0;
             for (Event event : events) {

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookServiceTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookServiceTest.java
@@ -366,6 +366,142 @@ class WebhookServiceTest {
         verify(eventRepository).list(isNull(), any(), any(), any(), any(), any(), any(), any(), anyInt());
     }
 
+    // ---- replay scope_filter conformance (same matcher as live dispatch) ----
+
+    private io.runcycles.admin.model.event.Event scopedEvent(String eventId, String scope) {
+        return io.runcycles.admin.model.event.Event.builder()
+            .eventId(eventId).eventType(EventType.BUDGET_CREATED)
+            .category(io.runcycles.admin.model.event.EventCategory.BUDGET)
+            .tenantId("tenant-1").source("admin").scope(scope)
+            .timestamp(Instant.now()).build();
+    }
+
+    @Test
+    void replay_scopeFilteredSubscription_deliversOnlyMatchingScopes() {
+        WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1");
+        sub.setScopeFilter("tenant:a/*");
+        when(webhookRepository.findById("whsub_1")).thenReturn(sub);
+        when(webhookRepository.acquireReplayLock(eq("whsub_1"), any())).thenReturn(true);
+
+        io.runcycles.admin.model.event.Event matching = scopedEvent("evt_match", "tenant:a/workspace:b");
+        io.runcycles.admin.model.event.Event otherScope = scopedEvent("evt_other", "tenant:b/workspace:c");
+        io.runcycles.admin.model.event.Event unscoped = scopedEvent("evt_null", null);
+        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt()))
+            .thenReturn(List.of(matching, otherScope, unscoped));
+
+        ReplayRequest request = ReplayRequest.builder()
+            .from(Instant.now().minusSeconds(3600))
+            .to(Instant.now())
+            .build();
+
+        ReplayResponse response = webhookService.replay("whsub_1", request);
+
+        // Only the event whose scope matches the subscription's scope_filter
+        // is re-delivered; the foreign-scope and null-scope events are not.
+        assertThat(response.getEventsQueued()).isEqualTo(1);
+        verify(dispatchService).dispatchToSubscription(matching, sub);
+        verify(dispatchService, never()).dispatchToSubscription(eq(otherScope), any());
+        verify(dispatchService, never()).dispatchToSubscription(eq(unscoped), any());
+    }
+
+    @Test
+    void replay_nullScopeEvent_excludedFromScopeFilteredSubscription() {
+        WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1");
+        sub.setScopeFilter("tenant:a/workspace:b");
+        when(webhookRepository.findById("whsub_1")).thenReturn(sub);
+        when(webhookRepository.acquireReplayLock(eq("whsub_1"), any())).thenReturn(true);
+        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt()))
+            .thenReturn(List.of(scopedEvent("evt_null", null)));
+
+        ReplayRequest request = ReplayRequest.builder()
+            .from(Instant.now().minusSeconds(3600))
+            .to(Instant.now())
+            .build();
+
+        ReplayResponse response = webhookService.replay("whsub_1", request);
+
+        assertThat(response.getEventsQueued()).isEqualTo(0);
+        verify(dispatchService, never()).dispatchToSubscription(any(), any());
+    }
+
+    @Test
+    void replay_bareWildcardSubscription_deliversScopedButNotUnscopedEvents() {
+        WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1");
+        sub.setScopeFilter("*");
+        when(webhookRepository.findById("whsub_1")).thenReturn(sub);
+        when(webhookRepository.acquireReplayLock(eq("whsub_1"), any())).thenReturn(true);
+
+        io.runcycles.admin.model.event.Event scoped = scopedEvent("evt_scoped", "tenant:a/workspace:b");
+        io.runcycles.admin.model.event.Event unscoped = scopedEvent("evt_null", null);
+        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt()))
+            .thenReturn(List.of(scoped, unscoped));
+
+        ReplayRequest request = ReplayRequest.builder()
+            .from(Instant.now().minusSeconds(3600))
+            .to(Instant.now())
+            .build();
+
+        ReplayResponse response = webhookService.replay("whsub_1", request);
+
+        assertThat(response.getEventsQueued()).isEqualTo(1);
+        verify(dispatchService).dispatchToSubscription(scoped, sub);
+        verify(dispatchService, never()).dispatchToSubscription(eq(unscoped), any());
+    }
+
+    @Test
+    void replay_noScopeFilter_deliversScopedAndUnscopedEvents() {
+        WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1"); // no scope_filter
+        when(webhookRepository.findById("whsub_1")).thenReturn(sub);
+        when(webhookRepository.acquireReplayLock(eq("whsub_1"), any())).thenReturn(true);
+
+        io.runcycles.admin.model.event.Event scoped = scopedEvent("evt_scoped", "tenant:a/workspace:b");
+        io.runcycles.admin.model.event.Event unscoped = scopedEvent("evt_null", null);
+        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt()))
+            .thenReturn(List.of(scoped, unscoped));
+
+        ReplayRequest request = ReplayRequest.builder()
+            .from(Instant.now().minusSeconds(3600))
+            .to(Instant.now())
+            .build();
+
+        ReplayResponse response = webhookService.replay("whsub_1", request);
+
+        assertThat(response.getEventsQueued()).isEqualTo(2);
+        verify(dispatchService).dispatchToSubscription(scoped, sub);
+        verify(dispatchService).dispatchToSubscription(unscoped, sub);
+    }
+
+    @Test
+    void replay_scopeFilterAndEventTypeFilter_bothApply() {
+        WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1");
+        sub.setScopeFilter("tenant:a/*");
+        when(webhookRepository.findById("whsub_1")).thenReturn(sub);
+        when(webhookRepository.acquireReplayLock(eq("whsub_1"), any())).thenReturn(true);
+
+        // Matches scope but not the requested event type:
+        io.runcycles.admin.model.event.Event wrongType = io.runcycles.admin.model.event.Event.builder()
+            .eventId("evt_wrong_type").eventType(EventType.TENANT_CREATED)
+            .category(io.runcycles.admin.model.event.EventCategory.TENANT)
+            .tenantId("tenant-1").source("admin").scope("tenant:a/workspace:b")
+            .timestamp(Instant.now()).build();
+        // Matches both:
+        io.runcycles.admin.model.event.Event matchesBoth = scopedEvent("evt_both", "tenant:a/workspace:b");
+        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt()))
+            .thenReturn(List.of(wrongType, matchesBoth));
+
+        ReplayRequest request = ReplayRequest.builder()
+            .from(Instant.now().minusSeconds(3600))
+            .to(Instant.now())
+            .eventTypes(List.of(EventType.BUDGET_CREATED))
+            .build();
+
+        ReplayResponse response = webhookService.replay("whsub_1", request);
+
+        assertThat(response.getEventsQueued()).isEqualTo(1);
+        verify(dispatchService).dispatchToSubscription(matchesBoth, sub);
+        verify(dispatchService, never()).dispatchToSubscription(eq(wrongType), any());
+    }
+
     @Test
     void test_withNoSigningSecret_stillWorks() throws Exception {
         WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1");

--- a/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/WebhookRepository.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/WebhookRepository.java
@@ -337,17 +337,20 @@ public class WebhookRepository {
      *   <li>{@code null}/blank filter — matches every event, including events
      *       with a null scope (no restriction).</li>
      *   <li>Bare {@code "*"} — matches every event that <b>has</b> a scope;
-     *       null-scope events are excluded.</li>
+     *       null-scope and blank-scope events are excluded.</li>
      *   <li>Filter ending in {@code "*"} (e.g. {@code "tenant:acme-corp/*"}) —
      *       prefix match on the filter minus the trailing {@code "*"}: the
-     *       event scope must start with {@code "tenant:acme-corp/"}. The bare
-     *       base scope {@code "tenant:acme-corp"} does <b>not</b> match — the
+     *       event scope must start with {@code "tenant:acme-corp/"} <b>and</b>
+     *       carry a non-empty remainder after the prefix. The bare base scope
+     *       {@code "tenant:acme-corp"} does <b>not</b> match, nor does the
+     *       degenerate {@code "tenant:acme-corp/"} (empty child segment) — the
      *       spec says "all scopes <b>under</b> acme-corp" (children only).</li>
      *   <li>Filter without a trailing {@code "*"} — <b>exact</b> match only.
      *       Child scopes do not match. Any non-trailing {@code "*"} is a
-     *       literal character.</li>
-     *   <li>Non-blank filter + null event scope — no match: unscoped events
-     *       are not delivered to scope-filtered subscriptions.</li>
+     *       literal character. Matching is case-sensitive.</li>
+     *   <li>Non-blank filter + null or blank event scope — no match: unscoped
+     *       events are not delivered to scope-filtered subscriptions (a blank
+     *       scope is treated as unscoped).</li>
      * </ul>
      *
      * <p><b>BEHAVIOR CHANGE</b> from the previous implementation, which did
@@ -359,16 +362,22 @@ public class WebhookRepository {
      * matched nothing. Such prefix-style filters must now be written with the
      * spec wildcard form {@code "tenant:acme-corp/*"} to match child scopes.
      *
-     * <p>Package-visible (like {@link #webhookComparator}) for direct unit
-     * testing.
+     * <p>Public and static: this is the single scope_filter matcher for every
+     * delivery path — live dispatch ({@link #findMatchingSubscriptions}) and
+     * the api-module replay path ({@code WebhookService#replay}) both call it,
+     * so live and replayed deliveries cannot drift.
+     *
+     * @param sub   the subscription whose {@code scope_filter} applies
+     * @param scope the event's scope path, may be null/blank (= unscoped)
      */
-    static boolean matchesScope(WebhookSubscription sub, String scope) {
+    public static boolean matchesScope(WebhookSubscription sub, String scope) {
         String filter = sub.getScopeFilter();
         if (filter == null || filter.isBlank()) return true;
-        if (scope == null) return false;
+        if (scope == null || scope.isBlank()) return false;
         if (filter.equals("*")) return true;
         if (filter.endsWith("*")) {
-            return scope.startsWith(filter.substring(0, filter.length() - 1));
+            String prefix = filter.substring(0, filter.length() - 1);
+            return scope.length() > prefix.length() && scope.startsWith(prefix);
         }
         return scope.equals(filter);
     }

--- a/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/WebhookRepository.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/WebhookRepository.java
@@ -325,11 +325,52 @@ public class WebhookRepository {
             && (sub.getEventCategories() == null || sub.getEventCategories().isEmpty());
     }
 
-    private boolean matchesScope(WebhookSubscription sub, String scope) {
-        if (sub.getScopeFilter() == null || sub.getScopeFilter().isBlank()) return true;
-        if (scope == null) return true;
-        // Scope filter uses prefix matching (e.g., "workspace:eng" matches "workspace:eng:project1")
-        return scope.startsWith(sub.getScopeFilter()) || sub.getScopeFilter().equals("*");
+    /**
+     * Spec-conformant {@code scope_filter} matcher. The admin OpenAPI spec
+     * (WebhookCreateRequest/WebhookUpdateRequest {@code scope_filter}) is the
+     * authority: <i>"Optional scope pattern to narrow event matching. Supports
+     * wildcards: "tenant:acme-corp/*" matches all scopes under acme-corp. If
+     * omitted, matches all scopes within the tenant."</i>
+     *
+     * <p>Semantics:
+     * <ul>
+     *   <li>{@code null}/blank filter — matches every event, including events
+     *       with a null scope (no restriction).</li>
+     *   <li>Bare {@code "*"} — matches every event that <b>has</b> a scope;
+     *       null-scope events are excluded.</li>
+     *   <li>Filter ending in {@code "*"} (e.g. {@code "tenant:acme-corp/*"}) —
+     *       prefix match on the filter minus the trailing {@code "*"}: the
+     *       event scope must start with {@code "tenant:acme-corp/"}. The bare
+     *       base scope {@code "tenant:acme-corp"} does <b>not</b> match — the
+     *       spec says "all scopes <b>under</b> acme-corp" (children only).</li>
+     *   <li>Filter without a trailing {@code "*"} — <b>exact</b> match only.
+     *       Child scopes do not match. Any non-trailing {@code "*"} is a
+     *       literal character.</li>
+     *   <li>Non-blank filter + null event scope — no match: unscoped events
+     *       are not delivered to scope-filtered subscriptions.</li>
+     * </ul>
+     *
+     * <p><b>BEHAVIOR CHANGE</b> from the previous implementation, which did
+     * literal prefix matching ({@code scope.startsWith(filter)}) and matched
+     * every filter when the event scope was null. Under the old matcher a
+     * filter like {@code "tenant:acme-corp"} also matched
+     * {@code "tenant:acme-corp/workspace:prod"} (and even
+     * {@code "tenant:acme-corpX"}), while a spec-style {@code "tenant:acme-corp/*"}
+     * matched nothing. Such prefix-style filters must now be written with the
+     * spec wildcard form {@code "tenant:acme-corp/*"} to match child scopes.
+     *
+     * <p>Package-visible (like {@link #webhookComparator}) for direct unit
+     * testing.
+     */
+    static boolean matchesScope(WebhookSubscription sub, String scope) {
+        String filter = sub.getScopeFilter();
+        if (filter == null || filter.isBlank()) return true;
+        if (scope == null) return false;
+        if (filter.equals("*")) return true;
+        if (filter.endsWith("*")) {
+            return scope.startsWith(filter.substring(0, filter.length() - 1));
+        }
+        return scope.equals(filter);
     }
 
     private List<WebhookSubscription> listFromSet(String setKey, String status, String eventType,

--- a/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/WebhookRepositoryTest.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/WebhookRepositoryTest.java
@@ -578,6 +578,48 @@ class WebhookRepositoryTest {
     }
 
     @Test
+    void matchesScope_bareWildcard_excludesBlankScope() {
+        // A blank scope is treated as unscoped — even the bare "*" wildcard
+        // (which requires the event to HAVE a scope) must not match it.
+        assertThat(WebhookRepository.matchesScope(withFilter("*"), "")).isFalse();
+        assertThat(WebhookRepository.matchesScope(withFilter("*"), "   ")).isFalse();
+    }
+
+    @Test
+    void matchesScope_nonBlankFilter_excludesBlankScope() {
+        assertThat(WebhookRepository.matchesScope(withFilter("tenant:a"), "")).isFalse();
+        assertThat(WebhookRepository.matchesScope(withFilter("tenant:a/*"), "")).isFalse();
+    }
+
+    @Test
+    void matchesScope_trailingWildcard_excludesEmptyChildSegment() {
+        // "tenant:a/*" means children UNDER tenant:a — the degenerate scope
+        // "tenant:a/" (prefix with nothing after it) is not a child.
+        assertThat(WebhookRepository.matchesScope(withFilter("tenant:a/*"), "tenant:a/")).isFalse();
+    }
+
+    @Test
+    void matchesScope_slashStarFilter_requiresNonEmptyRemainder() {
+        assertThat(WebhookRepository.matchesScope(withFilter("/*"), "/")).isFalse();
+        assertThat(WebhookRepository.matchesScope(withFilter("/*"), "/x")).isTrue();
+    }
+
+    @Test
+    void matchesScope_trailingSlashNoStar_isExactMatchOnly() {
+        assertThat(WebhookRepository.matchesScope(withFilter("tenant:a/"), "tenant:a/")).isTrue();
+        assertThat(WebhookRepository.matchesScope(withFilter("tenant:a/"), "tenant:a/workspace:b")).isFalse();
+        assertThat(WebhookRepository.matchesScope(withFilter("tenant:a/"), "tenant:a")).isFalse();
+    }
+
+    @Test
+    void matchesScope_isCaseSensitive() {
+        assertThat(WebhookRepository.matchesScope(
+            withFilter("tenant:A/*"), "tenant:a/workspace:b")).isFalse();
+        assertThat(WebhookRepository.matchesScope(
+            withFilter("tenant:a"), "Tenant:a")).isFalse();
+    }
+
+    @Test
     void listByTenant_withCursor_skipsIdsUpToCursor() throws Exception {
         Set<String> ids = new LinkedHashSet<>(List.of("whsub_1", "whsub_2", "whsub_3"));
         when(jedis.smembers("webhooks:tenant-1")).thenReturn(ids);

--- a/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/WebhookRepositoryTest.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/WebhookRepositoryTest.java
@@ -324,11 +324,12 @@ class WebhookRepositoryTest {
         when(jedis.smembers("webhooks:tenant-1")).thenReturn(tenantIds);
         when(jedis.smembers("webhooks:__system__")).thenReturn(Set.of());
 
+        // Spec wildcard form: "org/eng/*" matches all scopes under org/eng.
         WebhookSubscription sub = WebhookSubscription.builder()
                 .subscriptionId("whsub_1").tenantId("tenant-1").url("https://a.com")
                 .status(WebhookStatus.ACTIVE)
                 .eventTypes(List.of(EventType.BUDGET_CREATED))
-                .scopeFilter("org/eng")
+                .scopeFilter("org/eng/*")
                 .createdAt(Instant.now()).consecutiveFailures(0).build();
         String subJson = objectMapper.writeValueAsString(sub);
         when(jedis.get("webhook:whsub_1")).thenReturn(subJson);
@@ -446,7 +447,7 @@ class WebhookRepositoryTest {
     }
 
     @Test
-    void findMatchingSubscriptions_nullScopeWithScopeFilter_matches() throws Exception {
+    void findMatchingSubscriptions_nullScopeWithScopeFilter_excluded() throws Exception {
         Set<String> tenantIds = new LinkedHashSet<>(List.of("whsub_1"));
         when(jedis.smembers("webhooks:tenant-1")).thenReturn(tenantIds);
         when(jedis.smembers("webhooks:__system__")).thenReturn(Set.of());
@@ -460,10 +461,11 @@ class WebhookRepositoryTest {
         String subJson = objectMapper.writeValueAsString(sub);
         when(jedis.get("webhook:whsub_1")).thenReturn(subJson);
 
-        // null scope should match (matchesScope returns true when scope is null)
+        // Spec semantics: an event with a null scope is NOT delivered to a
+        // subscription with a non-blank scope_filter.
         List<WebhookSubscription> result = repository.findMatchingSubscriptions("tenant-1", EventType.BUDGET_CREATED, null);
 
-        assertThat(result).hasSize(1);
+        assertThat(result).isEmpty();
     }
 
     @Test
@@ -484,6 +486,95 @@ class WebhookRepositoryTest {
         List<WebhookSubscription> result = repository.findMatchingSubscriptions("tenant-1", EventType.BUDGET_CREATED, "any/scope");
 
         assertThat(result).hasSize(1);
+    }
+
+    // ---- matchesScope (spec scope_filter wildcard semantics) ----
+    // Spec authority (admin OpenAPI, WebhookCreateRequest.scope_filter):
+    // "Optional scope pattern to narrow event matching. Supports wildcards:
+    //  \"tenant:acme-corp/*\" matches all scopes under acme-corp. If omitted,
+    //  matches all scopes within the tenant."
+
+    private static WebhookSubscription withFilter(String scopeFilter) {
+        return WebhookSubscription.builder().scopeFilter(scopeFilter).build();
+    }
+
+    @Test
+    void matchesScope_nullFilter_matchesScopedAndNullScope() {
+        assertThat(WebhookRepository.matchesScope(withFilter(null), "tenant:a/workspace:b")).isTrue();
+        assertThat(WebhookRepository.matchesScope(withFilter(null), null)).isTrue();
+    }
+
+    @Test
+    void matchesScope_blankFilter_matchesScopedAndNullScope() {
+        assertThat(WebhookRepository.matchesScope(withFilter("   "), "tenant:a/workspace:b")).isTrue();
+        assertThat(WebhookRepository.matchesScope(withFilter(""), null)).isTrue();
+    }
+
+    @Test
+    void matchesScope_bareWildcard_matchesAnyScopedEvent() {
+        assertThat(WebhookRepository.matchesScope(withFilter("*"), "tenant:a")).isTrue();
+        assertThat(WebhookRepository.matchesScope(withFilter("*"), "tenant:a/workspace:b/agent:c")).isTrue();
+    }
+
+    @Test
+    void matchesScope_bareWildcard_excludesNullScope() {
+        assertThat(WebhookRepository.matchesScope(withFilter("*"), null)).isFalse();
+    }
+
+    @Test
+    void matchesScope_trailingWildcard_matchesChildScopes() {
+        assertThat(WebhookRepository.matchesScope(withFilter("tenant:a/*"), "tenant:a/workspace:b")).isTrue();
+        assertThat(WebhookRepository.matchesScope(withFilter("tenant:a/*"), "tenant:a/workspace:b/agent:c")).isTrue();
+    }
+
+    @Test
+    void matchesScope_trailingWildcard_excludesExactBaseScope() {
+        // Spec: "tenant:acme-corp/*" matches all scopes UNDER acme-corp —
+        // children only; the bare base scope itself does not match.
+        assertThat(WebhookRepository.matchesScope(withFilter("tenant:a/*"), "tenant:a")).isFalse();
+    }
+
+    @Test
+    void matchesScope_trailingWildcard_excludesSiblingWithSharedPrefix() {
+        assertThat(WebhookRepository.matchesScope(withFilter("tenant:a/*"), "tenant:aX")).isFalse();
+        assertThat(WebhookRepository.matchesScope(withFilter("tenant:a/*"), "tenant:aX/workspace:b")).isFalse();
+    }
+
+    @Test
+    void matchesScope_trailingWildcard_excludesNullScope() {
+        assertThat(WebhookRepository.matchesScope(withFilter("tenant:a/*"), null)).isFalse();
+    }
+
+    @Test
+    void matchesScope_exactFilter_matchesOnlyExactScope() {
+        assertThat(WebhookRepository.matchesScope(
+            withFilter("tenant:a/workspace:b"), "tenant:a/workspace:b")).isTrue();
+        // No wildcard = exact match: child scopes do NOT match (old prefix
+        // behavior would have matched both of these).
+        assertThat(WebhookRepository.matchesScope(
+            withFilter("tenant:a/workspace:b"), "tenant:a/workspace:b/agent:c")).isFalse();
+        assertThat(WebhookRepository.matchesScope(
+            withFilter("tenant:a/workspace:b"), "tenant:a/workspace:bX")).isFalse();
+    }
+
+    @Test
+    void matchesScope_exactFilter_excludesNullScope() {
+        assertThat(WebhookRepository.matchesScope(withFilter("tenant:a"), null)).isFalse();
+    }
+
+    @Test
+    void matchesScope_midStringWildcard_isLiteralNotWildcard() {
+        // "*" is only meaningful at the end of the filter; elsewhere it is a
+        // literal character in an exact-match comparison.
+        assertThat(WebhookRepository.matchesScope(
+            withFilter("tenant:*/workspace:b"), "tenant:a/workspace:b")).isFalse();
+        assertThat(WebhookRepository.matchesScope(
+            withFilter("tenant:*/workspace:b"), "tenant:*/workspace:b")).isTrue();
+        // Mid-string "*" stays literal even when the filter also ends in "*".
+        assertThat(WebhookRepository.matchesScope(
+            withFilter("tenant:*/ws:*"), "tenant:*/ws:prod")).isTrue();
+        assertThat(WebhookRepository.matchesScope(
+            withFilter("tenant:*/ws:*"), "tenant:a/ws:prod")).isFalse();
     }
 
     @Test

--- a/docker-compose.full-stack.yml
+++ b/docker-compose.full-stack.yml
@@ -77,7 +77,7 @@ services:
       REDIS_PASSWORD: ""
       WEBHOOK_SECRET_ENCRYPTION_KEY: ${WEBHOOK_SECRET_ENCRYPTION_KEY:-}
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:7980/actuator/health"]
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:9980/actuator/health"]
       interval: 10s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary

**BEHAVIOR CHANGE**: brings webhook `scope_filter` matching to the admin spec's documented semantics, and applies the filter on the replay path (which previously bypassed it entirely).

The spec (`cycles-governance-admin`, scope_filter description) documents wildcard semantics: `"tenant:acme-corp/*" matches all scopes under acme-corp`. The matcher instead did literal prefix matching with null-scope pass-through — so `/*` filters matched nothing, bare filters matched siblings (`tenant:acme-corpX`), and unscoped events were delivered to every filtered subscription. Specs are authority (project rule); the matcher now implements: exact match by default, trailing-`*` prefix match (children only, non-empty child segment), bare `*` = any scoped event, blank/null scope = unscoped (excluded from filtered subscriptions).

## Migration (see CHANGELOG)

- `tenant:acme-corp` (old prefix behavior) → `tenant:acme-corp/*` for descendants; base + descendants requires an exact plus a wildcard subscription (a single filter cannot express both)
- Accidental sibling-prefix matches now require explicit filters
- Unscoped events are no longer delivered to scope-filtered subscriptions
- Replay now honors `scope_filter` (previously delivered everything the event_types filter passed)

## Verification

- 11 matcher unit tests + 6 edge-case tests (blank scope, empty child segment, `/*`, trailing-slash-no-star, case sensitivity) + 5 replay tests
- Full reactor: **802 tests, 0 failures**; JaCoCo gates met (data 95.52% line, WebhookRepository 98.39%, api 95.39%)
- Codex external review: 2 rounds (REVISE-MINOR → SHIP); round 1 caught the blank-scope edges and the replay bypass
- Spec description fetched live from cycles-protocol@main and quoted in AUDIT.md

Companion docs update: runcycles/cycles-docs#785 (scope-filter page documents both semantics, scoped to release versions). Surfaced by the cycles-docs integration audit.
