### PR TITLE
Security: tenant webhook event_categories boundary + match-ALL update guard (v0.1.25.50)

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,4 +1,4 @@
-# Complete Budget Governance v0.1.25.49 — Admin Server Audit
+# Complete Budget Governance v0.1.25.50 — Admin Server Audit
 
 **Spec:**
 [`cycles-governance-admin-v0.1.25.yaml`](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml)
@@ -32,6 +32,70 @@ documentation-only on an open string field) in
 pin (SB 3.5.15 still manages 3.17.0) · tomcat-embed-core 10.1.55 pin
 (re-introduced 2026-05-25 for Apache Tomcat CVE-2026-43512 / -43513 / -43514 /
 -43515 / -42498 / -41284 / -41293)
+
+### 2026-07-10 — v0.1.25.50: tenant webhook event_categories boundary + match-ALL update guard (security)
+
+Confirmed authorization gap on the tenant webhook plane.
+`WebhookTenantController.validateTenantEventTypes` enforces the
+tenant-accessible boundary (budget.*/reservation.*/tenant.*) on
+`event_types` for create and update, but `event_categories` was never
+validated on that plane — and `WebhookRepository.matchesEventType`
+treats categories as an ADDITIVE union with types. Exploit: a tenant
+API key creates (or PATCHes) a subscription with one allowed
+`event_type` plus `"event_categories": ["api_key"]` (or policy /
+webhook / system) and receives admin-only event classes for its tenant
+— API-key lifecycle, policy changes, webhook lifecycle, system events.
+Governance spec revision v0.1.25.38 (pending, prepared in parallel)
+adds the normative rule: tenant-plane create AND update MUST validate
+event_categories against the same boundary, 400 INVALID_REQUEST.
+
+Fix and decisions:
+- New `validateTenantEventCategories` alongside the event_types check,
+  applied on BOTH create and update. The boundary is derived from a new
+  `EventCategory.isTenantAccessible()` (BUDGET/RESERVATION/TENANT) and
+  `EventType.isTenantAccessible()` now DELEGATES to it — one source of
+  truth, the type-level and category-level checks cannot drift.
+- **Admin-on-behalf-of decision:** the check runs unconditionally on
+  the tenant-plane endpoints, admin callers included — exactly how
+  `validateTenantEventTypes` already behaves on the dual-auth PATCH
+  path (create is tenant-key-only by design, spec v0.1.25.14). The
+  boundary belongs to the ENDPOINT, not the caller: admin-provisioned
+  subscriptions with admin categories are minted and managed on
+  `/v1/admin/webhooks/*`, and letting admin PATCH admin categories
+  onto a tenant-plane subscription would recreate the smuggle with
+  extra steps (tenant retains the endpoint + signing secret).
+- **Empty-both edge (verified reachable, guarded):** create requires
+  `@NotEmpty event_types`, but `WebhookService.update` applied
+  `"event_types": []` verbatim; with no categories the result matched
+  `matchesEventType`'s empty-both branch = match-ALL — every event
+  class, on either plane, admin-only included. Update now 400s when a
+  PATCH would leave both `event_types` and `event_categories` empty
+  ("Subscription must retain at least one event_type or
+  event_category"), on both planes: a match-all subscription is not
+  creatable, so it must not be reachable by update. Category-only
+  subscriptions (clear types, keep categories) remain legal. Legacy
+  empty-both rows (only producible via the old update bug) now 400 on
+  any PATCH until the request re-establishes at least one event field —
+  deliberate: such a row is a match-all landmine and must be repaired,
+  not silently carried forward.
+- The events-list plane already had a category boundary
+  (`EventTenantController.TENANT_ACCESSIBLE_CATEGORIES`, string-based);
+  webhooks lacked it. Left the events-list implementation untouched
+  (raw query-param handling differs); the enum method is now the
+  canonical boundary for typed call sites.
+
+Operator follow-up (also in CHANGELOG): audit existing tenant-plane
+subscriptions on <=0.1.25.49 for admin-only categories; recipe in the
+CHANGELOG security note.
+
+Tests: controller — smuggle on create -> 400 (service never called),
+smuggle on update -> 400, admin-on-behalf-of PATCH with admin category
+-> 400 (endpoint-bound boundary pinned), tenant-accessible categories
+pass on create (all three) and update; service — clearing event_types
+with no categories -> 400, clearing both in one PATCH -> 400,
+category-only survivor -> allowed; pure admin-plane
+`/v1/admin/webhooks` endpoints unaffected (no new validation there;
+existing suite green). Version/revision 0.1.25.49 -> 0.1.25.50.
 
 ### 2026-07-10 — spec-alignment declaration corrected to governance v0.1.25.37 (docs only; no behavior change)
 

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -85,8 +85,36 @@ Fix and decisions:
   canonical boundary for typed call sites.
 
 Operator follow-up (also in CHANGELOG): audit existing tenant-plane
-subscriptions on <=0.1.25.49 for admin-only categories; recipe in the
-CHANGELOG security note.
+subscriptions on <=0.1.25.49 for admin-only categories AND legacy
+empty-both match-all rows; single copy-pasteable recipe in the
+CHANGELOG security note (scans only `webhook:whsub_*` subscription
+keys - not `webhook:secret:*` / `webhooks:*` - and tolerates non-JSON
+values via `fromjson?`; flags ADMIN_CATEGORIES and MATCH_ALL rows).
+
+Codex security round 2 (REVISE-MINOR; core fix confirmed sound - no
+bypass routes, boundary derivation correct, unknown/mixed-case enum
+values already 400 at Jackson binding, delivery-time enforcement
+correctly rejected as it would break legit admin-created rows):
+- Operator recipe corrected (the original `webhook:*` scan also
+  matched encrypted `webhook:secret:*` values and broke the jq
+  pipeline; it also missed the empty-both match-all class). Recipe
+  logic re-verified against the stored JSON shape (event_categories is
+  NON_NULL - absent when null, `[]` when empty; event_types always
+  serialized) and the key layout before writing.
+- Tests added: admin-plane create/update WITH admin-only categories
+  still 201/200 (proves the boundary is tenant-plane-only, not a
+  global tightening); exhaustive EventCategory.isTenantAccessible()
+  over all enum values + every EventType delegating to its category
+  (future-drift guard); category-only repair path (clear
+  event_categories to [] with event_types omitted -> survives).
+- Open question (recorded decision, no code change): a tenant-plane
+  PATCH on a legacy/admin-created row that already holds admin-only
+  categories validates only the PROVIDED arrays, so a tenant could
+  keep pre-existing admin categories by PATCHing an unrelated field.
+  Current behavior matches the spec (validate the request, not the
+  stored state); a tenant taking over an admin-created tenant-scoped
+  subscription is a separate provenance/ownership threat model, out of
+  scope for this patch. Not expanded here.
 
 Tests: controller — smuggle on create -> 400 (service never called),
 smuggle on update -> 400, admin-on-behalf-of PATCH with admin category

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,14 +35,37 @@ new optional request fields) are **not** considered breaking.
 
   **Operator note — audit existing subscriptions:** on 0.1.25.49 and
   earlier, tenant-created subscriptions may already carry admin-only
-  categories. Audit tenant-plane subscriptions and strip/delete offenders,
-  e.g. against your Redis store:
-  `redis-cli --scan --pattern 'webhook:*' | xargs -L1 redis-cli GET | jq -r
-  'select(.event_categories != null) | select(.event_categories - ["budget","reservation","tenant"] | length > 0) | .subscription_id + " " + .tenant_id + " " + (.event_categories|tostring)'`
-  (subscriptions created via `/v1/admin/webhooks` by operators are
-  legitimate carriers of admin categories — check `tenant_id` provenance
-  against your admin-provisioned list, or the `createTenantWebhook` audit
-  log entries.)
+  categories, and a legacy PATCH could also leave a subscription with
+  **both** `event_types` and `event_categories` empty, which matches
+  **every** event class (delivery-side wildcard). Both classes are still
+  deliverable until repaired. This single pass flags both — it scans only
+  subscription keys (`webhook:whsub_*`; secrets live under
+  `webhook:secret:*` and indexes under `webhooks:*`, neither of which
+  matches) and tolerates any non-JSON value via `fromjson?`:
+
+  ```bash
+  redis-cli --scan --pattern 'webhook:whsub_*' \
+    | while read -r k; do redis-cli GET "$k"; done \
+    | jq -rR 'fromjson? // empty
+        | (.event_categories // []) as $cats
+        | (.event_types // []) as $types
+        | ($cats - ["budget","reservation","tenant"]) as $admin
+        | if ($admin | length) > 0 then
+            "ADMIN_CATEGORIES \(.subscription_id) \(.tenant_id) \($admin)"
+          elif ($types | length) == 0 and ($cats | length) == 0 then
+            "MATCH_ALL \(.subscription_id) \(.tenant_id)"
+          else empty end'
+  ```
+
+  `ADMIN_CATEGORIES` rows carry admin-only categories; `MATCH_ALL` rows are
+  the empty-both wildcards. Repair each with a `PATCH /v1/webhooks/{id}`
+  that sets a valid `event_types`/`event_categories` (this release rejects
+  the offending shapes), or delete it. Subscriptions created via
+  `/v1/admin/webhooks` by operators are legitimate carriers of admin
+  categories — check `tenant_id` provenance against your admin-provisioned
+  list, or the `createTenantWebhook` (tenant-plane) vs
+  `createWebhookSubscription` (admin-plane) audit-log entries — before
+  repairing an `ADMIN_CATEGORIES` hit.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,47 @@ changes to request/response bodies or Lua-script semantics would require a
 minor bump. Additive fields (new optional response fields, new enum values,
 new optional request fields) are **not** considered breaking.
 
+## [0.1.25.50] — 2026-07-10
+
+### Security
+
+- **Tenant-plane webhook `event_categories` are now validated against the
+  tenant-accessible boundary.** `POST /v1/webhooks` and
+  `PATCH /v1/webhooks/{id}` validated `event_types` (budget.*,
+  reservation.*, tenant.* only) but never `event_categories` — and event
+  matching treats categories as an ADDITIVE union with types. A tenant API
+  key could therefore create or update a subscription with one allowed
+  `event_type` plus an admin-only category (`api_key`, `policy`, `webhook`,
+  `system`) and receive admin-only event classes for its tenant (e.g.
+  `api_key.created` payloads). Both paths now reject admin-only categories
+  with 400 `INVALID_REQUEST`, same message style as the `event_types` check
+  (governance spec revision v0.1.25.38, pending). The boundary applies to
+  the tenant-plane endpoint regardless of caller — admin-on-behalf-of PATCH
+  included — matching the existing `event_types` behavior; admin categories
+  belong on `/v1/admin/webhooks/*`.
+
+  **Operator note — audit existing subscriptions:** on 0.1.25.49 and
+  earlier, tenant-created subscriptions may already carry admin-only
+  categories. Audit tenant-plane subscriptions and strip/delete offenders,
+  e.g. against your Redis store:
+  `redis-cli --scan --pattern 'webhook:*' | xargs -L1 redis-cli GET | jq -r
+  'select(.event_categories != null) | select(.event_categories - ["budget","reservation","tenant"] | length > 0) | .subscription_id + " " + .tenant_id + " " + (.event_categories|tostring)'`
+  (subscriptions created via `/v1/admin/webhooks` by operators are
+  legitimate carriers of admin categories — check `tenant_id` provenance
+  against your admin-provisioned list, or the `createTenantWebhook` audit
+  log entries.)
+
+### Fixed
+
+- **PATCH can no longer produce a match-ALL subscription.** Create requires
+  a non-empty `event_types`, but update accepted `"event_types": []` — and
+  a subscription with BOTH `event_types` and `event_categories` empty
+  matches every event class (delivery-side wildcard). Update now returns
+  400 `INVALID_REQUEST` ("Subscription must retain at least one event_type
+  or event_category") on both the tenant and admin planes when a PATCH
+  would leave both empty. Category-only subscriptions (clearing
+  `event_types` while categories remain) are still legal.
+
 ## [0.1.25.49] — 2026-07-10
 
 ### Changed

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/WebhookTenantController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/WebhookTenantController.java
@@ -40,6 +40,7 @@ public class WebhookTenantController {
             @Valid @RequestBody WebhookCreateRequest request, HttpServletRequest httpRequest) {
         String tenantId = getAuthenticatedTenantId(httpRequest);
         validateTenantEventTypes(request.getEventTypes());
+        validateTenantEventCategories(request.getEventCategories());
         mutationGuard.assertTenantOpen(tenantId);
         WebhookCreateResponse response = webhookService.create(tenantId, request);
         auditRepository.log(buildAuditEntry(httpRequest)
@@ -100,6 +101,9 @@ public class WebhookTenantController {
         enforceTenantOwnership(httpRequest, existing);
         if (request.getEventTypes() != null) {
             validateTenantEventTypes(request.getEventTypes());
+        }
+        if (request.getEventCategories() != null) {
+            validateTenantEventCategories(request.getEventCategories());
         }
         // Spec v0.1.25.29 Rule 2: any mutation on a webhook owned by a CLOSED
         // tenant returns 409 TENANT_CLOSED. This is the layer that makes
@@ -228,6 +232,32 @@ public class WebhookTenantController {
             if (!type.isTenantAccessible()) {
                 throw new GovernanceException(ErrorCode.INVALID_REQUEST,
                     "Event type " + type.getValue() + " is admin-only; tenants can subscribe to budget.*, reservation.*, tenant.* only", 400);
+            }
+        }
+    }
+
+    /**
+     * Tenant-plane {@code event_categories} boundary (governance revision
+     * v0.1.25.38): {@code WebhookRepository.matchesEventType} treats
+     * categories as an ADDITIVE union with {@code event_types}, so an
+     * unvalidated category smuggles admin-only event classes past
+     * {@link #validateTenantEventTypes} (e.g. one allowed event_type plus
+     * {@code "event_categories": ["api_key"]}). Same boundary, same 400,
+     * derived from the same source ({@code EventCategory.isTenantAccessible},
+     * which {@code EventType.isTenantAccessible} delegates to).
+     *
+     * <p>Like {@link #validateTenantEventTypes}, this runs unconditionally on
+     * the tenant-plane paths — including admin-on-behalf-of PATCH through
+     * {@code /v1/webhooks/*}: the boundary belongs to the ENDPOINT, not the
+     * caller. Admin-provisioned subscriptions with admin categories are
+     * created and managed via {@code /v1/admin/webhooks/*}.
+     */
+    private void validateTenantEventCategories(List<io.runcycles.admin.model.event.EventCategory> eventCategories) {
+        if (eventCategories == null) return;
+        for (io.runcycles.admin.model.event.EventCategory category : eventCategories) {
+            if (!category.isTenantAccessible()) {
+                throw new GovernanceException(ErrorCode.INVALID_REQUEST,
+                    "Event category " + category.getValue() + " is admin-only; tenants can subscribe to budget.*, reservation.*, tenant.* only", 400);
             }
         }
     }

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookService.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookService.java
@@ -107,6 +107,22 @@ public class WebhookService {
         if (request.getDescription() != null) existing.setDescription(request.getDescription());
         if (request.getEventTypes() != null) existing.setEventTypes(request.getEventTypes());
         if (request.getEventCategories() != null) existing.setEventCategories(request.getEventCategories());
+        // A subscription must always name at least one event_type or
+        // event_category. Create enforces @NotEmpty event_types, but PATCH
+        // could previously clear event_types to [] with no categories -
+        // and WebhookRepository.matchesEventType treats empty-both as
+        // match-ALL, which would silently subscribe to every event class
+        // (on the tenant plane that bypasses the admin-only boundary
+        // entirely). Guard the only path that could produce it, on BOTH
+        // planes: match-all subscriptions are not creatable, so they must
+        // not be reachable by update either. (governance revision
+        // v0.1.25.38)
+        boolean noEventTypes = existing.getEventTypes() == null || existing.getEventTypes().isEmpty();
+        boolean noEventCategories = existing.getEventCategories() == null || existing.getEventCategories().isEmpty();
+        if (noEventTypes && noEventCategories) {
+            throw new GovernanceException(ErrorCode.INVALID_REQUEST,
+                "Subscription must retain at least one event_type or event_category", 400);
+        }
         if (request.getScopeFilter() != null) existing.setScopeFilter(request.getScopeFilter());
         if (request.getThresholds() != null) existing.setThresholds(request.getThresholds());
         if (request.getSigningSecret() != null) existing.setSigningSecret(request.getSigningSecret());

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookAdminControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookAdminControllerTest.java
@@ -10,6 +10,7 @@ import io.runcycles.admin.data.repository.AuditRepository;
 import io.runcycles.admin.data.repository.ApiKeyRepository;
 import io.runcycles.admin.data.repository.WebhookRepository;
 import io.runcycles.admin.model.event.Actor;
+import io.runcycles.admin.model.event.EventCategory;
 import io.runcycles.admin.model.event.EventType;
 import io.runcycles.admin.model.shared.ErrorCode;
 import io.runcycles.admin.model.shared.SortDirection;
@@ -144,6 +145,53 @@ class WebhookAdminControllerTest {
                 "updateWebhookSubscription".equals(entry.getOperation()) &&
                 "tenant-1".equals(entry.getTenantId()) &&
                 entry.getStatus() == 200));
+    }
+
+    // v0.1.25.50: the tenant-plane event_categories boundary is NOT a global
+    // tightening — the admin plane (/v1/admin/webhooks) may create/update
+    // subscriptions with admin-only categories. Proves the boundary is
+    // scoped to the tenant endpoint, not applied to every WebhookService call.
+    @Test
+    void createWebhook_withAdminOnlyEventCategory_returns201() throws Exception {
+        WebhookSubscription sub = WebhookSubscription.builder()
+            .subscriptionId("whsub_admincat").tenantId("tenant-1").url("https://example.com/wh")
+            .eventTypes(List.of(EventType.BUDGET_CREATED))
+            .eventCategories(List.of(EventCategory.API_KEY)).status(WebhookStatus.ACTIVE)
+            .createdAt(Instant.now()).build();
+        WebhookCreateResponse response = WebhookCreateResponse.builder()
+            .subscription(sub).signingSecret("whsec_abc").build();
+        when(webhookService.create(eq("tenant-1"), any())).thenReturn(response);
+
+        mockMvc.perform(post("/v1/admin/webhooks")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .param("tenant_id", "tenant-1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"url\":\"https://example.com/wh\",\"event_types\":[\"budget.created\"],\"event_categories\":[\"api_key\"]}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.subscription.subscription_id").value("whsub_admincat"));
+
+        verify(webhookService).create(eq("tenant-1"), any());
+    }
+
+    @Test
+    void updateWebhook_withAdminOnlyEventCategory_returns200() throws Exception {
+        WebhookSubscription prior = WebhookSubscription.builder()
+            .subscriptionId("whsub_1").tenantId("tenant-1").url("https://example.com/wh")
+            .status(WebhookStatus.ACTIVE).createdAt(Instant.now()).build();
+        WebhookSubscription updated = WebhookSubscription.builder()
+            .subscriptionId("whsub_1").tenantId("tenant-1").url("https://example.com/wh")
+            .eventCategories(List.of(EventCategory.SYSTEM)).status(WebhookStatus.ACTIVE)
+            .createdAt(Instant.now()).build();
+        when(webhookService.get("whsub_1")).thenReturn(prior);
+        when(webhookService.update(eq("whsub_1"), any())).thenReturn(updated);
+
+        mockMvc.perform(patch("/v1/admin/webhooks/whsub_1")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"event_categories\":[\"system\"]}"))
+                .andExpect(status().isOk());
+
+        verify(webhookService).update(eq("whsub_1"), any());
     }
 
     @Test

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookTenantControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookTenantControllerTest.java
@@ -85,6 +85,44 @@ class WebhookTenantControllerTest {
                 .andExpect(jsonPath("$.error").value("INVALID_REQUEST"));
     }
 
+    // v0.1.25.50 (governance revision v0.1.25.38): event_categories must pass
+    // the same tenant-accessible boundary as event_types on the tenant plane.
+    // matchesEventType treats categories as an ADDITIVE union, so before this
+    // check a tenant could smuggle admin-only event classes with one allowed
+    // event_type plus an admin category.
+    @Test
+    void createWebhook_withAdminOnlyEventCategory_returns400() throws Exception {
+        setupApiKeyAuth();
+
+        mockMvc.perform(post("/v1/webhooks")
+                        .header("X-Cycles-API-Key", "valid-api-key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"url\":\"https://example.com/wh\",\"event_types\":[\"budget.created\"],\"event_categories\":[\"api_key\"]}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("INVALID_REQUEST"));
+
+        verify(webhookService, never()).create(anyString(), any());
+    }
+
+    @Test
+    void createWebhook_withTenantAccessibleEventCategories_returns201() throws Exception {
+        setupApiKeyAuth();
+        WebhookSubscription sub = WebhookSubscription.builder()
+            .subscriptionId("whsub_cat").tenantId("tenant-1").url("https://example.com/wh")
+            .eventTypes(List.of(EventType.BUDGET_CREATED)).status(WebhookStatus.ACTIVE)
+            .createdAt(Instant.now()).build();
+        WebhookCreateResponse response = WebhookCreateResponse.builder()
+            .subscription(sub).signingSecret("whsec_abc").build();
+        when(webhookService.create(eq("tenant-1"), any())).thenReturn(response);
+
+        mockMvc.perform(post("/v1/webhooks")
+                        .header("X-Cycles-API-Key", "valid-api-key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"url\":\"https://example.com/wh\",\"event_types\":[\"budget.created\"],\"event_categories\":[\"budget\",\"reservation\",\"tenant\"]}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.subscription.subscription_id").value("whsub_cat"));
+    }
+
     @Test
     void getWebhook_ownWebhook_returns200() throws Exception {
         setupApiKeyAuth();
@@ -221,6 +259,61 @@ class WebhookTenantControllerTest {
                         .content("{\"event_types\":[\"api_key.created\"]}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error").value("INVALID_REQUEST"));
+    }
+
+    @Test
+    void updateWebhook_withAdminOnlyEventCategory_returns400() throws Exception {
+        setupApiKeyAuth();
+        WebhookSubscription sub = WebhookSubscription.builder()
+            .subscriptionId("whsub_1").tenantId("tenant-1").url("https://example.com/wh")
+            .status(WebhookStatus.ACTIVE).createdAt(Instant.now()).build();
+        when(webhookService.get("whsub_1")).thenReturn(sub);
+
+        mockMvc.perform(patch("/v1/webhooks/whsub_1")
+                        .header("X-Cycles-API-Key", "valid-api-key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"event_categories\":[\"policy\"]}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("INVALID_REQUEST"));
+
+        verify(webhookService, never()).update(anyString(), any());
+    }
+
+    @Test
+    void updateWebhook_withTenantAccessibleEventCategory_returns200() throws Exception {
+        setupApiKeyAuth();
+        WebhookSubscription sub = WebhookSubscription.builder()
+            .subscriptionId("whsub_1").tenantId("tenant-1").url("https://example.com/wh")
+            .status(WebhookStatus.ACTIVE).createdAt(Instant.now()).build();
+        when(webhookService.get("whsub_1")).thenReturn(sub);
+        when(webhookService.update(eq("whsub_1"), any())).thenReturn(sub);
+
+        mockMvc.perform(patch("/v1/webhooks/whsub_1")
+                        .header("X-Cycles-API-Key", "valid-api-key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"event_categories\":[\"reservation\"]}"))
+                .andExpect(status().isOk());
+    }
+
+    // The category boundary belongs to the tenant-plane ENDPOINT, not the
+    // caller: admin-on-behalf-of PATCH through /v1/webhooks/* is bound by it
+    // too (consistent with validateTenantEventTypes; admin categories are
+    // managed via /v1/admin/webhooks/*).
+    @Test
+    void updateWebhook_withAdminKey_adminOnlyEventCategory_returns400() throws Exception {
+        WebhookSubscription sub = WebhookSubscription.builder()
+            .subscriptionId("whsub_1").tenantId("tenant-1").url("https://example.com/wh")
+            .status(WebhookStatus.ACTIVE).createdAt(Instant.now()).build();
+        when(webhookService.get("whsub_1")).thenReturn(sub);
+
+        mockMvc.perform(patch("/v1/webhooks/whsub_1")
+                        .header("X-Admin-API-Key", "test-admin-key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"event_categories\":[\"system\"]}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("INVALID_REQUEST"));
+
+        verify(webhookService, never()).update(anyString(), any());
     }
 
     @Test

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookServiceTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookServiceTest.java
@@ -158,6 +158,61 @@ class WebhookServiceTest {
             .hasMessageContaining("DISABLED");
     }
 
+    // v0.1.25.50 (governance revision v0.1.25.38): a subscription must always
+    // name at least one event_type or event_category. Create enforces
+    // @NotEmpty event_types, and WebhookRepository.matchesEventType treats
+    // empty-both as match-ALL - not creatable, so it must not be reachable
+    // via PATCH on any plane either.
+    @Test
+    void update_clearingEventTypesWithNoCategories_throws400() {
+        WebhookSubscription existing = buildSubscription("whsub_1", "tenant-1");
+        when(webhookRepository.findById("whsub_1")).thenReturn(existing);
+
+        WebhookUpdateRequest request = WebhookUpdateRequest.builder()
+            .eventTypes(List.of())
+            .build();
+
+        assertThatThrownBy(() -> webhookService.update("whsub_1", request))
+            .isInstanceOf(GovernanceException.class)
+            .hasFieldOrPropertyWithValue("httpStatus", 400)
+            .hasMessageContaining("at least one event_type or event_category");
+        verify(webhookRepository, never()).update(anyString(), any());
+    }
+
+    @Test
+    void update_clearingBothEventFieldsInOneRequest_throws400() {
+        WebhookSubscription existing = buildSubscription("whsub_1", "tenant-1");
+        existing.setEventCategories(List.of(io.runcycles.admin.model.event.EventCategory.BUDGET));
+        when(webhookRepository.findById("whsub_1")).thenReturn(existing);
+
+        WebhookUpdateRequest request = WebhookUpdateRequest.builder()
+            .eventTypes(List.of())
+            .eventCategories(List.of())
+            .build();
+
+        assertThatThrownBy(() -> webhookService.update("whsub_1", request))
+            .isInstanceOf(GovernanceException.class)
+            .hasFieldOrPropertyWithValue("httpStatus", 400);
+        verify(webhookRepository, never()).update(anyString(), any());
+    }
+
+    @Test
+    void update_clearingEventTypesWithCategoriesPresent_succeeds() {
+        // Category-only subscriptions remain legal: clearing event_types is
+        // fine as long as at least one event_category survives.
+        WebhookSubscription existing = buildSubscription("whsub_1", "tenant-1");
+        existing.setEventCategories(List.of(io.runcycles.admin.model.event.EventCategory.BUDGET));
+        when(webhookRepository.findById("whsub_1")).thenReturn(existing);
+
+        WebhookUpdateRequest request = WebhookUpdateRequest.builder()
+            .eventTypes(List.of())
+            .build();
+
+        webhookService.update("whsub_1", request);
+
+        verify(webhookRepository).update(eq("whsub_1"), any());
+    }
+
     @Test
     void update_validatesUrlIfProvided() {
         WebhookSubscription existing = buildSubscription("whsub_1", "tenant-1");

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookServiceTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookServiceTest.java
@@ -197,6 +197,26 @@ class WebhookServiceTest {
     }
 
     @Test
+    void update_clearingEventCategoriesWithEventTypesPresent_succeeds() {
+        // The realistic repair path for a smuggled ADMIN_CATEGORIES row:
+        // strip event_categories to [] (event_types omitted, so it survives) -
+        // event_types remains, so it is NOT empty-both and the update proceeds.
+        WebhookSubscription existing = buildSubscription("whsub_1", "tenant-1");
+        existing.setEventCategories(List.of(io.runcycles.admin.model.event.EventCategory.API_KEY));
+        when(webhookRepository.findById("whsub_1")).thenReturn(existing);
+
+        WebhookUpdateRequest request = WebhookUpdateRequest.builder()
+            .eventCategories(List.of())
+            .build();
+
+        webhookService.update("whsub_1", request);
+
+        assertThat(existing.getEventCategories()).isEmpty();
+        assertThat(existing.getEventTypes()).isNotEmpty();
+        verify(webhookRepository).update(eq("whsub_1"), any());
+    }
+
+    @Test
     void update_clearingEventTypesWithCategoriesPresent_succeeds() {
         // Category-only subscriptions remain legal: clearing event_types is
         // fine as long as at least one event_category survives.

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventCategory.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventCategory.java
@@ -23,6 +23,19 @@ public enum EventCategory {
         return value;
     }
 
+    /**
+     * The tenant-plane accessibility boundary: tenants can subscribe to /
+     * query {@code budget.*}, {@code reservation.*}, {@code tenant.*} only;
+     * API_KEY / POLICY / WEBHOOK / SYSTEM are admin-only (governance spec;
+     * revision v0.1.25.38 extends the rule to webhook
+     * {@code event_categories}). Single source of truth for the boundary -
+     * {@link EventType#isTenantAccessible()} delegates here, so the
+     * type-level and category-level checks can never drift.
+     */
+    public boolean isTenantAccessible() {
+        return this == BUDGET || this == RESERVATION || this == TENANT;
+    }
+
     @JsonCreator
     public static EventCategory fromValue(String value) {
         for (EventCategory c : values()) {

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventType.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/event/EventType.java
@@ -78,9 +78,7 @@ public enum EventType {
     public EventCategory getCategory() { return category; }
 
     public boolean isTenantAccessible() {
-        return category == EventCategory.BUDGET ||
-               category == EventCategory.RESERVATION ||
-               category == EventCategory.TENANT;
+        return category.isTenantAccessible();
     }
 
     @JsonCreator

--- a/cycles-admin-service/cycles-admin-service-model/src/test/java/io/runcycles/admin/model/EventModelTest.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/test/java/io/runcycles/admin/model/EventModelTest.java
@@ -111,6 +111,30 @@ class EventModelTest {
         assertFalse(EventType.SYSTEM_WEBHOOK_TEST.isTenantAccessible());
     }
 
+    // v0.1.25.50: the webhook event_categories boundary derives from
+    // EventCategory.isTenantAccessible(); EventType.isTenantAccessible()
+    // delegates to it. Exhaustive over BOTH enums so adding a future
+    // category or type can't silently widen the tenant boundary.
+
+    @Test
+    void eventCategory_isTenantAccessible_exactlyBudgetReservationTenant() {
+        for (EventCategory c : EventCategory.values()) {
+            boolean expected = c == EventCategory.BUDGET
+                    || c == EventCategory.RESERVATION
+                    || c == EventCategory.TENANT;
+            assertEquals(expected, c.isTenantAccessible(),
+                    "EventCategory." + c + " tenant-accessibility");
+        }
+    }
+
+    @Test
+    void eventType_isTenantAccessible_delegatesToCategoryForEveryType() {
+        for (EventType t : EventType.values()) {
+            assertEquals(t.getCategory().isTenantAccessible(), t.isTenantAccessible(),
+                    "EventType." + t + " must delegate to its category's accessibility");
+        }
+    }
+
     @Test
     void eventType_jsonValue_serializesToDotNotation() throws Exception {
         String json = mapper.writeValueAsString(EventType.BUDGET_CREATED);

--- a/cycles-admin-service/pom.xml
+++ b/cycles-admin-service/pom.xml
@@ -18,7 +18,7 @@
         <module>cycles-admin-service-api</module>
     </modules>
     <properties>
-        <revision>0.1.25.49</revision>
+        <revision>0.1.25.50</revision>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>


### PR DESCRIPTION
**Security fix (v0.1.25.50): tenant-plane webhook `event_categories` were never validated, letting a tenant key subscribe to admin-only event classes.**

## The gap

`WebhookTenantController.validateTenantEventTypes` enforces the tenant-accessible boundary (budget.\*/reservation.\*/tenant.\*) on `event_types` for both create and update — but `event_categories` was never validated on that plane, and `WebhookRepository.matchesEventType` treats categories as an **additive union** with types:

```json
POST /v1/webhooks  (tenant API key)
{"url": "...", "event_types": ["budget.created"], "event_categories": ["api_key"]}
```

→ 201, and the subscription receives every `api_key.*` event for the tenant (likewise `policy`, `webhook`, `system`). The same smuggle worked via `PATCH /v1/webhooks/{id}`.

**Spec citation:** governance spec revision **v0.1.25.38 (pending, prepared in parallel)** adds the normative rule — tenant-plane create AND update MUST validate `event_categories` against the same tenant-accessible boundary, 400 `INVALID_REQUEST`.

## The fix

- `validateTenantEventCategories` alongside the existing `event_types` check, on **both** create and update; same 400 + message style. The boundary is derived from a new `EventCategory.isTenantAccessible()` (BUDGET/RESERVATION/TENANT), and `EventType.isTenantAccessible()` now **delegates** to it — one source of truth, the two checks cannot drift.
- **Admin-on-behalf-of decision:** the check runs unconditionally on the tenant-plane endpoints, admin callers included — exactly how `validateTenantEventTypes` already behaves on the dual-auth PATCH path (create is tenant-key-only by design, spec v0.1.25.14). The boundary belongs to the *endpoint*, not the caller: admin categories are minted/managed on `/v1/admin/webhooks/*`; letting admin PATCH them onto a tenant-plane subscription would recreate the smuggle (the tenant retains the endpoint URL + signing secret).
- **Empty-both edge — verified reachable, guarded:** create requires `@NotEmpty event_types`, but `WebhookService.update` applied `"event_types": []` verbatim; with no categories the result hit `matchesEventType`'s empty-both branch = **match-ALL** (every event class, admin-only included). Update now returns 400 on **both planes** when a PATCH would leave both event fields empty — a match-all subscription is not creatable, so it must not be reachable by update. Category-only subscriptions remain legal.

## Operator note — audit existing subscriptions

On **0.1.25.49 and earlier**, tenant-created subscriptions may already carry admin-only categories. Audit tenant-plane subscriptions and strip/delete offenders, e.g.:

```bash
redis-cli --scan --pattern 'webhook:*' | xargs -L1 redis-cli GET | jq -r \
  'select(.event_categories != null)
   | select(.event_categories - ["budget","reservation","tenant"] | length > 0)
   | .subscription_id + " " + .tenant_id + " " + (.event_categories|tostring)'
```

Admin-provisioned subscriptions legitimately carry admin categories — check provenance via `createTenantWebhook` audit-log entries (tenant-plane creations) vs `createWebhookSubscription` (admin plane).

## Tests

- Controller: smuggle on create → 400 (service never invoked); smuggle on update → 400; **admin-on-behalf-of PATCH with an admin category → 400** (endpoint-bound boundary pinned); tenant-accessible categories pass on create (all three) and update.
- Service: clearing `event_types` with no categories → 400; clearing both in one PATCH → 400; category-only survivor → allowed.
- Pure admin-plane `/v1/admin/webhooks` endpoints unaffected (no new validation there; existing suite green).
- Full `mvn -B verify`: **1,561 tests (190 model + 561 data + 810 api), 0 failures, coverage gates met.**

Version 0.1.25.49 → **0.1.25.50** (pom `<revision>`, per the v0.1.25.48 feature-PR precedent); CHANGELOG (Security + Fixed sections with the operator recipe) and AUDIT.md updated.
