### PR TITLE
Security: admin-plane webhook category boundary + conservative offender cleanup (v0.1.25.51, closes #209)

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -38,6 +38,65 @@ pin (SB 3.5.15 still manages 3.17.0) · tomcat-embed-core 10.1.55 pin
 (re-introduced 2026-05-25 for Apache Tomcat CVE-2026-43512 / -43513 / -43514 /
 -43515 / -42498 / -41284 / -41293)
 
+### 2026-07-11 — v0.1.25.51 codex round 4: replay pagination cursor bugs → approach B (#209)
+
+Round 4 confirmed classification / reconciler / /test / honest-boolean CLEAN
+(the events-worker version-skew gap does NOT reproduce here — strict
+`@JsonCreator` throws on unknown enums, so an unknown record fails hydration and
+is skipped = fail-closed). The remaining issue was ENTIRELY in the round-3 replay
+pagination rewrite, which traded the old under-delivery for three cursor bugs on
+the millisecond-scored event index:
+- **HIGH** — equal-timestamp page boundary skip: `list()` resumes ASC with
+  `minScore = cursorScore + 1`, but scores are epoch-MILLIS, so same-ms members
+  past the page end were skipped.
+- **MEDIUM** — partial hydrated page misread as exhaustion: `list()` drops
+  expired/missing/corrupt/unknown-enum rows, so a `< pageSize` result did NOT
+  mean the ZSET range was exhausted; the collector stopped early.
+- **MEDIUM** — unresolvable cursor duplicates: if `zscore(cursor)` was null (member
+  gone) the lower bound didn't advance and the same page could repeat until
+  `max_events`.
+
+**Approach chosen: (B) — fetch the ordered member-id list up front, hydrate in
+batches over that FIXED list.** Rationale: it is inherently correct for a
+bounded-window scan (the ZSET gives the exact ordered, de-duplicated member set,
+so there is no score cursor to skip/duplicate and hydration drops can't look like
+exhaustion) AND it does NOT mutate `list()`'s cursor contract, so no other caller
+is affected. Approach (A) — extending `list()`'s cursor to a `(score, member)`
+total order — would have touched a method with ~30 call sites (controllers for
+events/audit/policy/tenant/budget/api-key/balance, AdminOverviewService,
+EventService); needlessly risky for a replay-only fix. **Caller-impact check:**
+grepped all `list(` callers; approach B adds two NEW methods
+(`EventRepository.listEventIdsInRange`, `hydrateByIds`) and leaves `list()`
+untouched, so every existing caller is byte-for-byte unchanged.
+
+Implementation: `WebhookService.collectDeliverableReplayEvents` calls
+`listEventIdsInRange(tenant, from, to, replayMaxScan)` (one `ZRANGEBYSCORE`,
+ascending score then member — chronological, de-duplicated, capped), then
+iterates the fixed id list in `REPLAY_PAGE_SIZE=500` slices, hydrating each via
+`hydrateByIds` (drops missing/corrupt/unknown-enum rows, fail-closed) and applying
+request-type ∩ subscription selectors (`matchesEventType`) ∩ `scope_filter`
+(`matchesScope`) ∩ ownership boundary — collecting up to `max_events` DELIVERABLE
+events, delivered chronologically. The scan ceiling became configurable
+(`webhook.replay.max-scan`, default 20000) so it is exercisable; hitting it before
+filling `max_events` logs a WARN (no silent truncation).
+
+Tests: the mocked WebhookServiceTest paging-mechanics tests (which supplied
+idealized pages and couldn't catch these) were removed; the mechanics now live in
+`WebhookReplayPaginationIntegrationTest` against REAL Redis / the real
+`EventRepository` covering all six required scenarios — (1) >500 same-millisecond
+events with matches in the lexicographic tail → all delivered; (2) interior
+hydration drops with later matches → not exhaustion; (3) vanished member → no
+duplicate; (4) scan-ceiling hit → WARN logged, `events_queued` reflects the
+truncation; (5) chronological order across the 500-item page boundary (600 events);
+(6) `max_events` counts deliverable-after-filters (interleaved matching /
+non-matching). Added data-module unit tests for `listEventIdsInRange`
+(tenant/global/infinity/non-positive-max) and `hydrateByIds` (drop
+missing/corrupt, empty). Remaining WebhookServiceTest replay tests re-mocked to the
+new methods via a `stubReplayWindow` helper.
+
+Full foreground build, all gates green: api unit 861, data unit 543 (LINE 0.9572,
+gate 0.95), api integration 874, data integration 593.
+
 ### 2026-07-11 — v0.1.25.51 codex round 3: replay cap-then-filter + boundary/atomicity/honesty hardening (#209)
 
 Round-3 findings verified against source (2bb2467) and fixed. The BIGGEST

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -38,6 +38,46 @@ pin (SB 3.5.15 still manages 3.17.0) · tomcat-embed-core 10.1.55 pin
 (re-introduced 2026-05-25 for Apache Tomcat CVE-2026-43512 / -43513 / -43514 /
 -43515 / -42498 / -41284 / -41293)
 
+### 2026-07-11 — v0.1.25.51 reviewer round: replay max_events validation + best-effort enqueue (#209)
+
+Two reviewer findings, one commit.
+
+**F3 (P2) — enforce max_events min:1/max:1000 (was silently clamped).**
+`ReplayRequest.maxEvents` had no validation and `WebhookService` silently clamped
+`> 1000` via `Math.min(maxEvents, 1000)`, diverging from the spec's declared
+`minimum:1`/`maximum:1000`. Fix: added `@Min(1) @Max(1000)` (jakarta.validation) to
+`ReplayRequest.maxEvents` (same pattern as `WebhookRetryPolicy` + `@Builder.Default`);
+REMOVED the `Math.min` clamp — validation rejects out-of-range instead. **@Valid was
+ALREADY applied** on the replay `@RequestBody` (`WebhookAdminController` line 280), so
+no controller change was needed. **Default behavior:** omitting `max_events` stays
+100 — the service's `getMaxEvents() != null ? ... : 100` fallback (also the
+`@Builder.Default = 100`); `@Min/@Max` pass for null (null is "valid"), so an omitted
+value is not rejected. Controller tests: `max_events=0` → 400 (service not called),
+`max_events=1001` → 400 (service not called), omitted → 202 (validation passes).
+
+**F1 (P1) — best-effort enqueue is the INTENDED, spec-aligned behavior (confirm +
+observe, NO behavior change).** Per the coordinator's decision, governance #130 is
+narrowed to selection-completeness + BEST-EFFORT enqueue (`events_queued` = accepted
+count, may be < selected on transient failure; replay not idempotent). So the existing
+per-event catch + count STAYS. Made it correct + observable:
+- Added a loud **WARN** when `queued < selected` (`replay_id`, `subscription_id`,
+  `tenant_id`, `selected`, `queued`, shortfall) — a degraded dispatch backend is now
+  operator-visible (this is an operator signal, not a silent success claim; the spec
+  documents `events_queued` as the accepted count).
+- Reframed the replay comments/javadoc to state best-effort-enqueue-with-count is
+  INTENDED and `events_queued` may be `< selected` on backend failure; replay is NOT
+  idempotent (random delivery IDs → retry may duplicate). Documented the same on
+  `ReplayResponse.eventsQueued`.
+- Added `replay_partialEnqueue_reportsAcceptedCount_andLogsWarn_bestEffort` (3
+  selected, backend rejects 1 → `events_queued=2`, asserts the PARTIAL-enqueue WARN
+  with `selected=3 queued=2`).
+- Did NOT add fail-on-partial / atomic enqueue (rejected in favor of the best-effort
+  spec alignment; atomic enqueue was NOT judged clearly cheaper/better, so no stop-and-
+  ask was warranted).
+
+Gates green: model 192, data unit 543 (LINE 0.9572, unchanged), api unit 866, api
+integration 881, data integration 593 (unchanged).
+
 ### 2026-07-11 — v0.1.25.51 codex confirm: replay all-or-narrow doc sweep (comment-only) (#209)
 
 Codex confirmed the all-or-narrow LOGIC correct/clean; one P2 DOC-ONLY — stale

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -38,6 +38,38 @@ pin (SB 3.5.15 still manages 3.17.0) · tomcat-embed-core 10.1.55 pin
 (re-introduced 2026-05-25 for Apache Tomcat CVE-2026-43512 / -43513 / -43514 /
 -43515 / -42498 / -41284 / -41293)
 
+### 2026-07-11 — v0.1.25.51 codex round: dispatch re-read must not misclassify backend errors as INACTIVE (#209)
+
+Codex P2 on the just-added classification: `dispatchToSubscription`'s `findById`
+re-read was wrapped in a blanket `catch (Exception e) → INACTIVE`. But
+`WebhookRepository.findById` (verified) throws
+`GovernanceException.webhookNotFound(id)` (`ErrorCode.WEBHOOK_NOT_FOUND`, 404) ONLY
+for a genuinely-missing row, and wraps Redis/deserialization/other failures in a
+plain `RuntimeException("Failed to find webhook subscription", e)`. So a real
+backend outage during the re-read was misclassified INACTIVE → replay emitted the
+benign INFO and HID the failure.
+
+Fix: catch `GovernanceException` and map to `INACTIVE` ONLY when
+`getErrorCode() == WEBHOOK_NOT_FOUND` (genuine delete, intended lifecycle); any
+other `GovernanceException`, and any other `Exception` (Redis/deser/unexpected),
+→ `ENQUEUE_FAILED` (degradation → degraded WARN), each logged. The paused/disabled
+INACTIVE trigger (non-ACTIVE status on a successful re-read) is unchanged.
+
+The exact not-found signal caught: `GovernanceException` with
+`ErrorCode.WEBHOOK_NOT_FOUND` (the only INACTIVE-worthy `findById` throw).
+
+Tests (`WebhookDispatchServiceTest`): renamed the deleted case →
+`dispatchToSubscription_subscriptionDeletedMidReplay_inactive` (WEBHOOK_NOT_FOUND →
+INACTIVE, unchanged); added `dispatchToSubscription_reReadBackendError_enqueueFailed_
+notInactive` (findById throws `RuntimeException` wrapping `JedisConnectionException`
+→ ENQUEUE_FAILED) and `dispatchToSubscription_reReadNonNotFoundGovernanceError_
+enqueueFailed` (a non-not-found `GovernanceException` → ENQUEUE_FAILED). Replay-level
+effect is covered by the existing pair: ENQUEUE_FAILED → degraded WARN, INACTIVE →
+benign INFO (`WebhookServiceTest`).
+
+Gates green: model 192, data unit 543 (LINE 0.9572, unchanged), api unit 869, api
+integration 884, data integration 593 (unchanged).
+
 ### 2026-07-11 — v0.1.25.51 reviewer round: categorize replay shortfall (structured dispatch outcome) (#209)
 
 Reviewer P2: the best-effort partial-enqueue WARN fired for EVERY

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -38,6 +38,76 @@ pin (SB 3.5.15 still manages 3.17.0) · tomcat-embed-core 10.1.55 pin
 (re-introduced 2026-05-25 for Apache Tomcat CVE-2026-43512 / -43513 / -43514 /
 -43515 / -42498 / -41284 / -41293)
 
+### 2026-07-11 — v0.1.25.51 codex round 2 REVISE-MAJOR: fail-closed dispatch boundary + strip cleanup (#209)
+
+Codex round 2 verified the write gate, effective-merge, reconciler
+correctness, shared predicate and migration wording as good, but flagged
+that the security property was still TIMING-DEPENDENT (reconciler is
+fail-open; live dispatch did no ownership check) plus a few residual
+bypasses. All verified against source, then fixed:
+
+**(HIGH) Architectural fix — enforce the boundary AT DELIVERY (fail-closed).**
+The durable confidentiality guarantee is no longer the reconciler (which is
+point-in-time hygiene) but a per-event dispatch filter. `WebhookDispatchService`
+now takes `WebhookCategoryBoundaryValidator` and, in BOTH live dispatch
+(`dispatch` loop) and replay (`dispatchToSubscription`), skips an event when
+`!WebhookSubscription.isSystemOwner(sub.getTenantId()) &&
+categoryBoundaryValidator.isAdminOnly(event.getEventType())`
+(`isBlockedByOwnershipBoundary`, a no-I/O helper on the passed sub). The skip
+is PER EVENT (a mixed subscription still receives its tenant-accessible events;
+counted `boundary_skipped`), so a concrete-tenant subscription can never
+receive an admin-only event regardless of stored selectors, reconciler state,
+or status. `dispatchToSubscription` now returns `boolean` (delivered?) so
+replay counts only real deliveries.
+
+**Reconciler action reconsidered — STRIP, not disable.** Because dispatch now
+blocks the leak, admin-only selectors on a concrete-tenant row are already
+non-functional, so the reconciler STRIPS them (keeping tenant-accessible
+selectors) instead of disabling the whole subscription — storage is brought in
+line with the already-enforced delivery behavior, with no collateral on
+legitimate deliveries and no signal lost (dispatch, not the row's ACTIVE flag,
+is the guarantee). Actions: `STRIPPED_ADMIN_SELECTORS`; if stripping empties
+both lists → `STRIPPED_AND_DISABLED`; legacy empty-both (any owner) →
+`DISABLED_EMPTY_BOTH`. Empty-both fallback preserved because a match-ALL row is
+a separate invariant violation.
+
+**Null-owner decision — reconciler MIGRATES null→`__system__`.** A null-owner
+row was limbo (exempt from repair yet absent from every dispatch index). The
+reconciler normalizes it to the `__system__` owner and `SADD`s it to
+`webhooks:__system__` (`NORMALIZED_NULL_OWNER`), in the same CAS write. The
+replay NPE (`sub.getTenantId().equals(...)`) is fixed via `isSystemOwner`.
+
+**(MEDIUM) Bulk RESUME bypass.** `WebhookAdminController` bulk `RESUME` reached
+ACTIVE via `webhookService.update` directly, bypassing single-op validation.
+RESUME now calls `categoryBoundaryValidator.validateForTarget` on the stored
+(effective) selectors first; an offender fails the row (`INVALID_TRANSITION`).
+
+**(MEDIUM) Replay status TOCTOU.** `dispatchToSubscription` re-reads the
+subscription (`findById`) and re-checks `ACTIVE` at dispatch time, so a
+subscription disabled concurrently mid-replay stops delivering.
+
+**(MINOR) Reconciler daemon lifecycle.** The raw `new Thread` is replaced with
+a managed single-thread `ExecutorService` (daemon factory); `@PreDestroy
+shutdown()` calls `shutdownNow()` (interrupts an in-flight retry backoff) +
+`awaitTermination(5s)`, so the sweep stops cleanly on context shutdown.
+
+Docs reframed: CHANGELOG / AUDIT / reconciler + repository javadoc now state
+the dispatch boundary is the security mechanism and the reconciler is
+best-effort storage hygiene that STRIPS (the "DISABLED-pending" framing is
+removed).
+
+Tests added/updated: dispatch-side per-event filtering (live + replay,
+`WebhookDispatchServiceTest`); bulk-RESUME offender blocked + clean row resumes
+(`WebhookAdminControllerTest`); replay counts only delivered events and honors
+dispatch-time status re-check (`WebhookServiceTest`); reconciler strip /
+strip-and-disable / normalize-null-owner actions + daemon shutdown interrupts
+backoff + exhausted-retry ERROR alert (`WebhookCategoryBoundaryReconcilerTest`,
+`WebhookRepositoryTest`); real-Redis integration strip/normalize/concurrency
+/multi-batch(600)/blank-owner + Lua CAS no-clobber
+(`WebhookCategoryBoundaryReconcileIntegrationTest`). Full foreground build,
+all gates green: api unit 854, data unit 534 (LINE 0.9565, gate 0.95), data
+integration 582, api integration 861.
+
 ### 2026-07-11 — v0.1.25.51 codex REVISE-MAJOR: close live bypasses (#209)
 
 Codex security review of the PR found the create/update gate sound but

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -38,6 +38,43 @@ pin (SB 3.5.15 still manages 3.17.0) · tomcat-embed-core 10.1.55 pin
 (re-introduced 2026-05-25 for Apache Tomcat CVE-2026-43512 / -43513 / -43514 /
 -43515 / -42498 / -41284 / -41293)
 
+### 2026-07-11 — v0.1.25.51 reviewer round: categorize replay shortfall (structured dispatch outcome) (#209)
+
+Reviewer P2: the best-effort partial-enqueue WARN fired for EVERY
+`events_queued < selected`, but `dispatchToSubscription` returned `false` for
+several reasons and only ONE is a degradation — so a benign concurrent-disable
+mid-replay raised a false "backend degraded" alarm.
+
+Fix (structured result, chosen over broadening the log wording — the operational
+distinction matters):
+1. `WebhookDispatchService.dispatchToSubscription` now returns a structured enum
+   `DispatchOutcome { ENQUEUED, INACTIVE, BLOCKED, ENQUEUE_FAILED }` instead of a
+   boolean; per-branch behavior is UNCHANGED (ownership guard → BLOCKED; deleted /
+   non-ACTIVE at the dispatch-time status re-check → INACTIVE; LPUSH/save fail →
+   ENQUEUE_FAILED; else ENQUEUED).
+2. Callers: the ONLY production caller is `WebhookService.replay` (live
+   `dispatch()` uses `createDelivery` directly and is unchanged — verified by
+   grep). Replay counts `ENQUEUED` as `events_queued` and tallies each category.
+3. Categorized shortfall logging: if `enqueue_failed > 0` → **WARN** "DEGRADED
+   dispatch backend" (`replay_id`/`subscription_id`/`tenant_id`/`selected`/
+   `enqueued`/`enqueue_failed`/`inactive`/`blocked`); if the shortfall is ONLY
+   INACTIVE/BLOCKED → **INFO** "intended, NOT degradation". The per-event outer
+   catch (unexpected error, e.g. deliveryRepository.save throwing) counts as
+   `enqueue_failed` (a degradation).
+4. Tests: renamed the partial test to `replay_partialEnqueue_backendFailure_
+   logsDegradedWarn` (one ENQUEUE_FAILED → asserts the DEGRADED WARN with
+   `enqueued=2 enqueue_failed=1`); added `replay_partialEnqueue_concurrentDisable_
+   logsBenignInfo_notDegradedWarn` (one INACTIVE → `events_queued=2`, asserts the
+   benign INFO and asserts NO degraded WARN). Updated `WebhookDispatchServiceTest`
+   (10 assertions boolean→`DispatchOutcome`: ENQUEUED/BLOCKED/INACTIVE/
+   ENQUEUE_FAILED per case, incl. the deleted-mid-replay → INACTIVE and the
+   LPUSH-fail → ENQUEUE_FAILED paths) and the replay integration mock
+   (→ ENQUEUED). BLOCKED is exercised by the dispatch unit tests
+   (concrete-tenant admin/inconsistent/unclassifiable → BLOCKED).
+
+Gates green: model 192, data unit 543 (LINE 0.9572, unchanged), api unit 867, api
+integration 882, data integration 593 (unchanged).
+
 ### 2026-07-11 — v0.1.25.51 reviewer round: replay max_events validation + best-effort enqueue (#209)
 
 Two reviewer findings, one commit.

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -38,6 +38,63 @@ pin (SB 3.5.15 still manages 3.17.0) · tomcat-embed-core 10.1.55 pin
 (re-introduced 2026-05-25 for Apache Tomcat CVE-2026-43512 / -43513 / -43514 /
 -43515 / -42498 / -41284 / -41293)
 
+### 2026-07-11 — v0.1.25.51 reviewer round: over-large replay window → caller-visible 400 (#209)
+
+Reviewer P2 (un-parked the PR): replay capped the candidate scan at
+`replayMaxScan` and, if matching events existed BEYOND the ceiling, returned a
+SUCCESSFUL response with `events_queued < max_events` plus a server-side WARN.
+To the caller that reads as "I got all matching events in my window" — but the
+search was truncated and the log is not caller-visible. The round-5 scan-ceiling
+test even codified the silent partial (50 of 60 + warning).
+
+**Fix — fail-fast, caller-visible (chosen over a truncation flag: no
+response-schema change, uses existing error semantics).** Precise semantics, only
+the genuinely-incomplete case fails:
+- `collectDeliverableReplayEvents` fetches `replayMaxScan + 1` candidate ids (one
+  past the ceiling) so it can tell "window fits" from "window overflows";
+  `ceilingReached = ids.size() > replayMaxScan`; it scans only the first
+  `replayMaxScan`.
+- If `ceilingReached` AND fewer than `max_events` DELIVERABLE events were
+  collected within the scanned set → the search is incomplete → throw
+  `GovernanceException(ErrorCode.INVALID_REQUEST, 400)` BEFORE the dispatch loop
+  (the collector runs before any enqueue, so there are NO partial side effects;
+  the replay lock is released by `replay()`'s `finally`). Message: "replay window
+  too large: it exceeds the replay scan limit of N events; narrow the from/to
+  range (or lower max_events to page within the limit)".
+- If `max_events` WAS filled within the ceiling → deliver normally (explicit
+  pagination cap, not truncation; `events_queued == max_events` signals "more may
+  exist").
+
+**Error code chosen: `INVALID_REQUEST` (400).** `LIMIT_EXCEEDED` is the 429
+rate-limit code (wrong status); there is no replay-window-specific code, and
+`INVALID_REQUEST/400` matches the existing webhook validators. Verified against
+`ErrorCode`.
+
+**Spec check (report — do NOT edit spec):** governance
+`cycles-governance-admin-v0.1.25.yaml` `replayEvents` (line 7096) ALREADY declares
+a `400 "Invalid replay request"` response (schema `ErrorResponse`), so returning
+`INVALID_REQUEST/400` for an over-large window is WITHIN its declared error
+responses — schema-conformant, no new error-response needed. What is NOT
+documented: the SEMANTIC that exceeding a server-side replay scan limit yields
+400 (the spec's LIMITS note only says "Maximum 1000 events per replay request"
+and "Use from/to to control the replay window", and documents `max_events`
+min1/max1000/default100 — nothing about a scan ceiling or over-large-window 400).
+Recommend a PROSE clause in the `replayEvents` description/LIMITS documenting the
+over-large-window 400 for governance PR #130. (Prose only — the 400 response
+object already exists.)
+
+Tests: rewrote the round-5 scan-ceiling test (which asserted the silent partial)
+into `replay_windowExceedsScanCeiling_incomplete_returns400_nothingEnqueued`
+(candidate 60 > ceiling 50, max_events 1000 unfilled → 400, `dispatchToSubscription`
+never called, replay lock released) and added
+`replay_windowExceedsCeiling_butMaxEventsFilledWithin_succeeds` (candidate 60 >
+ceiling 50 but max_events 10 filled within → success, 10 delivered, no false
+failure). The six approach-B correctness tests are intact. Ceiling injected via
+`webhook.replay.max-scan` (ReflectionTestUtils), so no 20000-row seeding.
+
+All gates green: api unit 861, data unit 543 (LINE 0.9572, unchanged), api
+integration 875, data integration 593 (unchanged).
+
 ### 2026-07-11 — v0.1.25.51 codex round 5: strengthen two replay regression tests (test-only) (#209)
 
 Round 5 confirmed the approach-B replay PRODUCTION fix sound (REVISE-MINOR,

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -38,6 +38,76 @@ pin (SB 3.5.15 still manages 3.17.0) · tomcat-embed-core 10.1.55 pin
 (re-introduced 2026-05-25 for Apache Tomcat CVE-2026-43512 / -43513 / -43514 /
 -43515 / -42498 / -41284 / -41293)
 
+### 2026-07-11 — v0.1.25.51 codex round 3: replay cap-then-filter + boundary/atomicity/honesty hardening (#209)
+
+Round-3 findings verified against source (2bb2467) and fixed. The BIGGEST
+round-3 item — enforcing the boundary in the separate `cycles-server-events`
+delivery worker — is handled in that repo by a different change; this entry
+covers only the admin-service findings.
+
+**P2 (replay cap-then-filter under-delivery).** `WebhookService.replay` fetched
+ONE page capped at `max_events` then applied the request-type / subscription
+-selector (`matchesEventType`) / `scope_filter` (`matchesScope`) filters as
+post-hoc stream filters — so if the first `max_events` events in `[from,to]`
+didn't match but later ones did, replay queued ZERO. Round-3's two added
+post-cap filters made this more acute. Fix: new `collectDeliverableReplayEvents`
+pages the window in timestamp-ASC batches (`REPLAY_PAGE_SIZE=500`) via the
+`EventRepository.list` cursor, applies ALL filters PLUS the ownership boundary
+(`dispatchService.isBlockedByOwnershipBoundary`, made public) DURING pagination,
+accumulating up to `max_events` DELIVERABLE events, then delivers chronologically
+(spec `replayEvents`). A `REPLAY_MAX_SCAN=20_000` ceiling bounds cost on sparse
+windows and logs (not silently truncates) if hit. Verified `EventRepository.list`
+timestamp-ASC uses `zrangeByScore` with a score-advancing cursor (chronological).
+
+**Finding 1 (LOW — category + unclassifiable).** `isBlockedByOwnershipBoundary`
+checked only `event.getEventType()`. `Event.category` is independent (EventService
+preserves a supplied category), so a tenant-accessible TYPE with an admin-only
+CATEGORY, or a typeless record, slipped through. Now blocks if type OR category
+is admin-only, AND blocks an unclassifiable (both-null) record for a concrete
+owner. Added `WebhookCategoryBoundaryValidator.isAdminOnly(EventCategory)`.
+
+**Finding 2 (MEDIUM — normalize atomicity + disabled/unindexed).** The null-owner
+SET (CAS Lua) and the `SADD webhooks:__system__` were separate commands — a crash
+between them left the row normalized-but-unindexed, and the retry saw
+`nullOwner=false & changed=false` and never repaired the membership; also the
+blanket DISABLED-skip meant disabled null-owner rows were never normalized. Fix:
+one `CAS_SET_AND_INDEX_LUA` folds the conditional SET and the SADD into a single
+atomic op; the reconciler computes `needsIndex` via `SISMEMBER` INDEPENDENTLY of
+status (repairs a DISABLED null-owner row, and a system row missing from the
+index → new `INDEXED_SYSTEM_MEMBER` action via idempotent SADD). Strip/disable
+still skip already-DISABLED rows.
+
+**Finding 3 (MEDIUM — /test bypass). DECISION: documented exception (route b).**
+`WebhookService.test` POSTs a spec-defined `system.webhook_test` (admin category)
+ping DIRECTLY to the subscription URL, so a tenant-owned sub's `/test` delivers
+an admin-classified event. I did NOT reclassify the envelope because (1) the yaml
+spec is the authority and defines the test event as `system.webhook_test` — the
+enum has no tenant-accessible test type; and (2) keeping the type while relabelling
+the category would create exactly the type/category-inconsistent record finding 1
+now blocks. Instead documented it as a narrow, explicit invariant EXCEPTION
+(owner-triggered synthetic probe, payload `{subscription_id, test:true}`, no
+governance telemetry, bypasses the dispatch queue) in code comment + CHANGELOG +
+this AUDIT. **The governance spec needs the /test exception noted spec-side —
+flagged to the coordinator.**
+
+**Finding 4 (LOW — honest boolean).** `createDelivery` swallowed an `LPUSH`
+failure yet `dispatchToSubscription` returned `true`, so replay over-counted.
+`createDelivery` now returns enqueue success; `dispatchToSubscription` and the
+live dispatch metric propagate it.
+
+**Finding 5 (test hardening).** Real-Redis CAS test now evals the ACTUAL
+production script (`WebhookRepository.reconcileCasSetAndIndexScript()`), not a
+hand-copied string; the 600-row SSCAN test asserts `>1` cursor round-trips at the
+production COUNT; the concurrency re-read test asserts the fresh `findById`
+re-read actually drove the skip; added tests for category/unclassifiable blocking,
+disabled-null-owner normalization + system-unindexed membership repair (unit +
+real-Redis), /test envelope pinning, and enqueue-failure → false. Also fixed the
+integration `seed` helper to mirror production `save()` (per-tenant index), so
+seeded `__system__` rows are correctly indexed.
+
+Full foreground build, all gates green: api unit 863, data unit 538 (LINE 0.9567,
+gate 0.95), data integration 588, api integration 870.
+
 ### 2026-07-11 — v0.1.25.51 codex round 2 REVISE-MAJOR: fail-closed dispatch boundary + strip cleanup (#209)
 
 Codex round 2 verified the write gate, effective-merge, reconciler

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,4 +1,4 @@
-# Complete Budget Governance v0.1.25.50 — Admin Server Audit
+# Complete Budget Governance v0.1.25.51 — Admin Server Audit
 
 **Spec:**
 [`cycles-governance-admin-v0.1.25.yaml`](https://github.com/runcycles/cycles-protocol/blob/main/cycles-governance-admin-v0.1.25.yaml)
@@ -37,6 +37,85 @@ behavior) in
 pin (SB 3.5.15 still manages 3.17.0) · tomcat-embed-core 10.1.55 pin
 (re-introduced 2026-05-25 for Apache Tomcat CVE-2026-43512 / -43513 / -43514 /
 -43515 / -42498 / -41284 / -41293)
+
+### 2026-07-11 — v0.1.25.51: admin-plane webhook category boundary + conservative offender cleanup (security, #209)
+
+Closes #209. The 0.1.25.50 fix closed the tenant-plane INJECTION path
+for admin-only webhook `event_categories`; #209 is the admin-plane
+CARRIER source. `WebhookAdminController.create`
+(`POST /v1/admin/webhooks?tenant_id=X`) and `.update` (PATCH) applied NO
+category validation, so an operator / admin-on-behalf-of could place
+admin-only categories (api_key/policy/webhook/system) on a subscription
+owned by concrete tenant X. Because `matchesEventType` treats categories
+as an ADDITIVE union, X — which owns the row's endpoint URL + signing
+secret — then received admin-only governance/security telemetry.
+
+(a) Admin write-path validation.
+- New shared `WebhookCategoryBoundaryValidator` (@Component) is the single
+  source of truth for the boundary. Both the tenant controller (refactored
+  off its two private methods) and the admin controller call it, so the
+  type-level and category-level checks and both planes cannot drift; the
+  boundary itself derives from `EventCategory.isTenantAccessible()`.
+- Admin plane validates only when the target is a CONCRETE tenant
+  (`validateForTarget` no-ops on the `__system__` sentinel). Target tenant:
+  on create the `tenant_id` param; on update the STORED subscription's
+  `tenant_id` (WebhookUpdateRequest has no tenant_id — ownership is the
+  subscription's, verified against `prior.getTenantId()`). Admin-only entry
+  on a non-`__system__` target → 400 INVALID_REQUEST.
+- `__system__` carve-out: admin-only categories remain allowed there
+  (legitimate system-wide monitoring; not tenant-owned).
+
+CAPABILITY REMOVAL (recorded). 0.1.25.50 explicitly tested/documented
+admin-plane create/update WITH admin-only categories as 201/200 ("the
+boundary is tenant-plane-only, not a global tightening"), and its
+operator recipe called `/v1/admin/webhooks`-created admin-category rows
+"legitimate carriers". Verified by grep: those two WebhookAdminControllerTest
+cases were the only place this was asserted — an incidental
+tested-as-allowed behavior, not a separately-documented product feature.
+Both are rewritten to assert the new 400 for a concrete tenant (and
+201/200 for `__system__`). This is an intentional security correction —
+a previously-allowed capability is removed because a tenant-owned row
+exposes URL + secret to the tenant.
+
+(d2) One-time cleanup — CONSERVATIVE (disable, not strip).
+- Startup `ApplicationRunner` (`WebhookCategoryBoundaryReconciler`) →
+  `WebhookRepository.reconcileTenantCategoryBoundary(dryRun)`. Chosen over
+  a maintenance endpoint because a new admin endpoint would fail the
+  OpenAPI contract-diff check (undocumented surface); mirrors the repo's
+  `@Scheduled` audit-sweep / `CommandLineRunner` precedent.
+- Per row (non-`__system__`): a row carrying admin-only categories, or a
+  legacy empty-both match-ALL row, is DISABLED — NOT silently stripped.
+  Rationale (codex concern on gov #129): a concrete-tenant admin-category
+  row may be legit-but-misconfigured operator monitoring; silently
+  rewriting its selectors would break it with no signal. Disabling stops
+  delivery immediately (dispatch matches only ACTIVE), is reversible,
+  preserves the row + offending categories for review, and is loudly
+  logged (subscription_id / tenant_id / offending categories + the
+  migration hint). Already-DISABLED offenders are skipped → idempotent.
+- Config: `webhook.category-boundary.reconcile-on-startup` (default true),
+  `webhook.category-boundary.reconcile-dry-run` (default false; true =
+  REPORT offenders in logs, mutate nothing — review before the disabling
+  pass). Disabled in test properties so it never races per-test seeding;
+  the logic is covered directly (real-Redis integration + component unit).
+- MIGRATION for genuine per-tenant admin monitoring (in CHANGELOG): use a
+  `__system__`-owned subscription (no `tenant_id`) filtered by
+  `event_categories` to the admin classes; it receives those events for ALL
+  tenants (`__system__` is in every tenant's dispatch union), so select the
+  target tenant CLIENT-SIDE on the envelope `tenant_id`. NOT a `scope_filter`:
+  admin lifecycle events are null-scoped (verified: ApiKeyController emits
+  scope=null) and `matchesScope` excludes null scopes from any non-blank
+  filter, so a `scope_filter` would deliver none. gov #129 corrected the same
+  way. The row stays operator-owned (URL + secret), unlike a tenant-owned row.
+
+Tests: WebhookCategoryBoundaryValidatorTest (boundary + system carve-out);
+admin controller — admin-only category/type on a real tenant → 400 (create
++ update, service never called), on `__system__` → 201/200, tenant-accessible
+→ ok; reconciler integration (real Redis) over a seeded mix → correct
+DISABLED terminal states with categories intact, `__system__`/legit/
+types-only/already-disabled untouched, dry-run reports-without-mutating,
+idempotent re-run; reconciler component unit (flag on/off, dry-run passthrough,
+failure-swallowed). Version/revision 0.1.25.50 → 0.1.25.51. README alignment
+stays at governance v0.1.25.39 (v0.1.25.40 / cycles-protocol#129 still pending).
 
 ### 2026-07-11 — spec-alignment declaration bumped to governance v0.1.25.39 (docs only; no behavior change)
 

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -38,6 +38,37 @@ pin (SB 3.5.15 still manages 3.17.0) · tomcat-embed-core 10.1.55 pin
 (re-introduced 2026-05-25 for Apache Tomcat CVE-2026-43512 / -43513 / -43514 /
 -43515 / -42498 / -41284 / -41293)
 
+### 2026-07-11 — v0.1.25.51 codex confirm: replay all-or-narrow doc sweep (comment-only) (#209)
+
+Codex confirmed the all-or-narrow LOGIC correct/clean; one P2 DOC-ONLY — stale
+pagination-framing comments that contradicted the new behavior. No code-behavior
+change (one local var rename `page`→`batch`; no test change). Fixed + swept the
+whole replay path case-insensitively (`pagin|paging|page|cursor|continue|advance
+from|there may be more|stops and logs|truncat|max_events`), zero survivors:
+- `WebhookService.replay` comment (~330): "collect … by paging … DURING
+  pagination" → all-or-narrow (collect EVERY deliverable event; over-large window
+  is a 400 before enqueue).
+- `WebhookService` `REPLAY_PAGE_SIZE` javadoc: "page size while paging" →
+  "Hydration BATCH size … NOT a pagination unit: the whole window is scanned
+  within one replay".
+- `WebhookService` `replayMaxScan` javadoc: "collection stops and logs — NOT a
+  silent truncation" → "returns a 400 INVALID_REQUEST (window too large — narrow
+  from/to), NOT a silent partial".
+- `WebhookService.collectDeliverableReplayEvents` local `page` → `batch`.
+- `WebhookDispatchService.isBlockedByOwnershipBoundary` javadoc: "apply the SAME
+  predicate while paginating … must not spend its max_events budget … the cap
+  would count" → "when selecting the deliverable events for a window … the
+  deliverable total drives the completeness check".
+- `EventRepository.listEventIdsInRange` javadoc: "replay pages hydration over" →
+  "replay hydrates fixed BATCHES over".
+Confirmed-correct (kept): the all-or-narrow negations in `WebhookService`
+(~332/367/402-408, "NOT a resumable pagination cursor", "no continuation", "never
+a partial with 'continue'"); the approach-B contrast in `EventRepository`
+(the three OLD `list()` cursor hazards it AVOIDS); and the unrelated
+cursor-paginated `listByTenant`/`listAll`/`listDeliveries` APIs and the `continue`
+loop keyword. No behavior/comment mismatch beyond wording was found. Gates green:
+api unit 862, data unit 543 (LINE 0.9572), model 192.
+
 ### 2026-07-11 — v0.1.25.51 reviewer round: replay is ALL-OR-NARROW (no fake continuation) (#209)
 
 Reviewer REVISE-MINOR: the prior scan-limit fix left a broken claim — it framed

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -38,6 +38,36 @@ pin (SB 3.5.15 still manages 3.17.0) · tomcat-embed-core 10.1.55 pin
 (re-introduced 2026-05-25 for Apache Tomcat CVE-2026-43512 / -43513 / -43514 /
 -43515 / -42498 / -41284 / -41293)
 
+### 2026-07-11 — v0.1.25.51 codex round 5: strengthen two replay regression tests (test-only) (#209)
+
+Round 5 confirmed the approach-B replay PRODUCTION fix sound (REVISE-MINOR,
+test-only). Two `WebhookReplayPaginationIntegrationTest` regression tests didn't
+actually reproduce the bugs they guard (they'd pass against round-4 too). No
+production change; only the two tests were rewritten.
+
+- **Hydration-thinning test** — was 10 members / 3 deleted (all 7 survivors hydrate
+  in the first fetch; round-4 passes too). Rewritten to
+  `replay_matchesBeyondFirstCandidateWindow_withHydrationDrops_stillDelivered`:
+  seeds 1500 non-matching filler (the round-4 `list()` `limit*3 = 1500` candidate
+  window), EVICTS 1100 interior rows (ZSET members remain) so that window
+  hydrates to 400 events (< 500), then seeds 30 DELIVERABLE matches at positions
+  1500+. Round-4's `page.size() < 500 → stop` treats the short first page as
+  exhaustion and delivers 0; approach B reads the full ordered id list up front
+  and delivers all 30. Asserting 30 genuinely distinguishes the two.
+- **Vanished-cursor test** — was 5 members / 1 row deleted (member stays; no
+  cursor re-query under approach B). ASSESSED: the old `zscore(cursor)==null`
+  duplicate class is STRUCTURALLY ELIMINATED by approach B — the full ordered id
+  list is fetched ONCE via `ZRANGEBYSCORE` and hydrated in batches, so there is
+  no per-page cursor re-query to return a stale page. Rewritten to
+  `replay_vanishedMembers_skippedCleanly_noDuplicate_acrossBatches`: 600 members
+  (2 hydration batches), 4 rows evicted across BOTH batches incl. the 500-item
+  boundary → each vanished member cleanly skipped, no duplicate, later members
+  (incl. 2nd batch) still delivered (596 queued). Pins the new structural
+  guarantee. The other four scenario tests were left unchanged (codex-clean).
+
+All gates green: api unit 861 (unchanged — integration test excluded from the
+unit job), data unit 543 (LINE 0.9572), api integration 874, data integration 593.
+
 ### 2026-07-11 — v0.1.25.51 codex round 4: replay pagination cursor bugs → approach B (#209)
 
 Round 4 confirmed classification / reconciler / /test / honest-boolean CLEAN

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -38,6 +38,63 @@ pin (SB 3.5.15 still manages 3.17.0) · tomcat-embed-core 10.1.55 pin
 (re-introduced 2026-05-25 for Apache Tomcat CVE-2026-43512 / -43513 / -43514 /
 -43515 / -42498 / -41284 / -41293)
 
+### 2026-07-11 — v0.1.25.51 reviewer round: replay is ALL-OR-NARROW (no fake continuation) (#209)
+
+Reviewer REVISE-MINOR: the prior scan-limit fix left a broken claim — it framed
+`max_events` as a RESUMABLE pagination cap ("lower max_events to page", "advance
+from") but `ReplayResponse` has NO continuation position (`replay_id`,
+`events_queued`, `estimated_completion_seconds` only). So a partial can't be
+resumed losslessly: distinct timestamps → the caller never learns the last
+replayed timestamp; same-millisecond events → an inclusive `from` repeats the
+page, advancing it skips the rest. The guidance was unusable.
+
+**Decision (chosen over adding a cursor — no schema change, lossless): REPLAY IS
+ALL-OR-NARROW.** A successful replay delivers EVERY deliverable event in the
+window; it never returns a partial with an implied "continue".
+
+Final `collectDeliverableReplayEvents` logic:
+- Fetch `replayMaxScan + 1` candidate ids. If `ids.size() > replayMaxScan` (window
+  not fully scannable) → **400** BEFORE any enqueue.
+- Else fully scanned: collect all deliverable events (request event_types ∩
+  subscription selectors ∩ scope ∩ ownership boundary), one past `max_events`
+  (`break` when `collected.size() > maxEvents`). If `collected.size() > maxEvents`
+  → **400** BEFORE any enqueue.
+- Else (fully scanned, ≤ `max_events`) → return ALL, delivered chronologically.
+This cleanly REPLACES the prior "ceiling reached AND < max_events → 400": now
+`> replayMaxScan candidates` OR `> max_events deliverable` → 400; else deliver all.
+
+**Error code: `INVALID_REQUEST` (400)** for both. Exact messages:
+- scan limit: "replay window too large: it exceeds the replay scan limit of N
+  events; narrow the from/to range"
+- too-many-deliverable: "replay window contains more than max_events (N)
+  deliverable events; narrow the from/to range, or raise max_events (up to 1000)"
+
+**Removed continuation guidance:** the old message tail "(or lower max_events to
+page within the limit)" and the code comment "eventsQueued == max_events signals
+'there may be more'" / "explicit pagination cap" framing are gone; the javadoc now
+states `max_events` is NOT a resumable cursor.
+
+Tests: replaced the two prior ceiling tests (4a/4b, which encoded the silent
+partial and a "cap filled within ceiling → success" that is now a scan-limit 400)
+and rewrote the old max_events-cap test. New integration tests (real Redis):
+window > scan limit → 400 (narrow, nothing enqueued, lock released); fully-scanned
+window > max_events deliverable → 400 (nothing enqueued); same-MILLISECOND cluster
+of 15 with max_events 10 → 400, then raising max_events to 20 → ONE replay delivers
+all 15 exactly once (the reviewer's same-timestamp concern, handled in the model);
+window ≤ max_events incl. a same-ms cluster → all delivered once, non-matching
+filtered. The four approach-B ordering/no-dup correctness tests are intact. Unit
+(WebhookServiceTest): `> max_events deliverable → 400, nothing dispatched, lock
+released` and `≤ max_events → all delivered in order`.
+
+**Spec reconciliation (report):** governance `replayEvents` (line 7096) already
+declares a `400 "Invalid replay request"` (`ErrorResponse`), so both 400s are
+within its declared responses — schema-conformant. The all-or-narrow SEMANTIC and
+the two messages must match the parallel governance PR #130 rewrite; final
+semantics/messages reported above for the coordinator to reconcile.
+
+All gates green: api unit 862, data unit 543 (LINE 0.9572, unchanged), api
+integration 877, data integration 593 (unchanged).
+
 ### 2026-07-11 — v0.1.25.51 reviewer round: over-large replay window → caller-visible 400 (#209)
 
 Reviewer P2 (un-parked the PR): replay capped the candidate scan at

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -38,6 +38,82 @@ pin (SB 3.5.15 still manages 3.17.0) · tomcat-embed-core 10.1.55 pin
 (re-introduced 2026-05-25 for Apache Tomcat CVE-2026-43512 / -43513 / -43514 /
 -43515 / -42498 / -41284 / -41293)
 
+### 2026-07-11 — v0.1.25.51 codex REVISE-MAJOR: close live bypasses (#209)
+
+Codex security review of the PR found the create/update gate sound but
+several LIVE bypasses that had to close before shipping as a security
+fix. All verified against source, then fixed:
+
+1. **Replay bypassed the boundary.** `WebhookService.replay` filtered
+   historical events only by the request's optional type filter + the
+   subscription's `scope_filter` — never by the subscription's OWN
+   `event_types`/`event_categories`, and no status check. A
+   concrete-tenant budget-only subscription could replay historical
+   admin-only events to its tenant endpoint. Fix: replay now intersects
+   with the subscription's own selectors via
+   `WebhookRepository.matchesEventType` (made `public static`, shared
+   with live dispatch — spec `replayEvents`: "all event types the
+   subscription is subscribed to") AND short-circuits to a no-op on a
+   non-ACTIVE subscription (so a DISABLED offender receives nothing —
+   makes "disabling stops delivery" true for replay too). Pre-existing
+   bug, fixed here as a direct bypass of this boundary.
+2. **Reconciled offenders could be reactivated unrepaired.** A
+   status-only `{"status":"ACTIVE"}` PATCH passes null selector arrays
+   (per-array validator skips them) and update permits DISABLED→ACTIVE.
+   Fix: both controllers now validate the EFFECTIVE resulting selectors
+   (stored ∪ request), so reactivating a concrete-tenant row that still
+   holds admin-only selectors → 400.
+3. **Reconciler ignored admin-only event TYPES** — examined only
+   `event_categories`. A concrete-tenant row with
+   `event_types:["api_key.created"]` stayed ACTIVE. Fix: offender =
+   admin-only TYPE or CATEGORY (action renamed
+   `DISABLED_ADMIN_SELECTORS`, outcome field `offendingSelectors`).
+4. **`__system__` empty-both rows escaped cleanup** — the unconditional
+   `__system__` skip ran before empty-both detection. Fix: the system
+   carve-out exempts admin selectors ONLY; empty-both is checked for all
+   owners (system empty-both rows are disabled).
+5. **Blank `tenant_id` got an undocumented system exemption** —
+   `isSystemTarget` treated blank as system. Fix: a new
+   `WebhookSubscription.isSystemOwner` (null/omitted or literal
+   `__system__` only; blank = concrete) is the SINGLE predicate used by
+   both the validator (api) and reconciler (data) — closing finding 6
+   (validator/reconciler disagreement on null owner) at the same time.
+7. **Reconciler robustness.** Rewritten from `SMEMBERS`+sequential
+   GET/SET to: `SSCAN` cursor batching (bounded memory); atomic
+   compare-and-set Lua write (never clobbers a concurrent operator
+   update — a CAS miss is a counted failure, retried next pass); runs on
+   a **background daemon thread** so startup/readiness is NEVER blocked;
+   an incomplete pass (row error or CAS miss) is retried with
+   exponential backoff, and exhausted retries emit a loud ERROR alert
+   while the service stays up. **Readiness decision:** deliberately do
+   NOT hard-block readiness on migration completion — a migration bug
+   must not brick the service, the write-path gate already stops NEW
+   offenders, and legacy offenders merely remain DISABLED-pending until
+   a clean pass. `reconcileTenantCategoryBoundary` now returns a
+   `ReconcileResult(repaired, failures)`; the reconciler retries while
+   `failures>0`.
+8. **Migration wording** corrected: `api_key`/`webhook`/`system` events
+   are null-scoped (not `scope_filter`able → client-side `tenant_id`
+   filtering); `policy` events carry a real tenant-bounded scope and CAN
+   be `scope_filter`ed.
+
+Tests added: replay cannot deliver outside the subscription's selectors
+and is a no-op on a DISABLED sub; status-only reactivation of an
+unrepaired offender → 400 (tenant + admin plane; `__system__` still
+reactivatable); admin-only event TYPE on a concrete tenant → 400 (write)
+and flagged by the reconciler; `__system__` empty-both disabled;
+null-owner treated as system for admin-selector exemption but still
+empty-both-checked; blank `tenant_id` create with admin category → 400;
+reconciler CAS-miss → failure/incomplete + retry, corrupt-row failure,
+SSCAN batch paging (>1 batch), whole-pass failure incomplete, dry-run
+reports-without-mutating, retry-until-complete, give-up-and-alert.
+Data-module unit-job coverage restored to 0.9562 (gate 0.95; the CI gate
+that failed at 0.93 — the earlier reconciler coverage came only from the
+Testcontainers integration test, which the CI unit job excludes, so the
+new branches are covered by mocked-Jedis unit tests). Full build:
+1,621 tests (192 model + 579 data + 850 api), all module coverage gates
+green.
+
 ### 2026-07-11 — v0.1.25.51: admin-plane webhook category boundary + conservative offender cleanup (security, #209)
 
 Closes #209. The 0.1.25.50 fix closed the tenant-plane INJECTION path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,26 +18,43 @@ new optional request fields) are **not** considered breaking.
 
 ### Security
 
-- **Admin-plane webhook `event_categories` boundary — closes the CARRIER
-  source (#209).** `POST /v1/admin/webhooks?tenant_id=X` and
-  `PATCH /v1/admin/webhooks/{id}` applied no category validation, so an
-  operator / admin-on-behalf-of could place admin-only categories
-  (`api_key`, `policy`, `webhook`, `system`) on a subscription owned by a
-  concrete tenant X. Since event matching treats categories as an ADDITIVE
-  union, X — which controls that subscription's endpoint URL and signing
-  secret — then received admin-only governance/security telemetry for its
-  tenant. The 0.1.25.50 fix closed the tenant-plane *injection* path; this
-  closes the admin-plane *carrier* source. Both admin write paths now
-  validate `event_types` AND `event_categories` against the tenant-accessible
-  boundary (`budget.*`, `reservation.*`, `tenant.*`) when the target is a
-  **concrete tenant** — create validates against the `tenant_id` param,
-  update against the STORED subscription's `tenant_id` — rejecting admin-only
-  entries with 400 `INVALID_REQUEST`. Governance spec revision v0.1.25.40
-  (pending, runcycles/cycles-protocol#129) makes this normative.
-  - **`__system__` carve-out:** admin-only categories remain allowed on
+- **Admin-plane webhook boundary — closes the CARRIER source (#209).**
+  `POST /v1/admin/webhooks?tenant_id=X` and `PATCH /v1/admin/webhooks/{id}`
+  applied no boundary validation, so an operator / admin-on-behalf-of could
+  place admin-only event **types OR categories** (`api_key`, `policy`,
+  `webhook`, `system`) on a subscription owned by a concrete tenant X. Since
+  event matching unions types and categories, X — which controls that
+  subscription's endpoint URL and signing secret — then received admin-only
+  governance/security telemetry for its tenant. The 0.1.25.50 fix closed the
+  tenant-plane *injection* path; this closes the admin-plane *carrier* source.
+  Both admin write paths now validate `event_types` AND `event_categories`
+  against the tenant-accessible boundary (`budget.*`, `reservation.*`,
+  `tenant.*`) when the target is a **concrete tenant** — create validates
+  against the `tenant_id` param, update against the **effective resulting
+  selectors** (stored ∪ request) on the STORED subscription's `tenant_id` —
+  rejecting admin-only entries with 400 `INVALID_REQUEST`. Validating the
+  effective result means a status-only reactivation (`{"status":"ACTIVE"}`)
+  cannot re-enable a disabled offender that still holds admin-only selectors.
+  Governance spec revision v0.1.25.40 (pending, runcycles/cycles-protocol#129)
+  makes this normative.
+  - **`__system__` carve-out:** admin-only selectors remain allowed on
     `__system__`-owned subscriptions (no `tenant_id` param, or an
-    `__system__` target) — those are legitimate system-wide monitoring and
-    are not tenant-owned.
+    `__system__` target) — legitimate system-wide monitoring, not
+    tenant-owned. A null/omitted owner is treated the same; a blank
+    (whitespace-only) `tenant_id` is NOT exempt (treated as concrete and
+    validated).
+
+- **Replay honors the subscription's own selectors (#209).**
+  `POST /v1/admin/webhooks/{id}/replay` filtered historical events only by
+  the request's optional `event_types` + the subscription's `scope_filter`,
+  never by the subscription's OWN `event_types`/`event_categories`, and did
+  not check status — so replaying a concrete-tenant budget-only subscription
+  could dispatch historical ADMIN-only events to its tenant-controlled
+  endpoint (a direct bypass of this boundary; likely pre-existing). Replay now
+  intersects delivered events with the subscription's own selectors (spec
+  `replayEvents`: "all event types the subscription is subscribed to") and is
+  a no-op on a non-`ACTIVE` subscription — so a DISABLED offender receives
+  nothing via replay either.
 
 - **BEHAVIOR CHANGE — previously-allowed capability removed.** In 0.1.25.50
   the admin plane deliberately did NOT restrict categories (documented as
@@ -52,33 +69,41 @@ new optional request fields) are **not** considered breaking.
   filtered by **`event_categories`** to the admin classes you need. Because
   `__system__` is in the dispatch union for every tenant, that subscription
   receives those admin events for ALL tenants; select the specific tenant
-  **client-side** on the envelope's `tenant_id` (admin lifecycle events carry
-  `tenant_id` even though their `scope` is null). Do NOT use a `scope_filter`
-  for this — admin lifecycle events are null-scoped, and a `scope_filter`
-  excludes null-scoped events, so it would deliver none of them. The
-  `__system__` row is not tenant-owned, so its URL and secret stay
-  operator-controlled.
+  **client-side** on the envelope's `tenant_id`. Note on `scope_filter`:
+  `api_key.*`, `webhook.*` and `system.*` events are **null-scoped**, and a
+  `scope_filter` excludes null-scoped events, so it would deliver none of
+  them — client-side `tenant_id` filtering is the general solution. `policy.*`
+  events carry a real tenant-bounded `scope` and CAN be `scope_filter`ed if
+  you only need policy events. The `__system__` row is not tenant-owned, so
+  its URL and secret stay operator-controlled.
 
 ### Fixed
 
 - **One-time cleanup of pre-existing offender rows (#209, d2).** A startup
-  reconciler (idempotent; runs once per boot, no new API surface) finds
-  TENANT-owned subscriptions that already carry admin-only `event_categories`
-  and legacy empty-both match-ALL rows, and **DISABLEs** them (status
-  `DISABLED`) — conservative by design: it does NOT silently strip
-  categories, because a concrete-tenant admin-category row might be a
-  legit-but-misconfigured operator monitoring subscription, and a silent
-  rewrite would break it with no signal. Disabling stops delivery
-  immediately (dispatch matches only `ACTIVE` rows), is reversible, preserves
-  the row and its offending categories for operator review, and is loudly
-  logged with the `subscription_id`, `tenant_id`, and offending categories.
-  Configure with `webhook.category-boundary.reconcile-on-startup` (default
-  `true`) and `webhook.category-boundary.reconcile-dry-run` (default `false`
-  — set `true` to REPORT offenders in the logs without disabling anything,
-  for review before the disabling pass). Operators can also still find
-  offenders with the `redis-cli`/`jq` recipe from the [0.1.25.50] Security
-  note. Repaired (DISABLED) rows should be migrated per the migration note
-  above, or deleted.
+  reconciler (idempotent, resumable, no new API surface) finds concrete-tenant
+  subscriptions that already carry admin-only event **types or categories**,
+  and empty-both match-ALL rows (on any owner, `__system__` included — the
+  system carve-out exempts admin selectors only, not the "at least one
+  selector" invariant), and **DISABLEs** them — conservative by design: it
+  does NOT silently strip selectors, because a concrete-tenant admin-selector
+  row might be a legit-but-misconfigured operator monitoring subscription and
+  a silent rewrite would break it with no signal. Disabling stops delivery
+  immediately (live dispatch AND replay match only `ACTIVE` rows), is
+  reversible, preserves the row + offending selectors for review, and is
+  loudly logged. **Robustness:** it `SSCAN`s the index in batches (bounded
+  memory), writes via an atomic compare-and-set (never clobbers a concurrent
+  operator update), and runs on a **background thread** so startup/readiness
+  is never blocked; an incomplete pass (row error or CAS miss) is retried with
+  exponential backoff, and if retries are exhausted a loud `ERROR` alert is
+  emitted and the service stays up (a migration bug must not brick the
+  service — and the write-path gate already stops NEW offenders, so legacy
+  offenders merely remain DISABLED-pending). Configure with
+  `webhook.category-boundary.reconcile-on-startup` (default `true`) and
+  `webhook.category-boundary.reconcile-dry-run` (default `false` — `true`
+  REPORTS offenders in the logs without disabling anything). Operators can
+  also find offenders with the `redis-cli`/`jq` recipe from the [0.1.25.50]
+  Security note. Repaired (DISABLED) rows should be migrated per the migration
+  note above, or deleted.
 
 ## [0.1.25.50] — 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,12 +146,15 @@ new optional request fields) are **not** considered breaking.
     concurrent lifecycle change is not mistaken for a backend problem —
     `dispatchToSubscription` returns a structured outcome
     (`ENQUEUED`/`INACTIVE`/`BLOCKED`/`ENQUEUE_FAILED`):
-    - if any event hit `ENQUEUE_FAILED` (real transient backend failure) →
-      **WARN** "DEGRADED dispatch backend" with the per-category counts
+    - if any event hit `ENQUEUE_FAILED` (real backend failure — the `LPUSH`/save
+      failed, OR the dispatch-time subscription re-read failed with a
+      Redis/deserialization error rather than a genuine not-found) → **WARN**
+      "DEGRADED dispatch backend" with the per-category counts
       (`selected`/`enqueued`/`enqueue_failed`/`inactive`/`blocked`);
     - if the shortfall is ONLY `INACTIVE` (subscription concurrently
-      paused/disabled/deleted, re-checked at dispatch) and/or `BLOCKED`
-      (delivery-time ownership guard) → **INFO** (intended, not degradation).
+      paused/disabled at the re-check, or genuinely deleted — `WEBHOOK_NOT_FOUND`
+      only) and/or `BLOCKED` (delivery-time ownership guard) → **INFO** (intended,
+      not degradation). A re-read backend error is NOT hidden as `INACTIVE`.
 
     Replay is **NOT idempotent** — delivery IDs are random, so a retry may
     duplicate already-queued deliveries.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,21 @@ new optional request fields) are **not** considered breaking.
     chronologically. There is no "advance `from` to continue" / "lower
     `max_events` to page" guidance — `max_events` bounds the window size, it is
     not a continuation cursor.
+  - **`max_events` is validated `[1,1000]` (400, not silently clamped).**
+    `ReplayRequest.max_events` now carries `@Min(1) @Max(1000)` (jakarta
+    validation) and the replay endpoint's `@RequestBody` is `@Valid`, so
+    `max_events=0` or `max_events=1001` is rejected with **400** (matching the
+    governance spec's declared `minimum:1`/`maximum:1000`). The prior
+    `Math.min(max_events, 1000)` silent clamp is removed. Omitting `max_events`
+    still defaults to 100.
+  - **Enqueue is BEST-EFFORT, and `events_queued` reports the accepted count
+    (governance #130).** Selection is complete for the window, but per-event
+    enqueue onto the dispatch queue is best-effort: on a transient backend
+    failure `events_queued` may be fewer than the events selected. A **loud WARN**
+    (`replay_id`, `subscription_id`, `selected`, `queued`) is logged whenever
+    `events_queued < selected` so a degraded backend is operator-observable.
+    Replay is **NOT idempotent** — delivery IDs are random, so a retry may
+    duplicate already-queued deliveries.
 
 - **Bulk RESUME routed through boundary validation (#209).**
   `POST /v1/admin/webhooks/bulk-action` with `action: RESUME` reached `ACTIVE`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,18 +93,26 @@ new optional request fields) are **not** considered breaking.
   status TOCTOU). The fail-closed dispatch boundary above also applies on the
   replay path, so even an ACTIVE offender delivers none of its admin-only
   historical events.
-  - **Cap-then-filter under-delivery fixed.** Replay previously fetched a single
-    page capped at `max_events` and then applied the selector/scope/type filters
-    AS post-hoc stream filters — so if the first `max_events` (default 100)
-    events in the `[from,to]` window didn't match but later ones did, replay
-    queued ZERO despite matching events existing. Replay now PAGES the window
-    chronologically (bounded batches) and applies every filter — request
+  - **Cap-then-filter under-delivery fixed (no-miss AND no-duplicate).** Replay
+    previously fetched a single page capped at `max_events` and then applied the
+    selector/scope/type filters AS post-hoc stream filters — so if the first
+    `max_events` (default 100) events in the `[from,to]` window didn't match but
+    later ones did, replay queued ZERO despite matching events existing. Replay
+    now takes ONE bounded, ordered, de-duplicated event-id list for the window
+    (a single `ZRANGEBYSCORE`, `EventRepository.listEventIdsInRange`) and
+    hydrates + filters in fixed batches over it, applying every filter — request
     `event_types` ∩ the subscription's own selectors ∩ `scope_filter` ∩ the
-    ownership boundary — DURING pagination, accumulating up to `max_events`
-    **deliverable** events (so the cap counts deliverable events, not scanned
-    ones), then delivers them in chronological order (spec `replayEvents`). A
-    total scan ceiling bounds cost on very sparse windows and logs a warning if
-    hit before the cap is filled (never a silent truncation).
+    ownership boundary — while accumulating up to `max_events` **deliverable**
+    events (so the cap counts deliverable events, not scanned ones), then
+    delivers them in chronological order (spec `replayEvents`). Reading the whole
+    ordered member set up front (rather than walking a millisecond score cursor)
+    avoids three cursor hazards on the ms-scored index: equal-timestamp members
+    skipped when the cursor advanced by `score+1`, a hydration-thinned short page
+    misread as range exhaustion, and duplicate pages when a cursor member had
+    vanished. The scan is bounded by `webhook.replay.max-scan` (default 20000);
+    hitting the ceiling before the cap is filled logs a warning (never a silent
+    truncation). No change to `EventRepository.list()` or its cursor, so other
+    event-listing callers are unaffected.
 
 - **Bulk RESUME routed through boundary validation (#209).**
   `POST /v1/admin/webhooks/bulk-action` with `action: RESUME` reached `ACTIVE`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,72 @@ changes to request/response bodies or Lua-script semantics would require a
 minor bump. Additive fields (new optional response fields, new enum values,
 new optional request fields) are **not** considered breaking.
 
+## [0.1.25.51] — 2026-07-11
+
+### Security
+
+- **Admin-plane webhook `event_categories` boundary — closes the CARRIER
+  source (#209).** `POST /v1/admin/webhooks?tenant_id=X` and
+  `PATCH /v1/admin/webhooks/{id}` applied no category validation, so an
+  operator / admin-on-behalf-of could place admin-only categories
+  (`api_key`, `policy`, `webhook`, `system`) on a subscription owned by a
+  concrete tenant X. Since event matching treats categories as an ADDITIVE
+  union, X — which controls that subscription's endpoint URL and signing
+  secret — then received admin-only governance/security telemetry for its
+  tenant. The 0.1.25.50 fix closed the tenant-plane *injection* path; this
+  closes the admin-plane *carrier* source. Both admin write paths now
+  validate `event_types` AND `event_categories` against the tenant-accessible
+  boundary (`budget.*`, `reservation.*`, `tenant.*`) when the target is a
+  **concrete tenant** — create validates against the `tenant_id` param,
+  update against the STORED subscription's `tenant_id` — rejecting admin-only
+  entries with 400 `INVALID_REQUEST`. Governance spec revision v0.1.25.40
+  (pending, runcycles/cycles-protocol#129) makes this normative.
+  - **`__system__` carve-out:** admin-only categories remain allowed on
+    `__system__`-owned subscriptions (no `tenant_id` param, or an
+    `__system__` target) — those are legitimate system-wide monitoring and
+    are not tenant-owned.
+
+- **BEHAVIOR CHANGE — previously-allowed capability removed.** In 0.1.25.50
+  the admin plane deliberately did NOT restrict categories (documented as
+  "the boundary is tenant-plane-only, not a global tightening"), so
+  admin-only categories on a concrete-tenant subscription via
+  `/v1/admin/webhooks` returned 201/200. That is now a 400 — a security
+  correction, because a tenant-owned row exposes the endpoint URL + signing
+  secret to the tenant. **Migration:** if you were monitoring a specific
+  tenant's admin-only events (e.g. `api_key.*`, `policy.*`) via a tenant-owned
+  subscription pointed at an operator endpoint, replace it with a
+  **`__system__`-owned** subscription (create with no `tenant_id` param)
+  filtered by **`event_categories`** to the admin classes you need. Because
+  `__system__` is in the dispatch union for every tenant, that subscription
+  receives those admin events for ALL tenants; select the specific tenant
+  **client-side** on the envelope's `tenant_id` (admin lifecycle events carry
+  `tenant_id` even though their `scope` is null). Do NOT use a `scope_filter`
+  for this — admin lifecycle events are null-scoped, and a `scope_filter`
+  excludes null-scoped events, so it would deliver none of them. The
+  `__system__` row is not tenant-owned, so its URL and secret stay
+  operator-controlled.
+
+### Fixed
+
+- **One-time cleanup of pre-existing offender rows (#209, d2).** A startup
+  reconciler (idempotent; runs once per boot, no new API surface) finds
+  TENANT-owned subscriptions that already carry admin-only `event_categories`
+  and legacy empty-both match-ALL rows, and **DISABLEs** them (status
+  `DISABLED`) — conservative by design: it does NOT silently strip
+  categories, because a concrete-tenant admin-category row might be a
+  legit-but-misconfigured operator monitoring subscription, and a silent
+  rewrite would break it with no signal. Disabling stops delivery
+  immediately (dispatch matches only `ACTIVE` rows), is reversible, preserves
+  the row and its offending categories for operator review, and is loudly
+  logged with the `subscription_id`, `tenant_id`, and offending categories.
+  Configure with `webhook.category-boundary.reconcile-on-startup` (default
+  `true`) and `webhook.category-boundary.reconcile-dry-run` (default `false`
+  — set `true` to REPORT offenders in the logs without disabling anything,
+  for review before the disabling pass). Operators can also still find
+  offenders with the `redis-cli`/`jq` recipe from the [0.1.25.50] Security
+  note. Repaired (DISABLED) rows should be migrated per the migration note
+  above, or deleted.
+
 ## [0.1.25.50] — 2026-07-10
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,10 +109,21 @@ new optional request fields) are **not** considered breaking.
     avoids three cursor hazards on the ms-scored index: equal-timestamp members
     skipped when the cursor advanced by `score+1`, a hydration-thinned short page
     misread as range exhaustion, and duplicate pages when a cursor member had
-    vanished. The scan is bounded by `webhook.replay.max-scan` (default 20000);
-    hitting the ceiling before the cap is filled logs a warning (never a silent
-    truncation). No change to `EventRepository.list()` or its cursor, so other
+    vanished. No change to `EventRepository.list()` or its cursor, so other
     event-listing callers are unaffected.
+  - **Over-large replay window is a caller-visible 400 (no silent partial).** The
+    scan is bounded by `webhook.replay.max-scan` (default 20000). Returning fewer
+    than `max_events` would read to the caller as "these are ALL the matching
+    events in my window" — but if the window's candidate count exceeds that
+    ceiling the search was truncated and more may exist beyond it. Replay now
+    fetches one candidate past the ceiling to detect this and, when the ceiling
+    is reached AND fewer than `max_events` deliverable events were found within
+    the scanned set, returns **400 `INVALID_REQUEST`** BEFORE enqueuing any
+    delivery (message: *"replay window too large: it exceeds the replay scan
+    limit of N events; narrow the from/to range"*) — no partial side effects.
+    When `max_events` IS filled within the ceiling that is the caller's explicit
+    pagination cap (not truncation) and replay proceeds normally
+    (`events_queued == max_events` signals "there may be more").
 
 - **Bulk RESUME routed through boundary validation (#209).**
   `POST /v1/admin/webhooks/bulk-action` with `action: RESUME` reached `ACTIVE`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,10 +141,18 @@ new optional request fields) are **not** considered breaking.
     still defaults to 100.
   - **Enqueue is BEST-EFFORT, and `events_queued` reports the accepted count
     (governance #130).** Selection is complete for the window, but per-event
-    enqueue onto the dispatch queue is best-effort: on a transient backend
-    failure `events_queued` may be fewer than the events selected. A **loud WARN**
-    (`replay_id`, `subscription_id`, `selected`, `queued`) is logged whenever
-    `events_queued < selected` so a degraded backend is operator-observable.
+    enqueue onto the dispatch queue is best-effort: `events_queued` may be fewer
+    than the events selected. A shortfall is **categorized** so a benign
+    concurrent lifecycle change is not mistaken for a backend problem —
+    `dispatchToSubscription` returns a structured outcome
+    (`ENQUEUED`/`INACTIVE`/`BLOCKED`/`ENQUEUE_FAILED`):
+    - if any event hit `ENQUEUE_FAILED` (real transient backend failure) →
+      **WARN** "DEGRADED dispatch backend" with the per-category counts
+      (`selected`/`enqueued`/`enqueue_failed`/`inactive`/`blocked`);
+    - if the shortfall is ONLY `INACTIVE` (subscription concurrently
+      paused/disabled/deleted, re-checked at dispatch) and/or `BLOCKED`
+      (delivery-time ownership guard) → **INFO** (intended, not degradation).
+
     Replay is **NOT idempotent** — delivery IDs are random, so a retry may
     duplicate already-queued deliveries.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,19 +111,27 @@ new optional request fields) are **not** considered breaking.
     misread as range exhaustion, and duplicate pages when a cursor member had
     vanished. No change to `EventRepository.list()` or its cursor, so other
     event-listing callers are unaffected.
-  - **Over-large replay window is a caller-visible 400 (no silent partial).** The
-    scan is bounded by `webhook.replay.max-scan` (default 20000). Returning fewer
-    than `max_events` would read to the caller as "these are ALL the matching
-    events in my window" — but if the window's candidate count exceeds that
-    ceiling the search was truncated and more may exist beyond it. Replay now
-    fetches one candidate past the ceiling to detect this and, when the ceiling
-    is reached AND fewer than `max_events` deliverable events were found within
-    the scanned set, returns **400 `INVALID_REQUEST`** BEFORE enqueuing any
-    delivery (message: *"replay window too large: it exceeds the replay scan
-    limit of N events; narrow the from/to range"*) — no partial side effects.
-    When `max_events` IS filled within the ceiling that is the caller's explicit
-    pagination cap (not truncation) and replay proceeds normally
-    (`events_queued == max_events` signals "there may be more").
+  - **Replay is ALL-OR-NARROW (a success is complete for its window).**
+    `max_events` is NOT a resumable pagination cursor — `ReplayResponse` carries
+    no continuation position, so a partial result could not be resumed losslessly
+    (distinct timestamps: the caller never learns the last replayed timestamp;
+    same-millisecond events: an inclusive `from` would repeat or skip). So a
+    SUCCESSFUL replay delivers EVERY deliverable event in `[from,to]`; it never
+    returns a partial with an implied "continue". Two fail-fast **400
+    `INVALID_REQUEST`** cases (thrown BEFORE any delivery is enqueued — no partial
+    side effects; the replay lock is released):
+    - the window's candidate count exceeds the server scan limit
+      (`webhook.replay.max-scan`, default 20000) — completeness can't be
+      guaranteed over the unscanned tail — *"replay window too large: it exceeds
+      the replay scan limit of N events; narrow the from/to range"*; or
+    - the fully-scanned window holds MORE than `max_events` deliverable events —
+      *"replay window contains more than max_events (N) deliverable events;
+      narrow the from/to range, or raise max_events (up to 1000)"*.
+
+    Otherwise (fully scanned, ≤ `max_events` deliverable) ALL are delivered,
+    chronologically. There is no "advance `from` to continue" / "lower
+    `max_events` to page" guidance — `max_events` bounds the window size, it is
+    not a continuation cursor.
 
 - **Bulk RESUME routed through boundary validation (#209).**
   `POST /v1/admin/webhooks/bulk-action` with `action: RESUME` reached `ACTIVE`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,22 @@ new optional request fields) are **not** considered breaking.
 
 ### Security
 
+- **Fail-closed DISPATCH boundary — the durable confidentiality guarantee (#209).**
+  The write-path gates (below) stop NEW offenders and the reconciler (below)
+  cleans up STORED ones, but both are point-in-time: a concrete-tenant
+  subscription that already holds admin-only selectors and has not yet been
+  reconciled would still deliver admin-only events. The guarantee is now
+  enforced at DELIVERY, unconditionally: in BOTH live dispatch
+  (`WebhookDispatchService`) and replay (`dispatchToSubscription`), an event is
+  skipped **per event** when the subscription is concrete-tenant-owned
+  (`isSystemOwner == false`) AND the event is admin-only (reusing the
+  `WebhookCategoryBoundaryValidator` boundary). This is fail-closed and does not
+  depend on the reconciler having run, on stored-selector correctness, or on
+  status transitions — a concrete-tenant subscription can never receive an
+  admin-only event. It filters per event, so a mixed subscription still receives
+  its tenant-accessible events; only the admin-only ones are withheld (counted
+  as `boundary_skipped`). `__system__`-owned subscriptions are unaffected.
+
 - **Admin-plane webhook boundary — closes the CARRIER source (#209).**
   `POST /v1/admin/webhooks?tenant_id=X` and `PATCH /v1/admin/webhooks/{id}`
   applied no boundary validation, so an operator / admin-on-behalf-of could
@@ -54,7 +70,20 @@ new optional request fields) are **not** considered breaking.
   intersects delivered events with the subscription's own selectors (spec
   `replayEvents`: "all event types the subscription is subscribed to") and is
   a no-op on a non-`ACTIVE` subscription — so a DISABLED offender receives
-  nothing via replay either.
+  nothing via replay either. Status is additionally **re-checked at dispatch
+  time** (in `dispatchToSubscription`, after the initial guard) so a
+  subscription disabled concurrently mid-replay stops delivering (closes a
+  status TOCTOU). The fail-closed dispatch boundary above also applies on the
+  replay path, so even an ACTIVE offender delivers none of its admin-only
+  historical events.
+
+- **Bulk RESUME routed through boundary validation (#209).**
+  `POST /v1/admin/webhooks/bulk-action` with `action: RESUME` reached `ACTIVE`
+  via `webhookService.update` directly, bypassing the single-op effective
+  -selector validation — so a PAUSED concrete-tenant offender could be bulk
+  -resumed. RESUME now validates the stored (effective) selectors against the
+  owning tenant before reactivating; an offender fails the row
+  (`INVALID_TRANSITION`) instead of resuming.
 
 - **BEHAVIOR CHANGE — previously-allowed capability removed.** In 0.1.25.50
   the admin plane deliberately did NOT restrict categories (documented as
@@ -79,31 +108,43 @@ new optional request fields) are **not** considered breaking.
 
 ### Fixed
 
-- **One-time cleanup of pre-existing offender rows (#209, d2).** A startup
-  reconciler (idempotent, resumable, no new API surface) finds concrete-tenant
-  subscriptions that already carry admin-only event **types or categories**,
-  and empty-both match-ALL rows (on any owner, `__system__` included — the
-  system carve-out exempts admin selectors only, not the "at least one
-  selector" invariant), and **DISABLEs** them — conservative by design: it
-  does NOT silently strip selectors, because a concrete-tenant admin-selector
-  row might be a legit-but-misconfigured operator monitoring subscription and
-  a silent rewrite would break it with no signal. Disabling stops delivery
-  immediately (live dispatch AND replay match only `ACTIVE` rows), is
-  reversible, preserves the row + offending selectors for review, and is
-  loudly logged. **Robustness:** it `SSCAN`s the index in batches (bounded
-  memory), writes via an atomic compare-and-set (never clobbers a concurrent
-  operator update), and runs on a **background thread** so startup/readiness
-  is never blocked; an incomplete pass (row error or CAS miss) is retried with
+- **One-time STORAGE HYGIENE for pre-existing offender rows (#209, d2).** A
+  startup reconciler (idempotent, resumable, no new API surface) brings STORED
+  selectors in line with the delivery behavior the dispatch boundary already
+  enforces. **This is not the security mechanism** — the fail-closed dispatch
+  boundary (above) is; the reconciler is best-effort cleanup and, because
+  dispatch already blocks the leak, admin-only selectors on a concrete-tenant
+  row are already non-functional. Per row (skips already-`DISABLED` rows):
+  - **Concrete-tenant rows carrying admin-only types/categories:** the
+    admin-only selectors are **STRIPPED** and tenant-accessible ones kept
+    (`STRIPPED_ADMIN_SELECTORS`). Because dispatch already withholds those
+    admin events, stripping is not a behavior change and has no collateral on
+    legitimate tenant-accessible deliveries; it makes storage match effective
+    behavior. If stripping empties BOTH selector lists (the row would then
+    match every event) it is DISABLED instead (`STRIPPED_AND_DISABLED`).
+  - **Empty-both match-ALL rows** on any owner (`__system__` included — the
+    system carve-out exempts admin selectors only, not the "at least one
+    selector" invariant) are **DISABLED** (`DISABLED_EMPTY_BOTH`).
+  - **Null-owner rows** (corruption): normalized to the `__system__` owner and
+    added to the `webhooks:__system__` dispatch index (`NORMALIZED_NULL_OWNER`),
+    removing the limbo state (exempt from repair yet absent from every dispatch
+    index) rather than leaving them un-indexed.
+
+  Every action is loudly logged. **Robustness:** it `SSCAN`s the index in
+  batches (bounded memory), writes via an atomic compare-and-set (never
+  clobbers a concurrent operator update — a CAS miss is a counted failure and
+  retried), and runs on a **managed daemon executor** that is interrupted and
+  awaited on Spring context shutdown (`@PreDestroy`) so it stops cleanly instead
+  of leaking a thread sleeping through a retry backoff. Startup/readiness is
+  never blocked; an incomplete pass (row error or CAS miss) is retried with
   exponential backoff, and if retries are exhausted a loud `ERROR` alert is
-  emitted and the service stays up (a migration bug must not brick the
-  service — and the write-path gate already stops NEW offenders, so legacy
-  offenders merely remain DISABLED-pending). Configure with
+  emitted and the service stays up (hygiene must not brick the service — and
+  delivery is already safe via the dispatch boundary). Configure with
   `webhook.category-boundary.reconcile-on-startup` (default `true`) and
   `webhook.category-boundary.reconcile-dry-run` (default `false` — `true`
-  REPORTS offenders in the logs without disabling anything). Operators can
+  REPORTS the actions in the logs without mutating anything). Operators can
   also find offenders with the `redis-cli`/`jq` recipe from the [0.1.25.50]
-  Security note. Repaired (DISABLED) rows should be migrated per the migration
-  note above, or deleted.
+  Security note.
 
 ## [0.1.25.50] — 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,12 +27,29 @@ new optional request fields) are **not** considered breaking.
   (`WebhookDispatchService`) and replay (`dispatchToSubscription`), an event is
   skipped **per event** when the subscription is concrete-tenant-owned
   (`isSystemOwner == false`) AND the event is admin-only (reusing the
-  `WebhookCategoryBoundaryValidator` boundary). This is fail-closed and does not
-  depend on the reconciler having run, on stored-selector correctness, or on
-  status transitions — a concrete-tenant subscription can never receive an
-  admin-only event. It filters per event, so a mixed subscription still receives
-  its tenant-accessible events; only the admin-only ones are withheld (counted
-  as `boundary_skipped`). `__system__`-owned subscriptions are unaffected.
+  `WebhookCategoryBoundaryValidator` boundary). The predicate is strictly
+  fail-closed: it blocks if EITHER the event's TYPE **or** its (independent,
+  cross-plane) CATEGORY is admin-only, and it blocks an unclassifiable record
+  (type and category both null) — `Event.category` is not always derived from
+  the type, so a malformed or type/category-inconsistent record can't slip
+  through to a tenant endpoint. This does not depend on the reconciler having
+  run, on stored-selector correctness, or on status transitions — a
+  concrete-tenant subscription can never receive an admin-only event. It filters
+  per event, so a mixed subscription still receives its tenant-accessible
+  events; only the admin-only ones are withheld (counted as `boundary_skipped`).
+  `__system__`-owned subscriptions are unaffected.
+  - **`/test` exception (documented).** `POST /v1/webhooks/{id}/test` and its
+    admin twin POST a spec-defined `system.webhook_test` ping DIRECTLY to the
+    subscription URL (not via the dispatch queue), so a tenant-owned
+    subscription's own test delivers an admin-category (`system`) synthetic
+    event. This is a narrow, explicit EXCEPTION to the invariant: the governance
+    spec (the authority) defines the test event as `system.webhook_test`, the
+    payload is an owner-triggered probe (`{subscription_id, test:true}`) carrying
+    NO real governance/security telemetry, and reclassifying the wire envelope
+    would both diverge from the spec and produce the type/category-inconsistent
+    record the dispatch boundary now blocks. Confidentiality is intact (no real
+    admin telemetry reaches a tenant endpoint); only a synthetic self-test
+    carries the `system` label. The spec-side exception is tracked separately.
 
 - **Admin-plane webhook boundary — closes the CARRIER source (#209).**
   `POST /v1/admin/webhooks?tenant_id=X` and `PATCH /v1/admin/webhooks/{id}`
@@ -76,6 +93,18 @@ new optional request fields) are **not** considered breaking.
   status TOCTOU). The fail-closed dispatch boundary above also applies on the
   replay path, so even an ACTIVE offender delivers none of its admin-only
   historical events.
+  - **Cap-then-filter under-delivery fixed.** Replay previously fetched a single
+    page capped at `max_events` and then applied the selector/scope/type filters
+    AS post-hoc stream filters — so if the first `max_events` (default 100)
+    events in the `[from,to]` window didn't match but later ones did, replay
+    queued ZERO despite matching events existing. Replay now PAGES the window
+    chronologically (bounded batches) and applies every filter — request
+    `event_types` ∩ the subscription's own selectors ∩ `scope_filter` ∩ the
+    ownership boundary — DURING pagination, accumulating up to `max_events`
+    **deliverable** events (so the cap counts deliverable events, not scanned
+    ones), then delivers them in chronological order (spec `replayEvents`). A
+    total scan ceiling bounds cost on very sparse windows and logs a warning if
+    hit before the cap is filled (never a silent truncation).
 
 - **Bulk RESUME routed through boundary validation (#209).**
   `POST /v1/admin/webhooks/bulk-action` with `action: RESUME` reached `ACTIVE`
@@ -114,7 +143,9 @@ new optional request fields) are **not** considered breaking.
   enforces. **This is not the security mechanism** — the fail-closed dispatch
   boundary (above) is; the reconciler is best-effort cleanup and, because
   dispatch already blocks the leak, admin-only selectors on a concrete-tenant
-  row are already non-functional. Per row (skips already-`DISABLED` rows):
+  row are already non-functional. The strip/disable actions skip already
+  -`DISABLED` rows (idempotent); the NORMALIZE and INDEX actions run regardless
+  of status. Per row:
   - **Concrete-tenant rows carrying admin-only types/categories:** the
     admin-only selectors are **STRIPPED** and tenant-accessible ones kept
     (`STRIPPED_ADMIN_SELECTORS`). Because dispatch already withholds those
@@ -128,12 +159,18 @@ new optional request fields) are **not** considered breaking.
   - **Null-owner rows** (corruption): normalized to the `__system__` owner and
     added to the `webhooks:__system__` dispatch index (`NORMALIZED_NULL_OWNER`),
     removing the limbo state (exempt from repair yet absent from every dispatch
-    index) rather than leaving them un-indexed.
+    index) rather than leaving them un-indexed. The owner rewrite (SET) and the
+    index add (SADD) run in ONE atomic Lua op, so a partial failure can never
+    persist the owner while leaving the row un-indexed. This runs even for a
+    DISABLED null-owner row.
+  - **System-owned rows MISSING from the index** (e.g. left behind by a prior
+    partial normalization): membership repaired via an idempotent SADD,
+    independent of status (`INDEXED_SYSTEM_MEMBER`).
 
   Every action is loudly logged. **Robustness:** it `SSCAN`s the index in
-  batches (bounded memory), writes via an atomic compare-and-set (never
-  clobbers a concurrent operator update — a CAS miss is a counted failure and
-  retried), and runs on a **managed daemon executor** that is interrupted and
+  batches (bounded memory), writes via an atomic compare-and-set + index add
+  (never clobbers a concurrent operator update — a CAS miss is a counted failure
+  and retried), and runs on a **managed daemon executor** that is interrupted and
   awaited on Spring context shutdown (`@PreDestroy`) so it stops cleanly instead
   of leaking a thread sleeping through a retry backoff. Startup/readiness is
   never blocked; an incomplete pass (row error or CAS miss) is retried with
@@ -145,6 +182,13 @@ new optional request fields) are **not** considered breaking.
   REPORTS the actions in the logs without mutating anything). Operators can
   also find offenders with the `redis-cli`/`jq` recipe from the [0.1.25.50]
   Security note.
+
+- **Replay `events_queued` no longer over-reports (#209).** `dispatchToSubscription`
+  returned `true` even when the delivery row was persisted but the `LPUSH` onto
+  `dispatch:pending` failed (the enqueue error was swallowed), so replay counted
+  a delivery the worker would never pick up. `createDelivery` now returns whether
+  the row was actually ENQUEUED, and `dispatchToSubscription` (and the live
+  dispatch metric) propagate it — `events_queued` counts only real enqueues.
 
 ## [0.1.25.50] — 2026-07-10
 

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/WebhookAdminController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/WebhookAdminController.java
@@ -482,6 +482,14 @@ public class WebhookAdminController {
                     .message("Cannot resume DISABLED subscription").build());
                 return;
             }
+            // #209: bulk RESUME reached ACTIVE via webhookService.update directly,
+            // bypassing the single-op effective-selector validation — so a PAUSED
+            // concrete-tenant offender could be resumed. Validate the stored
+            // (effective) selectors against the owning tenant; an offender fails
+            // the row (dispatch is fail-closed regardless, but an offender must
+            // not go ACTIVE with admin-only selectors on a concrete tenant).
+            categoryBoundaryValidator.validateForTarget(live.getTenantId(),
+                live.getEventTypes(), live.getEventCategories());
             WebhookUpdateRequest update = WebhookUpdateRequest.builder()
                 .status(WebhookStatus.ACTIVE).build();
             webhookService.update(id, update);

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/WebhookAdminController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/WebhookAdminController.java
@@ -7,6 +7,7 @@ import io.runcycles.admin.api.filter.TraceContextFilter;
 import io.runcycles.admin.api.service.BulkActionAuditMetadataBuilder;
 import io.runcycles.admin.api.service.EventService;
 import io.runcycles.admin.api.service.TerminalOwnerMutationGuard;
+import io.runcycles.admin.api.service.WebhookCategoryBoundaryValidator;
 import io.runcycles.admin.api.service.WebhookService;
 import io.runcycles.admin.data.exception.GovernanceException;
 import io.runcycles.admin.data.idempotency.IdempotencyStore;
@@ -59,6 +60,7 @@ public class WebhookAdminController {
     @Autowired private AuditRepository auditRepository;
     @Autowired private IdempotencyStore idempotencyStore;
     @Autowired private TerminalOwnerMutationGuard mutationGuard;
+    @Autowired private WebhookCategoryBoundaryValidator categoryBoundaryValidator;
     @Autowired private EventService eventService;
     @Autowired private ObjectMapper objectMapper;
 
@@ -66,7 +68,17 @@ public class WebhookAdminController {
     public ResponseEntity<WebhookCreateResponse> create(
             @RequestParam(required = false) String tenant_id,
             @Valid @RequestBody WebhookCreateRequest request, HttpServletRequest httpRequest) {
-        String tenantId = tenant_id != null ? tenant_id : "__system__";
+        String tenantId = tenant_id != null ? tenant_id : WebhookCategoryBoundaryValidator.SYSTEM_TENANT;
+        // #209 / governance v0.1.25.40 (pending): the admin plane is the CARRIER
+        // source — an operator could place admin-only event_types/categories on
+        // a tenant-owned subscription, and since matchesEventType treats
+        // categories as an ADDITIVE union the owning tenant (which controls the
+        // endpoint URL + signing secret) would then receive admin-only
+        // governance/security telemetry. Validate the request against the target
+        // tenant; __system__ subscriptions are NOT tenant-owned, so admin-only
+        // categories remain allowed there (legitimate system-wide monitoring).
+        categoryBoundaryValidator.validateForTarget(tenantId,
+            request.getEventTypes(), request.getEventCategories());
         // Rule 2: refuse creating a subscription under a CLOSED tenant. Guard
         // no-ops on the "__system__" sentinel (no tenant record exists for it).
         if (tenant_id != null) mutationGuard.assertTenantOpen(tenantId);
@@ -140,6 +152,12 @@ public class WebhookAdminController {
         // Capture prior status BEFORE mutating so we can classify the emit
         // type (WEBHOOK_PAUSED / WEBHOOK_RESUMED vs plain WEBHOOK_UPDATED).
         WebhookSubscription prior = webhookService.get(subscriptionId);
+        // #209 / governance v0.1.25.40 (pending): validate the provided
+        // event_types/event_categories against the STORED subscription's owning
+        // tenant (WebhookUpdateRequest has no tenant_id — ownership is the
+        // subscription's, not the request's). __system__ rows are exempt.
+        categoryBoundaryValidator.validateForTarget(prior.getTenantId(),
+            request.getEventTypes(), request.getEventCategories());
         WebhookStatus previousStatus = prior.getStatus();
         WebhookSubscription updated = webhookService.update(subscriptionId, request);
         java.util.Map<String, Object> updateMeta = new java.util.LinkedHashMap<>();

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/WebhookAdminController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/WebhookAdminController.java
@@ -152,12 +152,16 @@ public class WebhookAdminController {
         // Capture prior status BEFORE mutating so we can classify the emit
         // type (WEBHOOK_PAUSED / WEBHOOK_RESUMED vs plain WEBHOOK_UPDATED).
         WebhookSubscription prior = webhookService.get(subscriptionId);
-        // #209 / governance v0.1.25.40 (pending): validate the provided
-        // event_types/event_categories against the STORED subscription's owning
-        // tenant (WebhookUpdateRequest has no tenant_id — ownership is the
-        // subscription's, not the request's). __system__ rows are exempt.
+        // #209 / governance v0.1.25.40 (pending): validate the EFFECTIVE
+        // resulting selectors (stored ∪ request) against the STORED
+        // subscription's owning tenant (WebhookUpdateRequest has no tenant_id —
+        // ownership is the subscription's). Effective (not request-only) so a
+        // status-only PATCH cannot reactivate an unrepaired concrete-tenant
+        // offender that still holds admin-only selectors. __system__ rows are
+        // exempt.
         categoryBoundaryValidator.validateForTarget(prior.getTenantId(),
-            request.getEventTypes(), request.getEventCategories());
+            request.getEventTypes() != null ? request.getEventTypes() : prior.getEventTypes(),
+            request.getEventCategories() != null ? request.getEventCategories() : prior.getEventCategories());
         WebhookStatus previousStatus = prior.getStatus();
         WebhookSubscription updated = webhookService.update(subscriptionId, request);
         java.util.Map<String, Object> updateMeta = new java.util.LinkedHashMap<>();

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/WebhookTenantController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/WebhookTenantController.java
@@ -101,8 +101,15 @@ public class WebhookTenantController {
         WebhookSubscription existing = webhookService.get(subscriptionId);
         boolean isAdminAuth = isAdminAuth(httpRequest);
         enforceTenantOwnership(httpRequest, existing);
-        categoryBoundaryValidator.validateEventTypes(request.getEventTypes());
-        categoryBoundaryValidator.validateEventCategories(request.getEventCategories());
+        // #209 finding 2: validate the EFFECTIVE resulting selectors (stored ∪
+        // request), not just the arrays present in the request. A status-only
+        // PATCH (e.g. {"status":"ACTIVE"}) carries null selector arrays, which
+        // the per-array validator skips — so a tenant could re-enable a disabled
+        // offender that still holds admin-only selectors. Validating the
+        // effective result blocks reactivating/mutating an unrepaired offender.
+        categoryBoundaryValidator.validateForTarget(existing.getTenantId(),
+            request.getEventTypes() != null ? request.getEventTypes() : existing.getEventTypes(),
+            request.getEventCategories() != null ? request.getEventCategories() : existing.getEventCategories());
         // Spec v0.1.25.29 Rule 2: any mutation on a webhook owned by a CLOSED
         // tenant returns 409 TENANT_CLOSED. This is the layer that makes
         // DISABLED effectively-terminal for closed-owner webhooks without

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/WebhookTenantController.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/controller/WebhookTenantController.java
@@ -5,12 +5,12 @@ import static io.runcycles.admin.api.logging.LogSanitizer.safe;
 import io.runcycles.admin.api.filter.RequestIdFilter;
 import io.runcycles.admin.api.filter.TraceContextFilter;
 import io.runcycles.admin.api.service.TerminalOwnerMutationGuard;
+import io.runcycles.admin.api.service.WebhookCategoryBoundaryValidator;
 import io.runcycles.admin.api.service.WebhookService;
 import io.runcycles.admin.data.exception.GovernanceException;
 import io.runcycles.admin.data.repository.AuditRepository;
 import io.runcycles.admin.model.audit.AuditLogEntry;
 import io.runcycles.admin.model.event.ActorType;
-import io.runcycles.admin.model.event.EventType;
 import io.runcycles.admin.model.shared.ErrorCode;
 import io.runcycles.admin.model.webhook.*;
 import io.swagger.v3.oas.annotations.Operation;
@@ -21,13 +21,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import java.time.Instant;
-import java.util.List;
 
 @RestController @RequestMapping("/v1/webhooks") @Tag(name = "Webhooks")
 public class WebhookTenantController {
     @Autowired private WebhookService webhookService;
     @Autowired private AuditRepository auditRepository;
     @Autowired private TerminalOwnerMutationGuard mutationGuard;
+    @Autowired private WebhookCategoryBoundaryValidator categoryBoundaryValidator;
 
     // createTenantWebhook is intentionally NOT dual-auth (spec v0.1.25.14):
     // URL / signing secret / event choice are tenant policy; admin creating
@@ -39,8 +39,10 @@ public class WebhookTenantController {
     public ResponseEntity<WebhookCreateResponse> create(
             @Valid @RequestBody WebhookCreateRequest request, HttpServletRequest httpRequest) {
         String tenantId = getAuthenticatedTenantId(httpRequest);
-        validateTenantEventTypes(request.getEventTypes());
-        validateTenantEventCategories(request.getEventCategories());
+        // Tenant plane: the owning tenant is always concrete, so validate
+        // unconditionally against the tenant-accessible boundary.
+        categoryBoundaryValidator.validateEventTypes(request.getEventTypes());
+        categoryBoundaryValidator.validateEventCategories(request.getEventCategories());
         mutationGuard.assertTenantOpen(tenantId);
         WebhookCreateResponse response = webhookService.create(tenantId, request);
         auditRepository.log(buildAuditEntry(httpRequest)
@@ -99,12 +101,8 @@ public class WebhookTenantController {
         WebhookSubscription existing = webhookService.get(subscriptionId);
         boolean isAdminAuth = isAdminAuth(httpRequest);
         enforceTenantOwnership(httpRequest, existing);
-        if (request.getEventTypes() != null) {
-            validateTenantEventTypes(request.getEventTypes());
-        }
-        if (request.getEventCategories() != null) {
-            validateTenantEventCategories(request.getEventCategories());
-        }
+        categoryBoundaryValidator.validateEventTypes(request.getEventTypes());
+        categoryBoundaryValidator.validateEventCategories(request.getEventCategories());
         // Spec v0.1.25.29 Rule 2: any mutation on a webhook owned by a CLOSED
         // tenant returns 409 TENANT_CLOSED. This is the layer that makes
         // DISABLED effectively-terminal for closed-owner webhooks without
@@ -226,39 +224,4 @@ public class WebhookTenantController {
         return safe(v);
     }
 
-    private void validateTenantEventTypes(List<EventType> eventTypes) {
-        if (eventTypes == null) return;
-        for (EventType type : eventTypes) {
-            if (!type.isTenantAccessible()) {
-                throw new GovernanceException(ErrorCode.INVALID_REQUEST,
-                    "Event type " + type.getValue() + " is admin-only; tenants can subscribe to budget.*, reservation.*, tenant.* only", 400);
-            }
-        }
-    }
-
-    /**
-     * Tenant-plane {@code event_categories} boundary (governance revision
-     * v0.1.25.38): {@code WebhookRepository.matchesEventType} treats
-     * categories as an ADDITIVE union with {@code event_types}, so an
-     * unvalidated category smuggles admin-only event classes past
-     * {@link #validateTenantEventTypes} (e.g. one allowed event_type plus
-     * {@code "event_categories": ["api_key"]}). Same boundary, same 400,
-     * derived from the same source ({@code EventCategory.isTenantAccessible},
-     * which {@code EventType.isTenantAccessible} delegates to).
-     *
-     * <p>Like {@link #validateTenantEventTypes}, this runs unconditionally on
-     * the tenant-plane paths — including admin-on-behalf-of PATCH through
-     * {@code /v1/webhooks/*}: the boundary belongs to the ENDPOINT, not the
-     * caller. Admin-provisioned subscriptions with admin categories are
-     * created and managed via {@code /v1/admin/webhooks/*}.
-     */
-    private void validateTenantEventCategories(List<io.runcycles.admin.model.event.EventCategory> eventCategories) {
-        if (eventCategories == null) return;
-        for (io.runcycles.admin.model.event.EventCategory category : eventCategories) {
-            if (!category.isTenantAccessible()) {
-                throw new GovernanceException(ErrorCode.INVALID_REQUEST,
-                    "Event category " + category.getValue() + " is admin-only; tenants can subscribe to budget.*, reservation.*, tenant.* only", 400);
-            }
-        }
-    }
 }

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookCategoryBoundaryReconciler.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookCategoryBoundaryReconciler.java
@@ -1,0 +1,82 @@
+package io.runcycles.admin.api.service;
+
+import io.runcycles.admin.data.repository.WebhookRepository;
+import io.runcycles.admin.data.repository.WebhookRepository.CategoryBoundaryAction;
+import io.runcycles.admin.data.repository.WebhookRepository.CategoryBoundaryRepairOutcome;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * One-time (idempotent) startup cleanup for #209 — the (d2) half of the fix.
+ * On boot it finds TENANT-owned webhook subscriptions carrying admin-only
+ * {@code event_categories} (placed there via the admin plane before the
+ * boundary was enforced in this release), plus legacy empty-both match-ALL
+ * rows, and <b>DISABLEs</b> them. See
+ * {@link WebhookRepository#reconcileTenantCategoryBoundary(boolean)} for the
+ * per-row rules and why it disables (conservative) rather than silently strips.
+ *
+ * <p>Implemented as a startup {@link ApplicationRunner} rather than a new admin
+ * endpoint: the migration touches no public wire surface (an undocumented
+ * endpoint would fail the OpenAPI contract-diff check), and it mirrors the
+ * repo's existing background-maintenance precedent (the {@code @Scheduled}
+ * audit-index sweep and the {@code CommandLineRunner} startup banner).
+ * Disabling is reversible and idempotent, so re-running on every boot is safe;
+ * operators can turn it off after the one-time run with
+ * {@code webhook.category-boundary.reconcile-on-startup=false}, or set
+ * {@code webhook.category-boundary.reconcile-dry-run=true} to only REPORT the
+ * offenders (log, no mutation) for review before the disabling pass.
+ */
+@Component
+public class WebhookCategoryBoundaryReconciler implements ApplicationRunner {
+
+    private static final Logger LOG = LoggerFactory.getLogger(WebhookCategoryBoundaryReconciler.class);
+
+    @Autowired private WebhookRepository webhookRepository;
+
+    @Value("${webhook.category-boundary.reconcile-on-startup:true}")
+    private boolean reconcileOnStartup;
+
+    /** When true, report offenders (log) without disabling any row. */
+    @Value("${webhook.category-boundary.reconcile-dry-run:false}")
+    private boolean dryRun;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        if (!reconcileOnStartup) {
+            LOG.info("Webhook category-boundary reconcile: skipped (reconcile-on-startup=false)");
+            return;
+        }
+        reconcile();
+    }
+
+    /**
+     * Run the reconcile and log a summary. Returns the per-row outcomes (empty
+     * when there was nothing to repair). Never throws — a cleanup failure must
+     * not block startup.
+     */
+    public List<CategoryBoundaryRepairOutcome> reconcile() {
+        try {
+            List<CategoryBoundaryRepairOutcome> outcomes = webhookRepository.reconcileTenantCategoryBoundary(dryRun);
+            if (outcomes.isEmpty()) {
+                LOG.info("Webhook category-boundary reconcile: no offender rows (#209 cleanup, idempotent, dry_run={})", dryRun);
+            } else {
+                long adminCats = outcomes.stream().filter(o -> o.action() == CategoryBoundaryAction.DISABLED_ADMIN_CATEGORIES).count();
+                long emptyBoth = outcomes.stream().filter(o -> o.action() == CategoryBoundaryAction.DISABLED_EMPTY_BOTH).count();
+                LOG.warn("Webhook category-boundary reconcile: {} {} offender row(s) (#209) — admin_categories={} empty_both={}. Genuine per-tenant admin monitoring should move to a __system__ subscription filtered by event_categories, with per-tenant selection done client-side on the envelope tenant_id (admin events are null-scoped, so a scope_filter would exclude them).",
+                    dryRun ? "REPORTED (dry-run, no rows changed):" : "DISABLED",
+                    outcomes.size(), adminCats, emptyBoth);
+            }
+            return outcomes;
+        } catch (Exception e) {
+            LOG.error("Webhook category-boundary reconcile failed (#209 cleanup); startup continues", e);
+            return List.of();
+        }
+    }
+}

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookCategoryBoundaryReconciler.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookCategoryBoundaryReconciler.java
@@ -3,6 +3,7 @@ package io.runcycles.admin.api.service;
 import io.runcycles.admin.data.repository.WebhookRepository;
 import io.runcycles.admin.data.repository.WebhookRepository.CategoryBoundaryAction;
 import io.runcycles.admin.data.repository.WebhookRepository.ReconcileResult;
+import jakarta.annotation.PreDestroy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,33 +12,35 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.stereotype.Component;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
 /**
- * One-time (idempotent, resumable) startup cleanup for #209 — the (d2) half of
- * the fix. It finds webhook subscriptions that violate the tenant-accessible
- * boundary (concrete-tenant rows carrying admin-only event_types/categories,
- * plus legacy empty-both match-ALL rows) and DISABLEs them. See
+ * Best-effort startup HYGIENE for #209 — the (d2) half of the fix. It reconciles
+ * webhook subscriptions that violate the tenant-accessible boundary
+ * (concrete-tenant rows carrying admin-only event_types/categories → strip those
+ * selectors; empty-both match-ALL rows → disable; null-owner rows → normalize to
+ * {@code __system__}). See
  * {@link WebhookRepository#reconcileTenantCategoryBoundary(boolean)} for the
- * per-row rules and why it disables (conservative) rather than silently strips.
+ * per-row rules.
  *
- * <p>Robustness / readiness posture (finding 7):
- * <ul>
- *   <li>The pass runs on a <b>background daemon thread</b> — startup is never
- *       blocked, and readiness is NOT gated on the migration completing. A
- *       migration bug must not brick the service, and the create/update gate
- *       already stops NEW offenders; legacy offenders simply remain
- *       DISABLED-pending until a clean pass finishes.</li>
- *   <li>An incomplete pass (row error, or a compare-and-set miss from a
- *       concurrent update) is <b>retried with exponential backoff</b>. The
- *       sweep is idempotent, so retries are safe. If retries are exhausted
- *       without a clean pass, a loud {@code ERROR} alert is emitted and the
- *       service stays up.</li>
- * </ul>
- * No new API surface (an undocumented endpoint would fail the OpenAPI
- * contract-diff check); mirrors the repo's {@code @Scheduled} audit-sweep /
- * {@code CommandLineRunner} precedent. Config:
- * {@code webhook.category-boundary.reconcile-on-startup} (default {@code true}),
- * {@code webhook.category-boundary.reconcile-dry-run} (default {@code false} —
- * {@code true} REPORTS offenders in the logs without disabling anything).
+ * <p><b>This is not the security mechanism.</b> The durable confidentiality
+ * guarantee is the fail-closed DISPATCH boundary
+ * ({@code WebhookDispatchService}) — a concrete-tenant subscription never
+ * receives admin-only events, immediately and unconditionally. This reconciler
+ * only brings STORAGE in line with that already-enforced delivery behavior, so
+ * it is safe for it to be best-effort: it runs on a managed background thread
+ * (startup/readiness is never blocked), retries an incomplete pass (row error or
+ * CAS miss) with exponential backoff, and on exhausted retries logs a loud
+ * {@code ERROR} and lets the service stay up (a hygiene bug must not brick the
+ * service; delivery is already safe). No new API surface — an undocumented
+ * endpoint would fail the OpenAPI contract-diff check.
+ *
+ * <p>Config: {@code webhook.category-boundary.reconcile-on-startup} (default
+ * {@code true}), {@code webhook.category-boundary.reconcile-dry-run} (default
+ * {@code false} — {@code true} REPORTS the actions in the logs without mutating).
  */
 @Component
 public class WebhookCategoryBoundaryReconciler implements ApplicationRunner {
@@ -49,7 +52,7 @@ public class WebhookCategoryBoundaryReconciler implements ApplicationRunner {
     @Value("${webhook.category-boundary.reconcile-on-startup:true}")
     private boolean reconcileOnStartup;
 
-    /** When true, report offenders (log) without disabling any row. */
+    /** When true, report actions (log) without mutating any row. */
     @Value("${webhook.category-boundary.reconcile-dry-run:false}")
     private boolean dryRun;
 
@@ -61,16 +64,38 @@ public class WebhookCategoryBoundaryReconciler implements ApplicationRunner {
     @Value("${webhook.category-boundary.reconcile-initial-backoff-ms:1000}")
     private long initialBackoffMs;
 
+    /**
+     * Managed single-thread executor for the background sweep. A managed
+     * executor (not a raw {@code new Thread}) is interrupted and awaited on
+     * Spring context shutdown, so the sweep stops cleanly instead of leaking a
+     * thread that keeps sleeping through a retry backoff.
+     */
+    private final ExecutorService executor = Executors.newSingleThreadExecutor(new ThreadFactory() {
+        @Override public Thread newThread(Runnable r) {
+            Thread t = new Thread(r, "webhook-category-boundary-reconcile");
+            t.setDaemon(true);
+            return t;
+        }
+    });
+
     @Override
     public void run(ApplicationArguments args) {
         if (!reconcileOnStartup) {
             LOG.info("Webhook category-boundary reconcile: skipped (reconcile-on-startup=false)");
             return;
         }
-        // Background daemon thread: never block startup or readiness on the migration.
-        Thread t = new Thread(this::reconcileWithRetry, "webhook-category-boundary-reconcile");
-        t.setDaemon(true);
-        t.start();
+        // Background: never block startup or readiness on this hygiene sweep.
+        executor.submit(this::reconcileWithRetry);
+    }
+
+    @PreDestroy
+    void shutdown() {
+        executor.shutdownNow(); // interrupts an in-flight retry backoff
+        try {
+            executor.awaitTermination(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
     }
 
     /**
@@ -80,6 +105,9 @@ public class WebhookCategoryBoundaryReconciler implements ApplicationRunner {
     public void reconcileWithRetry() {
         long backoff = initialBackoffMs;
         for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            if (Thread.currentThread().isInterrupted()) {
+                return;
+            }
             ReconcileResult result = reconcile();
             if (result.isComplete()) {
                 return;
@@ -96,7 +124,7 @@ public class WebhookCategoryBoundaryReconciler implements ApplicationRunner {
                 backoff = Math.min(backoff * 2, 30_000L);
             }
         }
-        LOG.error("Webhook category-boundary reconcile did NOT complete after {} attempts (#209); service is up and NEW offenders are blocked by the write-path gate, but legacy offenders may remain until the next restart or a manual re-run. ALERT.",
+        LOG.error("Webhook category-boundary reconcile did NOT complete after {} attempts (#209); service is up and delivery is already safe (the dispatch boundary blocks admin-only events to concrete-tenant subs), but storage hygiene may be incomplete until the next restart or manual re-run. ALERT.",
             maxAttempts);
     }
 
@@ -109,17 +137,19 @@ public class WebhookCategoryBoundaryReconciler implements ApplicationRunner {
         try {
             ReconcileResult result = webhookRepository.reconcileTenantCategoryBoundary(dryRun);
             if (result.repaired().isEmpty() && result.isComplete()) {
-                LOG.info("Webhook category-boundary reconcile: no offender rows (#209 cleanup, idempotent, dry_run={})", dryRun);
+                LOG.info("Webhook category-boundary reconcile: nothing to reconcile (#209 hygiene, idempotent, dry_run={})", dryRun);
             } else {
-                long adminSel = result.repaired().stream().filter(o -> o.action() == CategoryBoundaryAction.DISABLED_ADMIN_SELECTORS).count();
-                long emptyBoth = result.repaired().stream().filter(o -> o.action() == CategoryBoundaryAction.DISABLED_EMPTY_BOTH).count();
-                LOG.warn("Webhook category-boundary reconcile: {} {} offender row(s) (#209), failures={} — admin_selectors={} empty_both={}. Genuine per-tenant admin monitoring should move to a __system__ subscription filtered by event_categories (select tenant client-side on the envelope tenant_id).",
-                    dryRun ? "REPORTED (dry-run, no rows changed):" : "DISABLED",
-                    result.repaired().size(), result.failures(), adminSel, emptyBoth);
+                long stripped = result.repaired().stream().filter(o -> o.action() == CategoryBoundaryAction.STRIPPED_ADMIN_SELECTORS).count();
+                long strippedDisabled = result.repaired().stream().filter(o -> o.action() == CategoryBoundaryAction.STRIPPED_AND_DISABLED).count();
+                long disabledEmptyBoth = result.repaired().stream().filter(o -> o.action() == CategoryBoundaryAction.DISABLED_EMPTY_BOTH).count();
+                long normalized = result.repaired().stream().filter(o -> o.action() == CategoryBoundaryAction.NORMALIZED_NULL_OWNER).count();
+                LOG.warn("Webhook category-boundary reconcile: {} {} row(s) (#209 hygiene), failures={} — stripped={} stripped_and_disabled={} disabled_empty_both={} normalized_null_owner={}",
+                    dryRun ? "REPORTED (dry-run, no rows changed):" : "repaired",
+                    result.repaired().size(), result.failures(), stripped, strippedDisabled, disabledEmptyBoth, normalized);
             }
             return result;
         } catch (Exception e) {
-            LOG.error("Webhook category-boundary reconcile failed (#209 cleanup); startup continues", e);
+            LOG.error("Webhook category-boundary reconcile failed (#209 hygiene); service continues", e);
             return new ReconcileResult(java.util.List.of(), 1);
         }
     }

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookCategoryBoundaryReconciler.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookCategoryBoundaryReconciler.java
@@ -2,7 +2,7 @@ package io.runcycles.admin.api.service;
 
 import io.runcycles.admin.data.repository.WebhookRepository;
 import io.runcycles.admin.data.repository.WebhookRepository.CategoryBoundaryAction;
-import io.runcycles.admin.data.repository.WebhookRepository.CategoryBoundaryRepairOutcome;
+import io.runcycles.admin.data.repository.WebhookRepository.ReconcileResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,27 +11,33 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 /**
- * One-time (idempotent) startup cleanup for #209 — the (d2) half of the fix.
- * On boot it finds TENANT-owned webhook subscriptions carrying admin-only
- * {@code event_categories} (placed there via the admin plane before the
- * boundary was enforced in this release), plus legacy empty-both match-ALL
- * rows, and <b>DISABLEs</b> them. See
+ * One-time (idempotent, resumable) startup cleanup for #209 — the (d2) half of
+ * the fix. It finds webhook subscriptions that violate the tenant-accessible
+ * boundary (concrete-tenant rows carrying admin-only event_types/categories,
+ * plus legacy empty-both match-ALL rows) and DISABLEs them. See
  * {@link WebhookRepository#reconcileTenantCategoryBoundary(boolean)} for the
  * per-row rules and why it disables (conservative) rather than silently strips.
  *
- * <p>Implemented as a startup {@link ApplicationRunner} rather than a new admin
- * endpoint: the migration touches no public wire surface (an undocumented
- * endpoint would fail the OpenAPI contract-diff check), and it mirrors the
- * repo's existing background-maintenance precedent (the {@code @Scheduled}
- * audit-index sweep and the {@code CommandLineRunner} startup banner).
- * Disabling is reversible and idempotent, so re-running on every boot is safe;
- * operators can turn it off after the one-time run with
- * {@code webhook.category-boundary.reconcile-on-startup=false}, or set
- * {@code webhook.category-boundary.reconcile-dry-run=true} to only REPORT the
- * offenders (log, no mutation) for review before the disabling pass.
+ * <p>Robustness / readiness posture (finding 7):
+ * <ul>
+ *   <li>The pass runs on a <b>background daemon thread</b> — startup is never
+ *       blocked, and readiness is NOT gated on the migration completing. A
+ *       migration bug must not brick the service, and the create/update gate
+ *       already stops NEW offenders; legacy offenders simply remain
+ *       DISABLED-pending until a clean pass finishes.</li>
+ *   <li>An incomplete pass (row error, or a compare-and-set miss from a
+ *       concurrent update) is <b>retried with exponential backoff</b>. The
+ *       sweep is idempotent, so retries are safe. If retries are exhausted
+ *       without a clean pass, a loud {@code ERROR} alert is emitted and the
+ *       service stays up.</li>
+ * </ul>
+ * No new API surface (an undocumented endpoint would fail the OpenAPI
+ * contract-diff check); mirrors the repo's {@code @Scheduled} audit-sweep /
+ * {@code CommandLineRunner} precedent. Config:
+ * {@code webhook.category-boundary.reconcile-on-startup} (default {@code true}),
+ * {@code webhook.category-boundary.reconcile-dry-run} (default {@code false} —
+ * {@code true} REPORTS offenders in the logs without disabling anything).
  */
 @Component
 public class WebhookCategoryBoundaryReconciler implements ApplicationRunner {
@@ -47,36 +53,74 @@ public class WebhookCategoryBoundaryReconciler implements ApplicationRunner {
     @Value("${webhook.category-boundary.reconcile-dry-run:false}")
     private boolean dryRun;
 
+    /** Max attempts before giving up (and alerting) on an incomplete pass. */
+    @Value("${webhook.category-boundary.reconcile-max-attempts:5}")
+    private int maxAttempts;
+
+    /** Initial backoff between retries; doubles each attempt, capped at 30s. */
+    @Value("${webhook.category-boundary.reconcile-initial-backoff-ms:1000}")
+    private long initialBackoffMs;
+
     @Override
     public void run(ApplicationArguments args) {
         if (!reconcileOnStartup) {
             LOG.info("Webhook category-boundary reconcile: skipped (reconcile-on-startup=false)");
             return;
         }
-        reconcile();
+        // Background daemon thread: never block startup or readiness on the migration.
+        Thread t = new Thread(this::reconcileWithRetry, "webhook-category-boundary-reconcile");
+        t.setDaemon(true);
+        t.start();
     }
 
     /**
-     * Run the reconcile and log a summary. Returns the per-row outcomes (empty
-     * when there was nothing to repair). Never throws — a cleanup failure must
-     * not block startup.
+     * Run the sweep, retrying with exponential backoff until a pass completes
+     * (no failures) or attempts are exhausted. Idempotent and never throws.
      */
-    public List<CategoryBoundaryRepairOutcome> reconcile() {
+    public void reconcileWithRetry() {
+        long backoff = initialBackoffMs;
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            ReconcileResult result = reconcile();
+            if (result.isComplete()) {
+                return;
+            }
+            LOG.warn("Webhook category-boundary reconcile incomplete (#209): attempt={} failures={} — retrying",
+                attempt, result.failures());
+            if (attempt < maxAttempts) {
+                try {
+                    Thread.sleep(backoff);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                backoff = Math.min(backoff * 2, 30_000L);
+            }
+        }
+        LOG.error("Webhook category-boundary reconcile did NOT complete after {} attempts (#209); service is up and NEW offenders are blocked by the write-path gate, but legacy offenders may remain until the next restart or a manual re-run. ALERT.",
+            maxAttempts);
+    }
+
+    /**
+     * A single reconcile pass. Logs a summary and returns its result (with the
+     * failure count that drives {@link #reconcileWithRetry()}). Public so tests
+     * exercise it directly; never throws.
+     */
+    public ReconcileResult reconcile() {
         try {
-            List<CategoryBoundaryRepairOutcome> outcomes = webhookRepository.reconcileTenantCategoryBoundary(dryRun);
-            if (outcomes.isEmpty()) {
+            ReconcileResult result = webhookRepository.reconcileTenantCategoryBoundary(dryRun);
+            if (result.repaired().isEmpty() && result.isComplete()) {
                 LOG.info("Webhook category-boundary reconcile: no offender rows (#209 cleanup, idempotent, dry_run={})", dryRun);
             } else {
-                long adminCats = outcomes.stream().filter(o -> o.action() == CategoryBoundaryAction.DISABLED_ADMIN_CATEGORIES).count();
-                long emptyBoth = outcomes.stream().filter(o -> o.action() == CategoryBoundaryAction.DISABLED_EMPTY_BOTH).count();
-                LOG.warn("Webhook category-boundary reconcile: {} {} offender row(s) (#209) — admin_categories={} empty_both={}. Genuine per-tenant admin monitoring should move to a __system__ subscription filtered by event_categories, with per-tenant selection done client-side on the envelope tenant_id (admin events are null-scoped, so a scope_filter would exclude them).",
+                long adminSel = result.repaired().stream().filter(o -> o.action() == CategoryBoundaryAction.DISABLED_ADMIN_SELECTORS).count();
+                long emptyBoth = result.repaired().stream().filter(o -> o.action() == CategoryBoundaryAction.DISABLED_EMPTY_BOTH).count();
+                LOG.warn("Webhook category-boundary reconcile: {} {} offender row(s) (#209), failures={} — admin_selectors={} empty_both={}. Genuine per-tenant admin monitoring should move to a __system__ subscription filtered by event_categories (select tenant client-side on the envelope tenant_id).",
                     dryRun ? "REPORTED (dry-run, no rows changed):" : "DISABLED",
-                    outcomes.size(), adminCats, emptyBoth);
+                    result.repaired().size(), result.failures(), adminSel, emptyBoth);
             }
-            return outcomes;
+            return result;
         } catch (Exception e) {
             LOG.error("Webhook category-boundary reconcile failed (#209 cleanup); startup continues", e);
-            return List.of();
+            return new ReconcileResult(java.util.List.of(), 1);
         }
     }
 }

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookCategoryBoundaryReconciler.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookCategoryBoundaryReconciler.java
@@ -143,9 +143,10 @@ public class WebhookCategoryBoundaryReconciler implements ApplicationRunner {
                 long strippedDisabled = result.repaired().stream().filter(o -> o.action() == CategoryBoundaryAction.STRIPPED_AND_DISABLED).count();
                 long disabledEmptyBoth = result.repaired().stream().filter(o -> o.action() == CategoryBoundaryAction.DISABLED_EMPTY_BOTH).count();
                 long normalized = result.repaired().stream().filter(o -> o.action() == CategoryBoundaryAction.NORMALIZED_NULL_OWNER).count();
-                LOG.warn("Webhook category-boundary reconcile: {} {} row(s) (#209 hygiene), failures={} — stripped={} stripped_and_disabled={} disabled_empty_both={} normalized_null_owner={}",
+                long indexed = result.repaired().stream().filter(o -> o.action() == CategoryBoundaryAction.INDEXED_SYSTEM_MEMBER).count();
+                LOG.warn("Webhook category-boundary reconcile: {} {} row(s) (#209 hygiene), failures={} — stripped={} stripped_and_disabled={} disabled_empty_both={} normalized_null_owner={} indexed_system_member={}",
                     dryRun ? "REPORTED (dry-run, no rows changed):" : "repaired",
-                    result.repaired().size(), result.failures(), stripped, strippedDisabled, disabledEmptyBoth, normalized);
+                    result.repaired().size(), result.failures(), stripped, strippedDisabled, disabledEmptyBoth, normalized, indexed);
             }
             return result;
         } catch (Exception e) {

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookCategoryBoundaryValidator.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookCategoryBoundaryValidator.java
@@ -76,6 +76,16 @@ public class WebhookCategoryBoundaryValidator {
         return WebhookSubscription.isSystemOwner(tenantId);
     }
 
+    /**
+     * True when this event type is admin-only (outside the tenant-accessible
+     * boundary). Single source used by the write-path gate AND the fail-closed
+     * dispatch boundary ({@code WebhookDispatchService}) so delivery filtering
+     * and validation share one definition.
+     */
+    public boolean isAdminOnly(EventType type) {
+        return type != null && !type.isTenantAccessible();
+    }
+
     /** Reject any admin-only event type. Null list is a no-op. */
     public void validateEventTypes(List<EventType> eventTypes) {
         if (eventTypes == null) return;

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookCategoryBoundaryValidator.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookCategoryBoundaryValidator.java
@@ -1,0 +1,97 @@
+package io.runcycles.admin.api.service;
+
+import io.runcycles.admin.data.exception.GovernanceException;
+import io.runcycles.admin.model.event.EventCategory;
+import io.runcycles.admin.model.event.EventType;
+import io.runcycles.admin.model.shared.ErrorCode;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Single source of truth for the tenant-accessible webhook boundary
+ * ({@code budget.*}, {@code reservation.*}, {@code tenant.*}): admin-only
+ * event types/categories ({@code api_key}, {@code policy}, {@code webhook},
+ * {@code system}) may not be placed on a TENANT-owned subscription.
+ *
+ * <p>Two callers share this component so the boundary cannot drift:
+ * <ul>
+ *   <li>{@code WebhookTenantController} (create/update on the tenant plane) —
+ *       its target is always a concrete tenant, so it validates
+ *       unconditionally (governance revision v0.1.25.38).</li>
+ *   <li>{@code WebhookAdminController} (create/update on the admin plane) —
+ *       validates only when the target subscription's owning tenant is a
+ *       CONCRETE tenant, i.e. not the {@link #SYSTEM_TENANT} sentinel. This
+ *       closes the admin-plane CARRIER source: an operator / admin-on-behalf-of
+ *       could otherwise place admin-only categories on a tenant-owned
+ *       subscription, and since {@code matchesEventType} treats categories as
+ *       an ADDITIVE union, that tenant (which controls the endpoint URL +
+ *       signing secret) would receive admin-only governance/security
+ *       telemetry. Governance revision v0.1.25.40 (pending) makes this
+ *       normative. {@code __system__} subscriptions are NOT tenant-owned —
+ *       admin-only categories on them are legitimate system-wide monitoring
+ *       and remain allowed.</li>
+ * </ul>
+ *
+ * <p>The boundary itself is derived from {@link EventCategory#isTenantAccessible()}
+ * (to which {@link EventType#isTenantAccessible()} delegates), so the
+ * type-level and category-level checks and both planes stay in lockstep.
+ */
+@Component
+public class WebhookCategoryBoundaryValidator {
+
+    /** Sentinel owning-tenant for admin-provisioned, non-tenant-owned subscriptions. */
+    public static final String SYSTEM_TENANT = "__system__";
+
+    /**
+     * Validate a request's {@code event_types}/{@code event_categories} against
+     * the tenant-accessible boundary <b>only when the target is a concrete
+     * tenant</b>. No-op for the {@link #SYSTEM_TENANT} sentinel (or a null/blank
+     * owner, treated as system): those subscriptions are not tenant-owned.
+     * Null arrays are skipped (partial updates validate only what they provide).
+     *
+     * @param targetTenantId the OWNING tenant of the subscription being written
+     *                       (on create: the {@code tenant_id} param; on update:
+     *                       the stored subscription's {@code tenant_id})
+     */
+    public void validateForTarget(String targetTenantId,
+                                  List<EventType> eventTypes,
+                                  List<EventCategory> eventCategories) {
+        if (isSystemTarget(targetTenantId)) {
+            return;
+        }
+        validateEventTypes(eventTypes);
+        validateEventCategories(eventCategories);
+    }
+
+    /** True when the owning tenant is the system sentinel (not tenant-owned). */
+    public boolean isSystemTarget(String tenantId) {
+        return tenantId == null || tenantId.isBlank() || SYSTEM_TENANT.equals(tenantId);
+    }
+
+    /** Reject any admin-only event type. Null list is a no-op. */
+    public void validateEventTypes(List<EventType> eventTypes) {
+        if (eventTypes == null) return;
+        for (EventType type : eventTypes) {
+            if (!type.isTenantAccessible()) {
+                throw new GovernanceException(ErrorCode.INVALID_REQUEST,
+                    "Event type " + type.getValue()
+                        + " is admin-only; tenants can subscribe to budget.*, reservation.*, tenant.* only",
+                    400);
+            }
+        }
+    }
+
+    /** Reject any admin-only event category. Null list is a no-op. */
+    public void validateEventCategories(List<EventCategory> eventCategories) {
+        if (eventCategories == null) return;
+        for (EventCategory category : eventCategories) {
+            if (!category.isTenantAccessible()) {
+                throw new GovernanceException(ErrorCode.INVALID_REQUEST,
+                    "Event category " + category.getValue()
+                        + " is admin-only; tenants can subscribe to budget.*, reservation.*, tenant.* only",
+                    400);
+            }
+        }
+    }
+}

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookCategoryBoundaryValidator.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookCategoryBoundaryValidator.java
@@ -86,6 +86,16 @@ public class WebhookCategoryBoundaryValidator {
         return type != null && !type.isTenantAccessible();
     }
 
+    /**
+     * True when this event category is admin-only. Companion to
+     * {@link #isAdminOnly(EventType)} — {@code Event.category} is an independent
+     * cross-plane field (not always derived from the type), so the fail-closed
+     * dispatch boundary checks BOTH.
+     */
+    public boolean isAdminOnly(EventCategory category) {
+        return category != null && !category.isTenantAccessible();
+    }
+
     /** Reject any admin-only event type. Null list is a no-op. */
     public void validateEventTypes(List<EventType> eventTypes) {
         if (eventTypes == null) return;

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookCategoryBoundaryValidator.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookCategoryBoundaryValidator.java
@@ -4,6 +4,7 @@ import io.runcycles.admin.data.exception.GovernanceException;
 import io.runcycles.admin.model.event.EventCategory;
 import io.runcycles.admin.model.event.EventType;
 import io.runcycles.admin.model.shared.ErrorCode;
+import io.runcycles.admin.model.webhook.WebhookSubscription;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -41,7 +42,7 @@ import java.util.List;
 public class WebhookCategoryBoundaryValidator {
 
     /** Sentinel owning-tenant for admin-provisioned, non-tenant-owned subscriptions. */
-    public static final String SYSTEM_TENANT = "__system__";
+    public static final String SYSTEM_TENANT = WebhookSubscription.SYSTEM_TENANT;
 
     /**
      * Validate a request's {@code event_types}/{@code event_categories} against
@@ -64,9 +65,15 @@ public class WebhookCategoryBoundaryValidator {
         validateEventCategories(eventCategories);
     }
 
-    /** True when the owning tenant is the system sentinel (not tenant-owned). */
+    /**
+     * True when the owning tenant is system-owned (not tenant-owned). Delegates
+     * to {@link WebhookSubscription#isSystemOwner} so the write-path validator
+     * and the cleanup reconciler share ONE predicate. Per gov v0.1.25.40 only
+     * null/omitted and the literal {@code __system__} sentinel are exempt; a
+     * blank (whitespace-only) tenant_id is treated as CONCRETE and validated.
+     */
     public boolean isSystemTarget(String tenantId) {
-        return tenantId == null || tenantId.isBlank() || SYSTEM_TENANT.equals(tenantId);
+        return WebhookSubscription.isSystemOwner(tenantId);
     }
 
     /** Reject any admin-only event type. Null list is a no-op. */

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookDispatchService.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookDispatchService.java
@@ -60,14 +60,35 @@ public class WebhookDispatchService {
      * offenders and the reconciler is best-effort hygiene, but THIS is the
      * guarantee. Per-event: a mixed subscription still receives its
      * tenant-accessible events; only the admin-only ones are skipped.
+     *
+     * <p>Public so the replay collector ({@code WebhookService.replay}) can
+     * apply the SAME predicate while paginating — it must not spend its
+     * {@code max_events} budget on events {@code dispatchToSubscription} would
+     * skip, otherwise the cap would count non-deliverable events. Delivery
+     * still re-applies this guard (defense in depth); exposing it only makes the
+     * cap count DELIVERABLE events.
      */
-    private boolean isBlockedByOwnershipBoundary(Event event, WebhookSubscription sub) {
-        boolean blocked = !WebhookSubscription.isSystemOwner(sub.getTenantId())
-            && categoryBoundaryValidator.isAdminOnly(event.getEventType());
+    public boolean isBlockedByOwnershipBoundary(Event event, WebhookSubscription sub) {
+        if (WebhookSubscription.isSystemOwner(sub.getTenantId())) {
+            return false; // system-owned subs receive everything
+        }
+        // Concrete owner: fail-closed. Block if EITHER the type OR the
+        // (independent, cross-plane) category is admin-only, AND block an
+        // unclassifiable record (both type and category null) — Event.category
+        // is not always derived from the type (EventService preserves a supplied
+        // category), so a record with a tenant-accessible type but an admin-only
+        // category, or a malformed/typeless record, must NOT reach a tenant
+        // endpoint. I/O-free.
+        boolean typeAdmin = categoryBoundaryValidator.isAdminOnly(event.getEventType());
+        boolean categoryAdmin = categoryBoundaryValidator.isAdminOnly(event.getCategory());
+        boolean unclassifiable = event.getEventType() == null && event.getCategory() == null;
+        boolean blocked = typeAdmin || categoryAdmin || unclassifiable;
         if (blocked) {
-            LOG.debug("Webhook delivery blocked by ownership boundary (#209): subscription_id={} tenant_id={} event_type={} — a concrete-tenant subscription cannot receive admin-only events",
+            LOG.debug("Webhook delivery blocked by ownership boundary (#209): subscription_id={} tenant_id={} event_type={} category={} type_admin={} category_admin={} unclassifiable={} — a concrete-tenant subscription cannot receive admin-only or unclassifiable events",
                 safe(sub.getSubscriptionId()), safe(sub.getTenantId()),
-                event.getEventType() != null ? event.getEventType().getValue() : null);
+                event.getEventType() != null ? event.getEventType().getValue() : null,
+                event.getCategory() != null ? event.getCategory().getValue() : null,
+                typeAdmin, categoryAdmin, unclassifiable);
         }
         return blocked;
     }
@@ -90,8 +111,8 @@ public class WebhookDispatchService {
                     continue;
                 }
                 try {
-                    createDelivery(event, sub);
-                    recordDispatch("queued");
+                    boolean enqueued = createDelivery(event, sub);
+                    recordDispatch(enqueued ? "queued" : "failure");
                 } catch (Exception e) {
                     LOG.error("Failed to create webhook delivery: event_id={} event_type={} tenant_id={} scope={} subscription_id={} correlation_id={} request_id={} trace_id={} error={}",
                             safe(event != null ? event.getEventId() : null),
@@ -161,11 +182,18 @@ public class WebhookDispatchService {
                 current != null ? current.getStatus() : null);
             return false;
         }
-        createDelivery(event, sub);
-        return true;
+        // Honest boolean: true only if the delivery was actually enqueued.
+        return createDelivery(event, sub);
     }
 
-    private void createDelivery(Event event, WebhookSubscription sub) {
+    /**
+     * Persist a delivery row and enqueue it for {@code cycles-server-events}.
+     * Returns {@code true} only when the row was actually ENQUEUED
+     * ({@code LPUSH} succeeded) — a saved-but-not-enqueued delivery returns
+     * {@code false} so callers (replay counting, dispatch metrics) don't
+     * over-report a delivery the worker will never pick up.
+     */
+    private boolean createDelivery(Event event, WebhookSubscription sub) {
         TraceSnapshot trace = currentTraceSnapshot(event);
         WebhookDelivery delivery = WebhookDelivery.builder()
             .deliveryId("del_" + UUID.randomUUID().toString().replace("-", "").substring(0, 16))
@@ -183,12 +211,14 @@ public class WebhookDispatchService {
         // Enqueue for cycles-server-events to pick up via BRPOP
         try (Jedis jedis = jedisPool.getResource()) {
             jedis.lpush("dispatch:pending", delivery.getDeliveryId());
+            return true;
         } catch (Exception e) {
             LOG.warn("Failed to enqueue webhook delivery: delivery_id={} event_id={} event_type={} subscription_id={} tenant_id={} queue=dispatch:pending trace_id={} error={}",
                     safe(delivery.getDeliveryId()), safe(delivery.getEventId()),
                     delivery.getEventType() != null ? delivery.getEventType().getValue() : null,
                     safe(delivery.getSubscriptionId()), safe(sub.getTenantId()),
                     safe(delivery.getTraceId()), safe(e.getMessage()), e);
+            return false;
         }
     }
 

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookDispatchService.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookDispatchService.java
@@ -34,17 +34,42 @@ public class WebhookDispatchService {
     private final ObjectMapper objectMapper;
     private final JedisPool jedisPool;
     private final MeterRegistry meterRegistry;
+    private final WebhookCategoryBoundaryValidator categoryBoundaryValidator;
 
     public WebhookDispatchService(WebhookRepository webhookRepository,
                                    WebhookDeliveryRepository deliveryRepository,
                                    ObjectMapper objectMapper,
                                    JedisPool jedisPool,
-                                   MeterRegistry meterRegistry) {
+                                   MeterRegistry meterRegistry,
+                                   WebhookCategoryBoundaryValidator categoryBoundaryValidator) {
         this.webhookRepository = webhookRepository;
         this.deliveryRepository = deliveryRepository;
         this.objectMapper = objectMapper;
         this.jedisPool = jedisPool;
         this.meterRegistry = meterRegistry;
+        this.categoryBoundaryValidator = categoryBoundaryValidator;
+    }
+
+    /**
+     * #209 — the DURABLE, fail-closed confidentiality boundary. A
+     * concrete-tenant-owned subscription (owner is not {@code __system__}/null,
+     * per {@link WebhookSubscription#isSystemOwner}) MUST NOT receive an
+     * admin-only event (admin category OR admin type). Enforced at DELIVERY, so
+     * the leak is impossible regardless of what selectors are stored on the row
+     * or whether the cleanup reconciler has run — the write-path gate stops NEW
+     * offenders and the reconciler is best-effort hygiene, but THIS is the
+     * guarantee. Per-event: a mixed subscription still receives its
+     * tenant-accessible events; only the admin-only ones are skipped.
+     */
+    private boolean isBlockedByOwnershipBoundary(Event event, WebhookSubscription sub) {
+        boolean blocked = !WebhookSubscription.isSystemOwner(sub.getTenantId())
+            && categoryBoundaryValidator.isAdminOnly(event.getEventType());
+        if (blocked) {
+            LOG.debug("Webhook delivery blocked by ownership boundary (#209): subscription_id={} tenant_id={} event_type={} — a concrete-tenant subscription cannot receive admin-only events",
+                safe(sub.getSubscriptionId()), safe(sub.getTenantId()),
+                event.getEventType() != null ? event.getEventType().getValue() : null);
+        }
+        return blocked;
     }
 
     /**
@@ -56,6 +81,14 @@ public class WebhookDispatchService {
             List<WebhookSubscription> subs = webhookRepository.findMatchingSubscriptions(
                 event.getTenantId(), event.getEventType(), event.getScope());
             for (WebhookSubscription sub : subs) {
+                // Fail-closed ownership boundary (no I/O). Live dispatch already
+                // read fresh status via findMatchingSubscriptions, so no status
+                // re-check is needed here (there is no large stale-snapshot window
+                // as there is on the replay path).
+                if (isBlockedByOwnershipBoundary(event, sub)) {
+                    recordDispatch("boundary_skipped");
+                    continue;
+                }
                 try {
                     createDelivery(event, sub);
                     recordDispatch("queued");
@@ -97,9 +130,39 @@ public class WebhookDispatchService {
 
     /**
      * Dispatch a single event to a specific subscription (used by replay).
+     * Returns {@code true} if a delivery was enqueued, {@code false} if it was
+     * skipped by a delivery guard.
+     *
+     * <p>Applies BOTH guards, so replay is fail-closed:
+     * <ul>
+     *   <li>the ownership boundary (a concrete-tenant sub never gets admin-only
+     *       events); and</li>
+     *   <li>a fresh STATUS re-read at delivery time — replay queues events from a
+     *       subscription snapshot captured before the replay lock, so a
+     *       subscription disabled (or paused) concurrently must stop receiving
+     *       deliveries mid-replay ("disabling stops delivery immediately" under
+     *       concurrency, TOCTOU fix).</li>
+     * </ul>
      */
-    public void dispatchToSubscription(Event event, WebhookSubscription sub) {
+    public boolean dispatchToSubscription(Event event, WebhookSubscription sub) {
+        if (isBlockedByOwnershipBoundary(event, sub)) {
+            return false;
+        }
+        WebhookSubscription current;
+        try {
+            current = webhookRepository.findById(sub.getSubscriptionId());
+        } catch (Exception e) {
+            // Subscription vanished (deleted) mid-replay — skip.
+            return false;
+        }
+        if (current == null || current.getStatus() != WebhookStatus.ACTIVE) {
+            LOG.debug("Webhook replay delivery skipped — subscription no longer ACTIVE: subscription_id={} tenant_id={} status={}",
+                safe(sub.getSubscriptionId()), safe(sub.getTenantId()),
+                current != null ? current.getStatus() : null);
+            return false;
+        }
         createDelivery(event, sub);
+        return true;
     }
 
     private void createDelivery(Event event, WebhookSubscription sub) {

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookDispatchService.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookDispatchService.java
@@ -5,10 +5,12 @@ import static io.runcycles.admin.api.logging.LogSanitizer.safe;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.runcycles.admin.api.filter.TraceContextFilter;
+import io.runcycles.admin.data.exception.GovernanceException;
 import io.runcycles.admin.data.repository.WebhookDeliveryRepository;
 import io.runcycles.admin.data.repository.WebhookRepository;
 import io.runcycles.admin.model.event.Event;
 import io.runcycles.admin.model.event.EventType;
+import io.runcycles.admin.model.shared.ErrorCode;
 import io.runcycles.admin.model.webhook.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
@@ -195,10 +197,23 @@ public class WebhookDispatchService {
         WebhookSubscription current;
         try {
             current = webhookRepository.findById(sub.getSubscriptionId());
+        } catch (GovernanceException e) {
+            if (e.getErrorCode() == ErrorCode.WEBHOOK_NOT_FOUND) {
+                // Subscription genuinely deleted mid-replay — an INTENDED lifecycle
+                // change, not a backend failure.
+                return DispatchOutcome.INACTIVE;
+            }
+            // Any OTHER governance error is unexpected — treat as degradation.
+            LOG.warn("Webhook replay re-read failed (non-not-found governance error): subscription_id={} tenant_id={} error_code={} error={}",
+                safe(sub.getSubscriptionId()), safe(sub.getTenantId()), e.getErrorCode(), safe(e.getMessage()));
+            return DispatchOutcome.ENQUEUE_FAILED;
         } catch (Exception e) {
-            // Subscription vanished (deleted) mid-replay — an intended lifecycle
-            // change, not a backend failure.
-            return DispatchOutcome.INACTIVE;
+            // Redis / deserialization / unexpected failure during the re-read —
+            // a real backend DEGRADATION, NOT a benign lifecycle change. Must not
+            // be hidden as INACTIVE (that would mask a real outage).
+            LOG.warn("Webhook replay re-read failed (backend error): subscription_id={} tenant_id={} error={}",
+                safe(sub.getSubscriptionId()), safe(sub.getTenantId()), safe(e.getMessage()), e);
+            return DispatchOutcome.ENQUEUE_FAILED;
         }
         if (current == null || current.getStatus() != WebhookStatus.ACTIVE) {
             LOG.debug("Webhook replay delivery skipped — subscription no longer ACTIVE: subscription_id={} tenant_id={} status={}",

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookDispatchService.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookDispatchService.java
@@ -62,11 +62,12 @@ public class WebhookDispatchService {
      * tenant-accessible events; only the admin-only ones are skipped.
      *
      * <p>Public so the replay collector ({@code WebhookService.replay}) can
-     * apply the SAME predicate while paginating — it must not spend its
-     * {@code max_events} budget on events {@code dispatchToSubscription} would
-     * skip, otherwise the cap would count non-deliverable events. Delivery
-     * still re-applies this guard (defense in depth); exposing it only makes the
-     * cap count DELIVERABLE events.
+     * apply the SAME predicate when selecting the deliverable events for a
+     * window — an event this boundary would skip is NOT a deliverable event, so
+     * it must not count toward the window's deliverable total (replay is
+     * all-or-narrow: the deliverable total drives the completeness check).
+     * Delivery still re-applies this guard (defense in depth); exposing it only
+     * keeps the collector's notion of "deliverable" identical to dispatch's.
      */
     public boolean isBlockedByOwnershipBoundary(Event event, WebhookSubscription sub) {
         if (WebhookSubscription.isSystemOwner(sub.getTenantId())) {

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookDispatchService.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookDispatchService.java
@@ -151,40 +151,63 @@ public class WebhookDispatchService {
     }
 
     /**
+     * Outcome of {@link #dispatchToSubscription} — a STRUCTURED result so replay
+     * can distinguish a real backend degradation from intended, benign skips
+     * (governance #130). Only {@link #ENQUEUE_FAILED} is a degradation.
+     */
+    public enum DispatchOutcome {
+        /** Delivery row persisted AND enqueued onto {@code dispatch:pending}. */
+        ENQUEUED,
+        /** Subscription no longer ACTIVE (paused / disabled / deleted) at the
+         *  dispatch-time status re-check — intended lifecycle behavior, NOT
+         *  degradation. */
+        INACTIVE,
+        /** The fail-closed ownership boundary blocked delivery at dispatch time
+         *  (rare race — selection already applied the boundary) — intended
+         *  security behavior, NOT degradation. */
+        BLOCKED,
+        /** A real transient backend failure — the delivery could not be enqueued
+         *  ({@code LPUSH}/save failed). Degradation, WARN-worthy. */
+        ENQUEUE_FAILED
+    }
+
+    /**
      * Dispatch a single event to a specific subscription (used by replay).
-     * Returns {@code true} if a delivery was enqueued, {@code false} if it was
-     * skipped by a delivery guard.
+     * Returns a {@link DispatchOutcome} — replay counts {@link DispatchOutcome#ENQUEUED}
+     * and categorizes the rest so a benign concurrent lifecycle change is not
+     * reported as a backend degradation.
      *
      * <p>Applies BOTH guards, so replay is fail-closed:
      * <ul>
      *   <li>the ownership boundary (a concrete-tenant sub never gets admin-only
-     *       events); and</li>
+     *       events) → {@link DispatchOutcome#BLOCKED}; and</li>
      *   <li>a fresh STATUS re-read at delivery time — replay queues events from a
      *       subscription snapshot captured before the replay lock, so a
      *       subscription disabled (or paused) concurrently must stop receiving
      *       deliveries mid-replay ("disabling stops delivery immediately" under
-     *       concurrency, TOCTOU fix).</li>
+     *       concurrency, TOCTOU fix) → {@link DispatchOutcome#INACTIVE}.</li>
      * </ul>
      */
-    public boolean dispatchToSubscription(Event event, WebhookSubscription sub) {
+    public DispatchOutcome dispatchToSubscription(Event event, WebhookSubscription sub) {
         if (isBlockedByOwnershipBoundary(event, sub)) {
-            return false;
+            return DispatchOutcome.BLOCKED;
         }
         WebhookSubscription current;
         try {
             current = webhookRepository.findById(sub.getSubscriptionId());
         } catch (Exception e) {
-            // Subscription vanished (deleted) mid-replay — skip.
-            return false;
+            // Subscription vanished (deleted) mid-replay — an intended lifecycle
+            // change, not a backend failure.
+            return DispatchOutcome.INACTIVE;
         }
         if (current == null || current.getStatus() != WebhookStatus.ACTIVE) {
             LOG.debug("Webhook replay delivery skipped — subscription no longer ACTIVE: subscription_id={} tenant_id={} status={}",
                 safe(sub.getSubscriptionId()), safe(sub.getTenantId()),
                 current != null ? current.getStatus() : null);
-            return false;
+            return DispatchOutcome.INACTIVE;
         }
-        // Honest boolean: true only if the delivery was actually enqueued.
-        return createDelivery(event, sub);
+        // ENQUEUED only if the delivery was actually enqueued; else ENQUEUE_FAILED.
+        return createDelivery(event, sub) ? DispatchOutcome.ENQUEUED : DispatchOutcome.ENQUEUE_FAILED;
     }
 
     /**

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookService.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookService.java
@@ -402,9 +402,20 @@ public class WebhookService {
      * {@link #REPLAY_MAX_SCAN}) and hydrates + filters in fixed batches over it.
      * The id list is the exact ordered member set, so hydration drops (expired /
      * corrupt / unknown-enum rows) never look like exhaustion and there is no
-     * score cursor to skip or duplicate. If the window holds more than
-     * {@code REPLAY_MAX_SCAN} events the ceiling caps the scan and we log (never
-     * silently truncate).
+     * score cursor to skip or duplicate.
+     *
+     * <p><b>An over-large window is a caller-visible 400, not a silent partial.</b>
+     * The scan is bounded by {@link #replayMaxScan}. Returning fewer than
+     * {@code max_events} would read to the caller as "these are ALL the matching
+     * events in my window" — but if the window's candidate count exceeds the
+     * ceiling the search was truncated and more may exist in the unscanned tail.
+     * So we fetch {@code replayMaxScan + 1} candidate ids to detect that, and if
+     * the ceiling is reached AND fewer than {@code max_events} deliverable events
+     * were collected within the scanned set, we throw a 400 {@code INVALID_REQUEST}
+     * BEFORE any delivery is enqueued (the search is genuinely incomplete — the
+     * caller must narrow {@code from}/{@code to}). If {@code max_events} WAS
+     * reached within the ceiling, that is the caller's explicit pagination cap
+     * (not truncation) and we deliver normally.
      */
     private List<Event> collectDeliverableReplayEvents(WebhookSubscription sub,
                                                         ReplayRequest request, int maxEvents) {
@@ -414,13 +425,17 @@ public class WebhookService {
         boolean hasRequestTypeFilter =
             request.getEventTypes() != null && !request.getEventTypes().isEmpty();
 
-        // One bounded, ordered, de-duplicated id list for the whole window.
+        // One bounded, ordered, de-duplicated id list. Fetch ONE past the ceiling
+        // so we can distinguish "window fits within the scan limit" from "window
+        // overflows it" (an over-large window is a caller-visible 400, below).
         List<String> ids = eventRepository.listEventIdsInRange(
-            queryTenant, request.getFrom(), request.getTo(), replayMaxScan);
+            queryTenant, request.getFrom(), request.getTo(), replayMaxScan + 1);
+        boolean ceilingReached = ids.size() > replayMaxScan;
+        int scanLimit = Math.min(ids.size(), replayMaxScan); // only scan within the ceiling
 
         List<Event> collected = new ArrayList<>();
-        for (int start = 0; start < ids.size() && collected.size() < maxEvents; start += REPLAY_PAGE_SIZE) {
-            int end = Math.min(start + REPLAY_PAGE_SIZE, ids.size());
+        for (int start = 0; start < scanLimit && collected.size() < maxEvents; start += REPLAY_PAGE_SIZE) {
+            int end = Math.min(start + REPLAY_PAGE_SIZE, scanLimit);
             List<Event> page = eventRepository.hydrateByIds(ids.subList(start, end));
             for (Event e : page) {
                 if (hasRequestTypeFilter && !request.getEventTypes().contains(e.getEventType())) {
@@ -434,11 +449,17 @@ public class WebhookService {
                 if (collected.size() >= maxEvents) break;
             }
         }
-        // Ceiling: the id list was capped at replayMaxScan, so a full-cap list
-        // that did not fill max_events may have more deliverable events beyond it.
-        if (collected.size() < maxEvents && ids.size() >= replayMaxScan) {
-            LOG.warn("Webhook replay hit the scan ceiling before filling max_events: subscription_id={} tenant_id={} scanned={} collected={} max_events={} — window may hold more matching events past the scan bound",
-                safe(sub.getSubscriptionId()), safe(sub.getTenantId()), ids.size(), collected.size(), maxEvents);
+        // Genuinely-incomplete search → fail-fast BEFORE enqueuing anything, so
+        // the truncation is caller-VISIBLE (a log is not). If max_events WAS
+        // filled within the ceiling, that is the caller's explicit pagination cap
+        // (eventsQueued == max_events signals "there may be more"), NOT truncation.
+        if (ceilingReached && collected.size() < maxEvents) {
+            LOG.warn("Webhook replay window exceeds the scan ceiling: subscription_id={} tenant_id={} scan_limit={} collected={} max_events={} — returning 400, no deliveries enqueued",
+                safe(sub.getSubscriptionId()), safe(sub.getTenantId()), replayMaxScan, collected.size(), maxEvents);
+            throw new GovernanceException(ErrorCode.INVALID_REQUEST,
+                "replay window too large: it exceeds the replay scan limit of " + replayMaxScan
+                    + " events; narrow the from/to range (or lower max_events to page within the limit)",
+                400);
         }
         return collected;
     }

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookService.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookService.java
@@ -311,9 +311,11 @@ public class WebhookService {
         }
         try {
             int maxEvents = request.getMaxEvents() != null ? Math.min(request.getMaxEvents(), 1000) : 100;
-            // Query events in the requested time range
+            // Query events in the requested time range. isSystemOwner is null-safe
+            // (a null owner classifies as system → query all tenants), avoiding an
+            // NPE on a null-owned row.
             List<Event> events = eventRepository.list(
-                sub.getTenantId().equals("__system__") ? null : sub.getTenantId(),
+                WebhookSubscription.isSystemOwner(sub.getTenantId()) ? null : sub.getTenantId(),
                 null, null, null, null,
                 request.getFrom(), request.getTo(), null, maxEvents);
             // Filter by event types if specified in replay request
@@ -339,8 +341,12 @@ public class WebhookService {
             int queued = 0;
             for (Event event : events) {
                 try {
-                    dispatchService.dispatchToSubscription(event, sub);
-                    queued++;
+                    // Count only events actually enqueued — dispatchToSubscription
+                    // returns false when a delivery guard (ownership boundary, or a
+                    // concurrent disable re-checked at dispatch time) skips it.
+                    if (dispatchService.dispatchToSubscription(event, sub)) {
+                        queued++;
+                    }
                 } catch (Exception e) {
                     LOG.warn("Failed to queue webhook replay delivery: replay_id={} subscription_id={} tenant_id={} event_id={} event_type={} correlation_id={} request_id={} trace_id={} error={}",
                             safe(replayId), safe(subscriptionId), safe(sub.getTenantId()), safe(event.getEventId()),

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookService.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookService.java
@@ -327,12 +327,13 @@ public class WebhookService {
         }
         try {
             int maxEvents = request.getMaxEvents() != null ? Math.min(request.getMaxEvents(), 1000) : 100;
-            // #209 P2: collect up to maxEvents DELIVERABLE events by paging the
-            // window chronologically and filtering DURING pagination — never a
-            // single capped fetch then post-hoc filter, which would drop matching
-            // events that fall past the cap when the first page is all
-            // non-matching ("scanned 100, queued 0"). Chronological order is
-            // preserved for delivery (spec replayEvents).
+            // #209 P2: ALL-OR-NARROW — collect EVERY deliverable event in the
+            // window, filtered against the same predicates as live dispatch, in
+            // chronological order (spec replayEvents). This is not paging toward a
+            // continuation: an over-large window (candidates beyond the scan
+            // limit, or more than maxEvents deliverable) fails with a 400 BEFORE
+            // any delivery is enqueued (see collectDeliverableReplayEvents), so a
+            // success delivers the COMPLETE set for its window.
             List<Event> events = collectDeliverableReplayEvents(sub, request, maxEvents);
             // Queue each matching event for re-delivery to this subscription
             int queued = 0;
@@ -361,16 +362,18 @@ public class WebhookService {
         }
     }
 
-    /** Per-fetch page size while paging the replay window (bounded memory). */
+    /** Hydration BATCH size — how many event ids are hydrated from the ordered
+     *  window id list per {@code hydrateByIds} call (bounds memory). NOT a
+     *  pagination unit: the whole window is scanned within one replay. */
     private static final int REPLAY_PAGE_SIZE = 500;
     /**
-     * Total scanned-event ceiling for one replay — the max size of the ordered
-     * id list pulled for the window. A very sparse window (few matching events
-     * among many) can't scan unbounded; if this bound is hit before
-     * {@code maxEvents} matches are collected, collection stops and logs — NOT a
-     * silent truncation. Configurable (`webhook.replay.max-scan`) so the ceiling
-     * is exercisable; the field initializer is the default used when no property
-     * is bound (e.g. plain unit construction).
+     * Scan limit for one replay — the max size of the ordered id list pulled for
+     * the window. Replay is ALL-OR-NARROW: if the window's candidate count
+     * exceeds this bound the window cannot be fully scanned, so replay returns a
+     * 400 {@code INVALID_REQUEST} ("window too large — narrow from/to"), NOT a
+     * silent partial. Configurable (`webhook.replay.max-scan`) so the limit is
+     * exercisable; the field initializer is the default used when no property is
+     * bound (e.g. plain unit construction).
      */
     @org.springframework.beans.factory.annotation.Value("${webhook.replay.max-scan:20000}")
     private int replayMaxScan = 20_000;
@@ -442,8 +445,8 @@ public class WebhookService {
         collect:
         for (int start = 0; start < ids.size(); start += REPLAY_PAGE_SIZE) {
             int end = Math.min(start + REPLAY_PAGE_SIZE, ids.size());
-            List<Event> page = eventRepository.hydrateByIds(ids.subList(start, end));
-            for (Event e : page) {
+            List<Event> batch = eventRepository.hydrateByIds(ids.subList(start, end));
+            for (Event e : batch) {
                 if (hasRequestTypeFilter && !request.getEventTypes().contains(e.getEventType())) {
                     continue;
                 }

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookService.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookService.java
@@ -376,9 +376,8 @@ public class WebhookService {
     private int replayMaxScan = 20_000;
 
     /**
-     * Collect up to {@code maxEvents} DELIVERABLE events from the replay window
-     * in CHRONOLOGICAL (ascending) order, applying every filter live
-     * dispatch/replay would apply, paginated in bounded batches:
+     * Collect EVERY DELIVERABLE event in the replay window, in CHRONOLOGICAL
+     * (ascending) order, applying every filter live dispatch/replay would apply:
      * <ul>
      *   <li>the request's optional {@code event_types} filter;</li>
      *   <li>the subscription's OWN {@code event_types}/{@code event_categories}
@@ -386,36 +385,35 @@ public class WebhookService {
      *       ({@link WebhookRepository#matchesScope}) — spec {@code replayEvents}:
      *       "replays all event types the subscription is subscribed to"; and</li>
      *   <li>the fail-closed ownership boundary
-     *       ({@link WebhookDispatchService#isBlockedByOwnershipBoundary}) so the
-     *       cap counts only events {@code dispatchToSubscription} will actually
-     *       deliver (a concrete-tenant sub never spends budget on admin-only
-     *       events).</li>
+     *       ({@link WebhookDispatchService#isBlockedByOwnershipBoundary}) — a
+     *       concrete-tenant sub never receives admin-only events.</li>
      * </ul>
      *
      * <p><b>Approach B (no-miss AND no-duplicate over a bounded window).</b>
-     * Rather than walk {@link EventRepository#list}'s millisecond score cursor
-     * — which can skip equal-timestamp members (resume advances by
-     * {@code score+1}), misread a hydration-thinned page as exhaustion, and
-     * re-emit a page when a cursor member has vanished — this takes ONE bounded,
-     * ordered, de-duplicated id list for the window
-     * ({@link EventRepository#listEventIdsInRange}, capped at
-     * {@link #REPLAY_MAX_SCAN}) and hydrates + filters in fixed batches over it.
-     * The id list is the exact ordered member set, so hydration drops (expired /
-     * corrupt / unknown-enum rows) never look like exhaustion and there is no
-     * score cursor to skip or duplicate.
+     * Takes ONE bounded, ordered, de-duplicated id list for the window
+     * ({@link EventRepository#listEventIdsInRange}) and hydrates + filters in
+     * fixed batches over it. The id list is the exact ordered member set, so
+     * hydration drops (expired / corrupt / unknown-enum rows) never look like
+     * exhaustion and there is no score cursor to skip or duplicate.
      *
-     * <p><b>An over-large window is a caller-visible 400, not a silent partial.</b>
-     * The scan is bounded by {@link #replayMaxScan}. Returning fewer than
-     * {@code max_events} would read to the caller as "these are ALL the matching
-     * events in my window" — but if the window's candidate count exceeds the
-     * ceiling the search was truncated and more may exist in the unscanned tail.
-     * So we fetch {@code replayMaxScan + 1} candidate ids to detect that, and if
-     * the ceiling is reached AND fewer than {@code max_events} deliverable events
-     * were collected within the scanned set, we throw a 400 {@code INVALID_REQUEST}
-     * BEFORE any delivery is enqueued (the search is genuinely incomplete — the
-     * caller must narrow {@code from}/{@code to}). If {@code max_events} WAS
-     * reached within the ceiling, that is the caller's explicit pagination cap
-     * (not truncation) and we deliver normally.
+     * <p><b>Replay is ALL-OR-NARROW.</b> {@code max_events} is NOT a resumable
+     * pagination cursor — {@code ReplayResponse} carries no continuation position,
+     * so a partial result could not be resumed losslessly (distinct timestamps:
+     * the caller never learns the last replayed timestamp; same-millisecond
+     * events: an inclusive {@code from} would repeat or skip). So a SUCCESSFUL
+     * replay delivers EVERY deliverable event in {@code [from,to]}; it never
+     * returns a partial with an implied "continue". Two fail-fast 400s (thrown
+     * BEFORE any delivery is enqueued, so there are no partial side effects):
+     * <ul>
+     *   <li>the window's candidate count exceeds the server scan limit
+     *       ({@link #replayMaxScan}) — completeness can't be guaranteed over the
+     *       unscanned tail → narrow {@code from}/{@code to}; or</li>
+     *   <li>the (fully scanned) window holds MORE than {@code max_events}
+     *       deliverable events → narrow {@code from}/{@code to}, or raise
+     *       {@code max_events} (up to the 1000 cap).</li>
+     * </ul>
+     * Otherwise (fully scanned, {@code <= max_events} deliverable) all are
+     * returned — a success is COMPLETE for its window.
      */
     private List<Event> collectDeliverableReplayEvents(WebhookSubscription sub,
                                                         ReplayRequest request, int maxEvents) {
@@ -425,17 +423,25 @@ public class WebhookService {
         boolean hasRequestTypeFilter =
             request.getEventTypes() != null && !request.getEventTypes().isEmpty();
 
-        // One bounded, ordered, de-duplicated id list. Fetch ONE past the ceiling
-        // so we can distinguish "window fits within the scan limit" from "window
-        // overflows it" (an over-large window is a caller-visible 400, below).
+        // Fetch ONE past the scan limit: if the window has more candidates than we
+        // can scan, we can't guarantee completeness → narrow the window (400).
         List<String> ids = eventRepository.listEventIdsInRange(
             queryTenant, request.getFrom(), request.getTo(), replayMaxScan + 1);
-        boolean ceilingReached = ids.size() > replayMaxScan;
-        int scanLimit = Math.min(ids.size(), replayMaxScan); // only scan within the ceiling
+        if (ids.size() > replayMaxScan) {
+            LOG.warn("Webhook replay window exceeds the scan limit: subscription_id={} tenant_id={} scan_limit={} — returning 400, no deliveries enqueued",
+                safe(sub.getSubscriptionId()), safe(sub.getTenantId()), replayMaxScan);
+            throw new GovernanceException(ErrorCode.INVALID_REQUEST,
+                "replay window too large: it exceeds the replay scan limit of " + replayMaxScan
+                    + " events; narrow the from/to range",
+                400);
+        }
 
+        // Fully scanned. Collect all deliverable events, one past max_events so we
+        // can detect a window that holds MORE than max_events deliverable.
         List<Event> collected = new ArrayList<>();
-        for (int start = 0; start < scanLimit && collected.size() < maxEvents; start += REPLAY_PAGE_SIZE) {
-            int end = Math.min(start + REPLAY_PAGE_SIZE, scanLimit);
+        collect:
+        for (int start = 0; start < ids.size(); start += REPLAY_PAGE_SIZE) {
+            int end = Math.min(start + REPLAY_PAGE_SIZE, ids.size());
             List<Event> page = eventRepository.hydrateByIds(ids.subList(start, end));
             for (Event e : page) {
                 if (hasRequestTypeFilter && !request.getEventTypes().contains(e.getEventType())) {
@@ -443,22 +449,17 @@ public class WebhookService {
                 }
                 if (!WebhookRepository.matchesEventType(sub, e.getEventType())) continue;
                 if (!WebhookRepository.matchesScope(sub, e.getScope())) continue;
-                // Don't spend cap budget on an event delivery will skip.
                 if (dispatchService.isBlockedByOwnershipBoundary(e, sub)) continue;
                 collected.add(e);
-                if (collected.size() >= maxEvents) break;
+                if (collected.size() > maxEvents) break collect; // overflow detected
             }
         }
-        // Genuinely-incomplete search → fail-fast BEFORE enqueuing anything, so
-        // the truncation is caller-VISIBLE (a log is not). If max_events WAS
-        // filled within the ceiling, that is the caller's explicit pagination cap
-        // (eventsQueued == max_events signals "there may be more"), NOT truncation.
-        if (ceilingReached && collected.size() < maxEvents) {
-            LOG.warn("Webhook replay window exceeds the scan ceiling: subscription_id={} tenant_id={} scan_limit={} collected={} max_events={} — returning 400, no deliveries enqueued",
-                safe(sub.getSubscriptionId()), safe(sub.getTenantId()), replayMaxScan, collected.size(), maxEvents);
+        if (collected.size() > maxEvents) {
+            LOG.warn("Webhook replay window holds more than max_events deliverable events: subscription_id={} tenant_id={} max_events={} — returning 400, no deliveries enqueued",
+                safe(sub.getSubscriptionId()), safe(sub.getTenantId()), maxEvents);
             throw new GovernanceException(ErrorCode.INVALID_REQUEST,
-                "replay window too large: it exceeds the replay scan limit of " + replayMaxScan
-                    + " events; narrow the from/to range (or lower max_events to page within the limit)",
+                "replay window contains more than max_events (" + maxEvents + ") deliverable events;"
+                    + " narrow the from/to range, or raise max_events (up to 1000)",
                 400);
         }
         return collected;

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookService.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookService.java
@@ -326,22 +326,30 @@ public class WebhookService {
             throw GovernanceException.replayInProgress(subscriptionId);
         }
         try {
-            int maxEvents = request.getMaxEvents() != null ? Math.min(request.getMaxEvents(), 1000) : 100;
-            // #209 P2: ALL-OR-NARROW — collect EVERY deliverable event in the
-            // window, filtered against the same predicates as live dispatch, in
+            // max_events is bounded to [1,1000] by @Min/@Max on ReplayRequest
+            // (rejected with 400 by @Valid, NOT silently clamped here); null
+            // defaults to 100 (spec default).
+            int maxEvents = request.getMaxEvents() != null ? request.getMaxEvents() : 100;
+            // #209 P2: ALL-OR-NARROW SELECTION — collect EVERY deliverable event in
+            // the window, filtered against the same predicates as live dispatch, in
             // chronological order (spec replayEvents). This is not paging toward a
             // continuation: an over-large window (candidates beyond the scan
             // limit, or more than maxEvents deliverable) fails with a 400 BEFORE
-            // any delivery is enqueued (see collectDeliverableReplayEvents), so a
-            // success delivers the COMPLETE set for its window.
+            // any delivery is enqueued (see collectDeliverableReplayEvents), so
+            // SELECTION is complete for its window.
             List<Event> events = collectDeliverableReplayEvents(sub, request, maxEvents);
-            // Queue each matching event for re-delivery to this subscription
+            int selected = events.size();
+            // #209 F1: enqueue is BEST-EFFORT by design (governance #130). Selection
+            // is complete, but events_queued reports how many were ACCEPTED onto the
+            // dispatch queue — it may be < selected if the backend transiently fails
+            // a per-event enqueue. Replay is NOT idempotent (delivery IDs are random;
+            // a retry may duplicate). We count only events actually enqueued
+            // (dispatchToSubscription returns false when a delivery guard — ownership
+            // boundary or a concurrent disable re-checked at dispatch — skips it, and
+            // an enqueue error is caught per event) so the count is honest.
             int queued = 0;
             for (Event event : events) {
                 try {
-                    // Count only events actually enqueued — dispatchToSubscription
-                    // returns false when a delivery guard (ownership boundary, or a
-                    // concurrent disable re-checked at dispatch time) skips it.
                     if (dispatchService.dispatchToSubscription(event, sub)) {
                         queued++;
                     }
@@ -351,6 +359,12 @@ public class WebhookService {
                             safe(event.getEventType() != null ? event.getEventType().getValue() : null),
                             safe(event.getCorrelationId()), safe(event.getRequestId()), safe(event.getTraceId()), safe(e.getMessage()), e);
                 }
+            }
+            // Loud, operator-facing signal that a degraded backend produced a
+            // PARTIAL enqueue (best-effort contract: events_queued < selected).
+            if (queued < selected) {
+                LOG.warn("Webhook replay PARTIAL enqueue (best-effort): replay_id={} subscription_id={} tenant_id={} selected={} queued={} — {} deliverable event(s) were NOT enqueued (degraded dispatch backend); replay is not idempotent, a retry may duplicate already-queued deliveries",
+                    safe(replayId), safe(subscriptionId), safe(sub.getTenantId()), selected, queued, selected - queued);
             }
             return ReplayResponse.builder()
                 .replayId(replayId)

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookService.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookService.java
@@ -10,7 +10,6 @@ import io.runcycles.admin.data.exception.GovernanceException;
 import io.runcycles.admin.model.event.*;
 import io.runcycles.admin.model.shared.ErrorCode;
 import io.runcycles.admin.model.shared.SortSpec;
-import io.runcycles.admin.model.shared.SortDirection;
 import io.runcycles.admin.model.webhook.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -365,12 +364,16 @@ public class WebhookService {
     /** Per-fetch page size while paging the replay window (bounded memory). */
     private static final int REPLAY_PAGE_SIZE = 500;
     /**
-     * Total scanned-event ceiling for one replay. A very sparse window (few
-     * matching events among many) can't scan unbounded; if this bound is hit
-     * before {@code maxEvents} matches are collected, collection stops and logs
-     * — NOT a silent truncation.
+     * Total scanned-event ceiling for one replay — the max size of the ordered
+     * id list pulled for the window. A very sparse window (few matching events
+     * among many) can't scan unbounded; if this bound is hit before
+     * {@code maxEvents} matches are collected, collection stops and logs — NOT a
+     * silent truncation. Configurable (`webhook.replay.max-scan`) so the ceiling
+     * is exercisable; the field initializer is the default used when no property
+     * is bound (e.g. plain unit construction).
      */
-    private static final int REPLAY_MAX_SCAN = 20_000;
+    @org.springframework.beans.factory.annotation.Value("${webhook.replay.max-scan:20000}")
+    private int replayMaxScan = 20_000;
 
     /**
      * Collect up to {@code maxEvents} DELIVERABLE events from the replay window
@@ -388,31 +391,38 @@ public class WebhookService {
      *       deliver (a concrete-tenant sub never spends budget on admin-only
      *       events).</li>
      * </ul>
-     * Pages via the timestamp-ASC cursor of {@link EventRepository#list} until
-     * {@code maxEvents} matches are collected, the window is exhausted, or the
-     * {@link #REPLAY_MAX_SCAN} scan ceiling is reached.
+     *
+     * <p><b>Approach B (no-miss AND no-duplicate over a bounded window).</b>
+     * Rather than walk {@link EventRepository#list}'s millisecond score cursor
+     * — which can skip equal-timestamp members (resume advances by
+     * {@code score+1}), misread a hydration-thinned page as exhaustion, and
+     * re-emit a page when a cursor member has vanished — this takes ONE bounded,
+     * ordered, de-duplicated id list for the window
+     * ({@link EventRepository#listEventIdsInRange}, capped at
+     * {@link #REPLAY_MAX_SCAN}) and hydrates + filters in fixed batches over it.
+     * The id list is the exact ordered member set, so hydration drops (expired /
+     * corrupt / unknown-enum rows) never look like exhaustion and there is no
+     * score cursor to skip or duplicate. If the window holds more than
+     * {@code REPLAY_MAX_SCAN} events the ceiling caps the scan and we log (never
+     * silently truncate).
      */
     private List<Event> collectDeliverableReplayEvents(WebhookSubscription sub,
                                                         ReplayRequest request, int maxEvents) {
         // isSystemOwner is null-safe (null owner → system → query all tenants).
         String queryTenant = WebhookSubscription.isSystemOwner(sub.getTenantId())
             ? null : sub.getTenantId();
-        SortSpec chronological = SortSpec.of("timestamp", SortDirection.ASC);
         boolean hasRequestTypeFilter =
             request.getEventTypes() != null && !request.getEventTypes().isEmpty();
 
+        // One bounded, ordered, de-duplicated id list for the whole window.
+        List<String> ids = eventRepository.listEventIdsInRange(
+            queryTenant, request.getFrom(), request.getTo(), replayMaxScan);
+
         List<Event> collected = new ArrayList<>();
-        String cursor = null;
-        int scanned = 0;
-        while (collected.size() < maxEvents && scanned < REPLAY_MAX_SCAN) {
-            List<Event> page = eventRepository.list(
-                queryTenant, null, null, null, null,
-                request.getFrom(), request.getTo(), cursor, REPLAY_PAGE_SIZE, chronological);
-            if (page.isEmpty()) {
-                break; // window exhausted
-            }
+        for (int start = 0; start < ids.size() && collected.size() < maxEvents; start += REPLAY_PAGE_SIZE) {
+            int end = Math.min(start + REPLAY_PAGE_SIZE, ids.size());
+            List<Event> page = eventRepository.hydrateByIds(ids.subList(start, end));
             for (Event e : page) {
-                scanned++;
                 if (hasRequestTypeFilter && !request.getEventTypes().contains(e.getEventType())) {
                     continue;
                 }
@@ -423,14 +433,12 @@ public class WebhookService {
                 collected.add(e);
                 if (collected.size() >= maxEvents) break;
             }
-            if (page.size() < REPLAY_PAGE_SIZE) {
-                break; // last (partial) page — window exhausted
-            }
-            cursor = page.get(page.size() - 1).getEventId();
         }
-        if (collected.size() < maxEvents && scanned >= REPLAY_MAX_SCAN) {
+        // Ceiling: the id list was capped at replayMaxScan, so a full-cap list
+        // that did not fill max_events may have more deliverable events beyond it.
+        if (collected.size() < maxEvents && ids.size() >= replayMaxScan) {
             LOG.warn("Webhook replay hit the scan ceiling before filling max_events: subscription_id={} tenant_id={} scanned={} collected={} max_events={} — window may hold more matching events past the scan bound",
-                safe(sub.getSubscriptionId()), safe(sub.getTenantId()), scanned, collected.size(), maxEvents);
+                safe(sub.getSubscriptionId()), safe(sub.getTenantId()), ids.size(), collected.size(), maxEvents);
         }
         return collected;
     }

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookService.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookService.java
@@ -295,6 +295,16 @@ public class WebhookService {
     public ReplayResponse replay(String subscriptionId, ReplayRequest request) {
         WebhookSubscription sub = webhookRepository.findById(subscriptionId);
         String replayId = "replay_" + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+        // #209: a replay MUST NOT deliver to a non-ACTIVE subscription — live
+        // dispatch only delivers to ACTIVE rows, so replay mirrors that. This
+        // makes "disabling stops delivery immediately" true for the reconciler's
+        // disabled offenders too: a DISABLED (or PAUSED) subscription queues
+        // nothing. Short-circuit before acquiring the replay lock.
+        if (sub.getStatus() != WebhookStatus.ACTIVE) {
+            LOG.info("Webhook replay is a no-op on a non-ACTIVE subscription: subscription_id={} tenant_id={} status={}",
+                safe(subscriptionId), safe(sub.getTenantId()), sub.getStatus());
+            return ReplayResponse.builder().replayId(replayId).eventsQueued(0).estimatedCompletionSeconds(0).build();
+        }
         // Acquire distributed lock — spec requires 409 REPLAY_IN_PROGRESS if already running
         if (!webhookRepository.acquireReplayLock(subscriptionId, replayId)) {
             throw GovernanceException.replayInProgress(subscriptionId);
@@ -312,11 +322,17 @@ public class WebhookService {
                     .filter(e -> request.getEventTypes().contains(e.getEventType()))
                     .toList();
             }
-            // Apply the subscription's scope_filter — same matcher as live
-            // dispatch (WebhookRepository.findMatchingSubscriptions), so a
-            // replay never delivers events the subscription would not have
-            // received live.
+            // #209: intersect with the SUBSCRIPTION's own event_types /
+            // event_categories — the same matcher as live dispatch
+            // (WebhookRepository.findMatchingSubscriptions). Spec (replayEvents):
+            // "If omitted, replays all event types the subscription is subscribed
+            // to." Without this, a concrete-tenant budget-only subscription could
+            // replay historical ADMIN-only events (api_key.*/policy.*/…) to its
+            // tenant-controlled endpoint — bypassing the category boundary this
+            // release establishes. Also apply the subscription's scope_filter so
+            // replay never delivers an event live dispatch would have skipped.
             events = events.stream()
+                .filter(e -> WebhookRepository.matchesEventType(sub, e.getEventType()))
                 .filter(e -> WebhookRepository.matchesScope(sub, e.getScope()))
                 .toList();
             // Queue each matching event for re-delivery to this subscription

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookService.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookService.java
@@ -10,6 +10,7 @@ import io.runcycles.admin.data.exception.GovernanceException;
 import io.runcycles.admin.model.event.*;
 import io.runcycles.admin.model.shared.ErrorCode;
 import io.runcycles.admin.model.shared.SortSpec;
+import io.runcycles.admin.model.shared.SortDirection;
 import io.runcycles.admin.model.webhook.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -153,6 +154,22 @@ public class WebhookService {
     }
 
     public WebhookTestResponse test(String subscriptionId) {
+        // #209 — NARROW, EXPLICIT invariant EXCEPTION. The webhook category
+        // boundary otherwise forbids delivering an admin-classified event to a
+        // concrete-tenant subscription. /test is exempt because:
+        //   (1) the governance spec (the authority) defines the test ping as the
+        //       admin-category event type `system.webhook_test` — reclassifying
+        //       the wire envelope here would diverge from the spec, and keeping
+        //       the type while relabelling the category would produce exactly the
+        //       type/category-inconsistent record the dispatch boundary now
+        //       blocks (WebhookDispatchService#isBlockedByOwnershipBoundary);
+        //   (2) this is a SYNTHETIC, owner-triggered connectivity probe (the
+        //       subscription owner tests their OWN endpoint) whose payload is
+        //       {subscription_id, test:true} — it carries NO real governance or
+        //       security telemetry, so the confidentiality guarantee is intact.
+        // It also POSTs DIRECTLY (not via the dispatch queue / events worker), so
+        // no dispatch-side boundary applies. Documented in CHANGELOG/AUDIT; the
+        // spec-side exception is tracked separately.
         WebhookSubscription sub = webhookRepository.findById(subscriptionId);
         String secret = webhookRepository.getSigningSecret(subscriptionId);
         String testEventId = "evt_test_" + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
@@ -311,32 +328,13 @@ public class WebhookService {
         }
         try {
             int maxEvents = request.getMaxEvents() != null ? Math.min(request.getMaxEvents(), 1000) : 100;
-            // Query events in the requested time range. isSystemOwner is null-safe
-            // (a null owner classifies as system → query all tenants), avoiding an
-            // NPE on a null-owned row.
-            List<Event> events = eventRepository.list(
-                WebhookSubscription.isSystemOwner(sub.getTenantId()) ? null : sub.getTenantId(),
-                null, null, null, null,
-                request.getFrom(), request.getTo(), null, maxEvents);
-            // Filter by event types if specified in replay request
-            if (request.getEventTypes() != null && !request.getEventTypes().isEmpty()) {
-                events = events.stream()
-                    .filter(e -> request.getEventTypes().contains(e.getEventType()))
-                    .toList();
-            }
-            // #209: intersect with the SUBSCRIPTION's own event_types /
-            // event_categories — the same matcher as live dispatch
-            // (WebhookRepository.findMatchingSubscriptions). Spec (replayEvents):
-            // "If omitted, replays all event types the subscription is subscribed
-            // to." Without this, a concrete-tenant budget-only subscription could
-            // replay historical ADMIN-only events (api_key.*/policy.*/…) to its
-            // tenant-controlled endpoint — bypassing the category boundary this
-            // release establishes. Also apply the subscription's scope_filter so
-            // replay never delivers an event live dispatch would have skipped.
-            events = events.stream()
-                .filter(e -> WebhookRepository.matchesEventType(sub, e.getEventType()))
-                .filter(e -> WebhookRepository.matchesScope(sub, e.getScope()))
-                .toList();
+            // #209 P2: collect up to maxEvents DELIVERABLE events by paging the
+            // window chronologically and filtering DURING pagination — never a
+            // single capped fetch then post-hoc filter, which would drop matching
+            // events that fall past the cap when the first page is all
+            // non-matching ("scanned 100, queued 0"). Chronological order is
+            // preserved for delivery (spec replayEvents).
+            List<Event> events = collectDeliverableReplayEvents(sub, request, maxEvents);
             // Queue each matching event for re-delivery to this subscription
             int queued = 0;
             for (Event event : events) {
@@ -362,6 +360,79 @@ public class WebhookService {
         } finally {
             webhookRepository.releaseReplayLock(subscriptionId, replayId);
         }
+    }
+
+    /** Per-fetch page size while paging the replay window (bounded memory). */
+    private static final int REPLAY_PAGE_SIZE = 500;
+    /**
+     * Total scanned-event ceiling for one replay. A very sparse window (few
+     * matching events among many) can't scan unbounded; if this bound is hit
+     * before {@code maxEvents} matches are collected, collection stops and logs
+     * — NOT a silent truncation.
+     */
+    private static final int REPLAY_MAX_SCAN = 20_000;
+
+    /**
+     * Collect up to {@code maxEvents} DELIVERABLE events from the replay window
+     * in CHRONOLOGICAL (ascending) order, applying every filter live
+     * dispatch/replay would apply, paginated in bounded batches:
+     * <ul>
+     *   <li>the request's optional {@code event_types} filter;</li>
+     *   <li>the subscription's OWN {@code event_types}/{@code event_categories}
+     *       ({@link WebhookRepository#matchesEventType}) and {@code scope_filter}
+     *       ({@link WebhookRepository#matchesScope}) — spec {@code replayEvents}:
+     *       "replays all event types the subscription is subscribed to"; and</li>
+     *   <li>the fail-closed ownership boundary
+     *       ({@link WebhookDispatchService#isBlockedByOwnershipBoundary}) so the
+     *       cap counts only events {@code dispatchToSubscription} will actually
+     *       deliver (a concrete-tenant sub never spends budget on admin-only
+     *       events).</li>
+     * </ul>
+     * Pages via the timestamp-ASC cursor of {@link EventRepository#list} until
+     * {@code maxEvents} matches are collected, the window is exhausted, or the
+     * {@link #REPLAY_MAX_SCAN} scan ceiling is reached.
+     */
+    private List<Event> collectDeliverableReplayEvents(WebhookSubscription sub,
+                                                        ReplayRequest request, int maxEvents) {
+        // isSystemOwner is null-safe (null owner → system → query all tenants).
+        String queryTenant = WebhookSubscription.isSystemOwner(sub.getTenantId())
+            ? null : sub.getTenantId();
+        SortSpec chronological = SortSpec.of("timestamp", SortDirection.ASC);
+        boolean hasRequestTypeFilter =
+            request.getEventTypes() != null && !request.getEventTypes().isEmpty();
+
+        List<Event> collected = new ArrayList<>();
+        String cursor = null;
+        int scanned = 0;
+        while (collected.size() < maxEvents && scanned < REPLAY_MAX_SCAN) {
+            List<Event> page = eventRepository.list(
+                queryTenant, null, null, null, null,
+                request.getFrom(), request.getTo(), cursor, REPLAY_PAGE_SIZE, chronological);
+            if (page.isEmpty()) {
+                break; // window exhausted
+            }
+            for (Event e : page) {
+                scanned++;
+                if (hasRequestTypeFilter && !request.getEventTypes().contains(e.getEventType())) {
+                    continue;
+                }
+                if (!WebhookRepository.matchesEventType(sub, e.getEventType())) continue;
+                if (!WebhookRepository.matchesScope(sub, e.getScope())) continue;
+                // Don't spend cap budget on an event delivery will skip.
+                if (dispatchService.isBlockedByOwnershipBoundary(e, sub)) continue;
+                collected.add(e);
+                if (collected.size() >= maxEvents) break;
+            }
+            if (page.size() < REPLAY_PAGE_SIZE) {
+                break; // last (partial) page — window exhausted
+            }
+            cursor = page.get(page.size() - 1).getEventId();
+        }
+        if (collected.size() < maxEvents && scanned >= REPLAY_MAX_SCAN) {
+            LOG.warn("Webhook replay hit the scan ceiling before filling max_events: subscription_id={} tenant_id={} scanned={} collected={} max_events={} — window may hold more matching events past the scan bound",
+                safe(sub.getSubscriptionId()), safe(sub.getTenantId()), scanned, collected.size(), maxEvents);
+        }
+        return collected;
     }
 
     /**

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookService.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/service/WebhookService.java
@@ -341,30 +341,42 @@ public class WebhookService {
             int selected = events.size();
             // #209 F1: enqueue is BEST-EFFORT by design (governance #130). Selection
             // is complete, but events_queued reports how many were ACCEPTED onto the
-            // dispatch queue — it may be < selected if the backend transiently fails
-            // a per-event enqueue. Replay is NOT idempotent (delivery IDs are random;
-            // a retry may duplicate). We count only events actually enqueued
-            // (dispatchToSubscription returns false when a delivery guard — ownership
-            // boundary or a concurrent disable re-checked at dispatch — skips it, and
-            // an enqueue error is caught per event) so the count is honest.
-            int queued = 0;
+            // dispatch queue. dispatchToSubscription returns a STRUCTURED outcome so
+            // we can tell a real backend degradation (ENQUEUE_FAILED) from intended,
+            // benign skips (INACTIVE = concurrent pause/disable/delete re-checked at
+            // dispatch; BLOCKED = delivery-time ownership guard). Replay is NOT
+            // idempotent (delivery IDs are random; a retry may duplicate).
+            int enqueued = 0, inactive = 0, blocked = 0, enqueueFailed = 0;
             for (Event event : events) {
                 try {
-                    if (dispatchService.dispatchToSubscription(event, sub)) {
-                        queued++;
+                    switch (dispatchService.dispatchToSubscription(event, sub)) {
+                        case ENQUEUED -> enqueued++;
+                        case INACTIVE -> inactive++;
+                        case BLOCKED -> blocked++;
+                        case ENQUEUE_FAILED -> enqueueFailed++;
                     }
                 } catch (Exception e) {
+                    // Unexpected error enqueuing this event — a backend degradation.
+                    enqueueFailed++;
                     LOG.warn("Failed to queue webhook replay delivery: replay_id={} subscription_id={} tenant_id={} event_id={} event_type={} correlation_id={} request_id={} trace_id={} error={}",
                             safe(replayId), safe(subscriptionId), safe(sub.getTenantId()), safe(event.getEventId()),
                             safe(event.getEventType() != null ? event.getEventType().getValue() : null),
                             safe(event.getCorrelationId()), safe(event.getRequestId()), safe(event.getTraceId()), safe(e.getMessage()), e);
                 }
             }
-            // Loud, operator-facing signal that a degraded backend produced a
-            // PARTIAL enqueue (best-effort contract: events_queued < selected).
+            int queued = enqueued;
+            // Categorized shortfall signal — a real backend failure is a "degraded"
+            // WARN; a purely lifecycle/guard shortfall is a benign INFO (intended).
             if (queued < selected) {
-                LOG.warn("Webhook replay PARTIAL enqueue (best-effort): replay_id={} subscription_id={} tenant_id={} selected={} queued={} — {} deliverable event(s) were NOT enqueued (degraded dispatch backend); replay is not idempotent, a retry may duplicate already-queued deliveries",
-                    safe(replayId), safe(subscriptionId), safe(sub.getTenantId()), selected, queued, selected - queued);
+                if (enqueueFailed > 0) {
+                    LOG.warn("Webhook replay PARTIAL enqueue — DEGRADED dispatch backend: replay_id={} subscription_id={} tenant_id={} selected={} enqueued={} enqueue_failed={} inactive={} blocked={} — {} deliverable event(s) were NOT enqueued; replay is not idempotent, a retry may duplicate already-queued deliveries",
+                        safe(replayId), safe(subscriptionId), safe(sub.getTenantId()),
+                        selected, enqueued, enqueueFailed, inactive, blocked, selected - queued);
+                } else {
+                    LOG.info("Webhook replay enqueued fewer than selected due to concurrent subscription lifecycle change / delivery-time guard (intended, NOT degradation): replay_id={} subscription_id={} tenant_id={} selected={} enqueued={} inactive={} blocked={}",
+                        safe(replayId), safe(subscriptionId), safe(sub.getTenantId()),
+                        selected, enqueued, inactive, blocked);
+                }
             }
             return ReplayResponse.builder()
                 .replayId(replayId)

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookAdminControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookAdminControllerTest.java
@@ -700,6 +700,64 @@ class WebhookAdminControllerTest {
     }
 
     @Test
+    void bulkActionWebhooks_resume_concreteTenantAdminOffender_failsRow_noResume() throws Exception {
+        // #209 bulk-RESUME bypass: a PAUSED concrete-tenant subscription carrying
+        // an admin-only category must NOT be resumed to ACTIVE — bulk RESUME now
+        // routes through effective-selector validation, so the row fails.
+        io.runcycles.admin.model.webhook.WebhookSubscription offender =
+                io.runcycles.admin.model.webhook.WebhookSubscription.builder()
+                        .subscriptionId("w1").tenantId("tenant-1")
+                        .url("https://example.com/w1")
+                        .eventCategories(List.of(io.runcycles.admin.model.event.EventCategory.API_KEY))
+                        .status(WebhookStatus.PAUSED).createdAt(Instant.now()).build();
+        when(idempotencyStore.lookup(anyString(), anyString(), eq(WebhookBulkActionResponse.class)))
+                .thenReturn(java.util.Optional.empty());
+        when(webhookRepository.matchForBulk(any(), any(), any(), any(), eq(500)))
+                .thenReturn(List.of(offender));
+        when(webhookRepository.findById("w1")).thenReturn(offender);
+
+        mockMvc.perform(post("/v1/admin/webhooks/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"filter\":{\"status\":\"PAUSED\"},\"action\":\"RESUME\",\"idempotency_key\":\"k1\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.failed.length()").value(1))
+                .andExpect(jsonPath("$.failed[0].id").value("w1"))
+                .andExpect(jsonPath("$.failed[0].error_code").value("INVALID_TRANSITION"))
+                .andExpect(jsonPath("$.succeeded.length()").value(0));
+
+        verify(webhookService, never()).update(anyString(), any());
+    }
+
+    @Test
+    void bulkActionWebhooks_resume_concreteTenantClean_resumes() throws Exception {
+        // A PAUSED concrete-tenant subscription with only tenant-accessible
+        // selectors passes validation and resumes normally.
+        io.runcycles.admin.model.webhook.WebhookSubscription clean =
+                io.runcycles.admin.model.webhook.WebhookSubscription.builder()
+                        .subscriptionId("w1").tenantId("tenant-1")
+                        .url("https://example.com/w1")
+                        .eventCategories(List.of(io.runcycles.admin.model.event.EventCategory.BUDGET))
+                        .status(WebhookStatus.PAUSED).createdAt(Instant.now()).build();
+        when(idempotencyStore.lookup(anyString(), anyString(), eq(WebhookBulkActionResponse.class)))
+                .thenReturn(java.util.Optional.empty());
+        when(webhookRepository.matchForBulk(any(), any(), any(), any(), eq(500)))
+                .thenReturn(List.of(clean));
+        when(webhookRepository.findById("w1")).thenReturn(clean);
+        when(webhookService.update(anyString(), any())).thenReturn(clean);
+
+        mockMvc.perform(post("/v1/admin/webhooks/bulk-action")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"filter\":{\"status\":\"PAUSED\"},\"action\":\"RESUME\",\"idempotency_key\":\"k1\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.succeeded.length()").value(1))
+                .andExpect(jsonPath("$.failed.length()").value(0));
+
+        verify(webhookService).update(eq("w1"), any());
+    }
+
+    @Test
     void bulkActionWebhooks_delete_missingRow_landsInSkipped() throws Exception {
         when(idempotencyStore.lookup(anyString(), anyString(), eq(WebhookBulkActionResponse.class)))
                 .thenReturn(java.util.Optional.empty());

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookAdminControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookAdminControllerTest.java
@@ -432,6 +432,44 @@ class WebhookAdminControllerTest {
                 entry.getStatus() == 202));
     }
 
+    // #209 F3: max_events is bounded [1,1000] by @Min/@Max on ReplayRequest and
+    // enforced by @Valid — out-of-range is REJECTED (400), not silently clamped.
+    @Test
+    void replay_maxEventsZero_returns400_serviceNotCalled() throws Exception {
+        mockMvc.perform(post("/v1/admin/webhooks/whsub_1/replay")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"max_events\":0}"))
+                .andExpect(status().isBadRequest());
+        verify(webhookService, never()).replay(anyString(), any());
+    }
+
+    @Test
+    void replay_maxEventsOver1000_returns400_serviceNotCalled() throws Exception {
+        mockMvc.perform(post("/v1/admin/webhooks/whsub_1/replay")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"max_events\":1001}"))
+                .andExpect(status().isBadRequest());
+        verify(webhookService, never()).replay(anyString(), any());
+    }
+
+    @Test
+    void replay_nullMaxEvents_passesValidation_returns202() throws Exception {
+        // Omitting max_events is valid (@Min/@Max pass for null); it defaults to
+        // 100 in the service. @Valid must NOT reject it.
+        ReplayResponse response = ReplayResponse.builder()
+            .replayId("replay_2").eventsQueued(0).estimatedCompletionSeconds(0).build();
+        when(webhookService.replay(eq("whsub_1"), any())).thenReturn(response);
+
+        mockMvc.perform(post("/v1/admin/webhooks/whsub_1/replay")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isAccepted());
+        verify(webhookService).replay(eq("whsub_1"), any());
+    }
+
     // --- Sort contract tests (spec v0.1.25.20 §V4 server-side sort) ---
 
     @Test

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookAdminControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookAdminControllerTest.java
@@ -280,6 +280,62 @@ class WebhookAdminControllerTest {
         verify(webhookService).update(eq("whsub_1"), any());
     }
 
+    // #209 finding 2: a status-only PATCH (null selector arrays) must validate
+    // the EFFECTIVE result (stored ∪ request), so it cannot reactivate a
+    // disabled concrete-tenant offender that still holds admin-only selectors.
+    @Test
+    void updateWebhook_statusOnlyReactivation_ofStoredAdminCategoryOffender_returns400() throws Exception {
+        WebhookSubscription prior = WebhookSubscription.builder()
+            .subscriptionId("whsub_off").tenantId("tenant-1").url("https://example.com/wh")
+            .eventTypes(List.of(EventType.BUDGET_CREATED))
+            .eventCategories(List.of(EventCategory.API_KEY)) // stored admin-only category
+            .status(WebhookStatus.DISABLED).createdAt(Instant.now()).build();
+        when(webhookService.get("whsub_off")).thenReturn(prior);
+
+        mockMvc.perform(patch("/v1/admin/webhooks/whsub_off")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"status\":\"ACTIVE\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("INVALID_REQUEST"));
+
+        verify(webhookService, never()).update(anyString(), any());
+    }
+
+    @Test
+    void updateWebhook_statusOnlyReactivation_ofSystemAdminCategoryRow_returns200() throws Exception {
+        // __system__ owner is exempt — an admin-category system row can be reactivated.
+        WebhookSubscription prior = WebhookSubscription.builder()
+            .subscriptionId("whsub_sys").tenantId("__system__").url("https://example.com/wh")
+            .eventCategories(List.of(EventCategory.API_KEY))
+            .status(WebhookStatus.DISABLED).createdAt(Instant.now()).build();
+        when(webhookService.get("whsub_sys")).thenReturn(prior);
+        when(webhookService.update(eq("whsub_sys"), any())).thenReturn(prior);
+
+        mockMvc.perform(patch("/v1/admin/webhooks/whsub_sys")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"status\":\"ACTIVE\"}"))
+                .andExpect(status().isOk());
+
+        verify(webhookService).update(eq("whsub_sys"), any());
+    }
+
+    // #209 finding 5: a blank (whitespace-only) tenant_id is NOT system-exempt —
+    // admin-only selectors on a blank owner are validated (rejected).
+    @Test
+    void createWebhook_blankTenantId_adminCategory_returns400() throws Exception {
+        mockMvc.perform(post("/v1/admin/webhooks")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .param("tenant_id", "   ")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"url\":\"https://example.com/wh\",\"event_types\":[\"budget.created\"],\"event_categories\":[\"api_key\"]}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("INVALID_REQUEST"));
+
+        verify(webhookService, never()).create(anyString(), any());
+    }
+
     @Test
     void deleteWebhook_returns204() throws Exception {
         WebhookSubscription sub = WebhookSubscription.builder()

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookAdminControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookAdminControllerTest.java
@@ -37,7 +37,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(WebhookAdminController.class)
-@Import({MetricsTestConfiguration.class, ContractValidationConfig.class})
+@Import({MetricsTestConfiguration.class, ContractValidationConfig.class,
+        io.runcycles.admin.api.service.WebhookCategoryBoundaryValidator.class})
 class WebhookAdminControllerTest {
 
     @Autowired private MockMvc mockMvc;
@@ -147,16 +148,66 @@ class WebhookAdminControllerTest {
                 entry.getStatus() == 200));
     }
 
-    // v0.1.25.50: the tenant-plane event_categories boundary is NOT a global
-    // tightening — the admin plane (/v1/admin/webhooks) may create/update
-    // subscriptions with admin-only categories. Proves the boundary is
-    // scoped to the tenant endpoint, not applied to every WebhookService call.
+    // #209 / governance v0.1.25.40 (pending): the admin plane is the CARRIER
+    // source. Admin-only categories on a TENANT-owned subscription are now
+    // rejected 400 (create validates against the tenant_id param; update
+    // against the STORED subscription's tenant_id); __system__ rows are NOT
+    // tenant-owned and admin-only categories there remain allowed.
     @Test
-    void createWebhook_withAdminOnlyEventCategory_returns201() throws Exception {
+    void createWebhook_adminOnlyEventCategory_onRealTenant_returns400() throws Exception {
+        mockMvc.perform(post("/v1/admin/webhooks")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .param("tenant_id", "tenant-1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"url\":\"https://example.com/wh\",\"event_types\":[\"budget.created\"],\"event_categories\":[\"api_key\"]}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("INVALID_REQUEST"));
+
+        verify(webhookService, never()).create(anyString(), any());
+    }
+
+    @Test
+    void createWebhook_adminOnlyEventType_onRealTenant_returns400() throws Exception {
+        mockMvc.perform(post("/v1/admin/webhooks")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .param("tenant_id", "tenant-1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"url\":\"https://example.com/wh\",\"event_types\":[\"api_key.created\"]}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("INVALID_REQUEST"));
+
+        verify(webhookService, never()).create(anyString(), any());
+    }
+
+    @Test
+    void createWebhook_adminOnlyEventCategory_onSystem_returns201() throws Exception {
+        // No tenant_id param -> __system__ target -> admin-only categories allowed
+        // (legitimate system-wide monitoring; not tenant-owned).
         WebhookSubscription sub = WebhookSubscription.builder()
-            .subscriptionId("whsub_admincat").tenantId("tenant-1").url("https://example.com/wh")
+            .subscriptionId("whsub_sys").tenantId("__system__").url("https://example.com/wh")
             .eventTypes(List.of(EventType.BUDGET_CREATED))
             .eventCategories(List.of(EventCategory.API_KEY)).status(WebhookStatus.ACTIVE)
+            .createdAt(Instant.now()).build();
+        WebhookCreateResponse response = WebhookCreateResponse.builder()
+            .subscription(sub).signingSecret("whsec_abc").build();
+        when(webhookService.create(eq("__system__"), any())).thenReturn(response);
+
+        mockMvc.perform(post("/v1/admin/webhooks")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"url\":\"https://example.com/wh\",\"event_types\":[\"budget.created\"],\"event_categories\":[\"api_key\"]}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.subscription.subscription_id").value("whsub_sys"));
+
+        verify(webhookService).create(eq("__system__"), any());
+    }
+
+    @Test
+    void createWebhook_tenantAccessibleCategories_onRealTenant_returns201() throws Exception {
+        WebhookSubscription sub = WebhookSubscription.builder()
+            .subscriptionId("whsub_ok").tenantId("tenant-1").url("https://example.com/wh")
+            .eventTypes(List.of(EventType.BUDGET_CREATED))
+            .eventCategories(List.of(EventCategory.RESERVATION)).status(WebhookStatus.ACTIVE)
             .createdAt(Instant.now()).build();
         WebhookCreateResponse response = WebhookCreateResponse.builder()
             .subscription(sub).signingSecret("whsec_abc").build();
@@ -166,29 +217,64 @@ class WebhookAdminControllerTest {
                         .header("X-Admin-API-Key", ADMIN_KEY)
                         .param("tenant_id", "tenant-1")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"url\":\"https://example.com/wh\",\"event_types\":[\"budget.created\"],\"event_categories\":[\"api_key\"]}"))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.subscription.subscription_id").value("whsub_admincat"));
+                        .content("{\"url\":\"https://example.com/wh\",\"event_types\":[\"budget.created\"],\"event_categories\":[\"budget\",\"reservation\",\"tenant\"]}"))
+                .andExpect(status().isCreated());
 
         verify(webhookService).create(eq("tenant-1"), any());
     }
 
     @Test
-    void updateWebhook_withAdminOnlyEventCategory_returns200() throws Exception {
+    void updateWebhook_adminOnlyEventCategory_onTenantOwned_returns400() throws Exception {
+        // Target tenant is the STORED subscription's tenant_id (tenant-1).
         WebhookSubscription prior = WebhookSubscription.builder()
             .subscriptionId("whsub_1").tenantId("tenant-1").url("https://example.com/wh")
             .status(WebhookStatus.ACTIVE).createdAt(Instant.now()).build();
-        WebhookSubscription updated = WebhookSubscription.builder()
-            .subscriptionId("whsub_1").tenantId("tenant-1").url("https://example.com/wh")
-            .eventCategories(List.of(EventCategory.SYSTEM)).status(WebhookStatus.ACTIVE)
-            .createdAt(Instant.now()).build();
         when(webhookService.get("whsub_1")).thenReturn(prior);
-        when(webhookService.update(eq("whsub_1"), any())).thenReturn(updated);
 
         mockMvc.perform(patch("/v1/admin/webhooks/whsub_1")
                         .header("X-Admin-API-Key", ADMIN_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"event_categories\":[\"system\"]}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("INVALID_REQUEST"));
+
+        verify(webhookService, never()).update(anyString(), any());
+    }
+
+    @Test
+    void updateWebhook_adminOnlyEventCategory_onSystemOwned_returns200() throws Exception {
+        // Stored subscription is __system__-owned -> admin-only categories allowed.
+        WebhookSubscription prior = WebhookSubscription.builder()
+            .subscriptionId("whsub_sys").tenantId("__system__").url("https://example.com/wh")
+            .status(WebhookStatus.ACTIVE).createdAt(Instant.now()).build();
+        WebhookSubscription updated = WebhookSubscription.builder()
+            .subscriptionId("whsub_sys").tenantId("__system__").url("https://example.com/wh")
+            .eventCategories(List.of(EventCategory.SYSTEM)).status(WebhookStatus.ACTIVE)
+            .createdAt(Instant.now()).build();
+        when(webhookService.get("whsub_sys")).thenReturn(prior);
+        when(webhookService.update(eq("whsub_sys"), any())).thenReturn(updated);
+
+        mockMvc.perform(patch("/v1/admin/webhooks/whsub_sys")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"event_categories\":[\"system\"]}"))
+                .andExpect(status().isOk());
+
+        verify(webhookService).update(eq("whsub_sys"), any());
+    }
+
+    @Test
+    void updateWebhook_tenantAccessibleCategory_onTenantOwned_returns200() throws Exception {
+        WebhookSubscription prior = WebhookSubscription.builder()
+            .subscriptionId("whsub_1").tenantId("tenant-1").url("https://example.com/wh")
+            .status(WebhookStatus.ACTIVE).createdAt(Instant.now()).build();
+        when(webhookService.get("whsub_1")).thenReturn(prior);
+        when(webhookService.update(eq("whsub_1"), any())).thenReturn(prior);
+
+        mockMvc.perform(patch("/v1/admin/webhooks/whsub_1")
+                        .header("X-Admin-API-Key", ADMIN_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"event_categories\":[\"budget\"]}"))
                 .andExpect(status().isOk());
 
         verify(webhookService).update(eq("whsub_1"), any());

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookTenantControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookTenantControllerTest.java
@@ -7,6 +7,7 @@ import io.runcycles.admin.data.exception.GovernanceException;
 import io.runcycles.admin.data.repository.AuditRepository;
 import io.runcycles.admin.data.repository.ApiKeyRepository;
 import io.runcycles.admin.model.auth.ApiKeyValidationResponse;
+import io.runcycles.admin.model.event.EventCategory;
 import io.runcycles.admin.model.event.EventType;
 import io.runcycles.admin.model.shared.ErrorCode;
 import io.runcycles.admin.model.webhook.*;
@@ -260,6 +261,29 @@ class WebhookTenantControllerTest {
                         .content("{\"event_types\":[\"api_key.created\"]}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error").value("INVALID_REQUEST"));
+    }
+
+    // #209 finding 2: a status-only PATCH cannot reactivate a disabled tenant
+    // offender that still holds admin-only selectors — the effective result
+    // (stored ∪ request) is validated, not just the request arrays.
+    @Test
+    void updateWebhook_statusOnlyReactivation_ofStoredOffender_returns400() throws Exception {
+        setupApiKeyAuth();
+        WebhookSubscription sub = WebhookSubscription.builder()
+            .subscriptionId("whsub_1").tenantId("tenant-1").url("https://example.com/wh")
+            .eventTypes(List.of(EventType.BUDGET_CREATED))
+            .eventCategories(List.of(EventCategory.API_KEY)) // stored admin-only category
+            .status(WebhookStatus.DISABLED).createdAt(Instant.now()).build();
+        when(webhookService.get("whsub_1")).thenReturn(sub);
+
+        mockMvc.perform(patch("/v1/webhooks/whsub_1")
+                        .header("X-Cycles-API-Key", "valid-api-key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"status\":\"ACTIVE\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("INVALID_REQUEST"));
+
+        verify(webhookService, never()).update(anyString(), any());
     }
 
     @Test

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookTenantControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/WebhookTenantControllerTest.java
@@ -30,7 +30,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(WebhookTenantController.class)
-@Import({MetricsTestConfiguration.class, ContractValidationConfig.class})
+@Import({MetricsTestConfiguration.class, ContractValidationConfig.class,
+        io.runcycles.admin.api.service.WebhookCategoryBoundaryValidator.class})
 class WebhookTenantControllerTest {
 
     @Autowired private MockMvc mockMvc;

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/integration/WebhookReplayPaginationIntegrationTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/integration/WebhookReplayPaginationIntegrationTest.java
@@ -163,49 +163,78 @@ class WebhookReplayPaginationIntegrationTest {
         assertThat(capturedDeliveries(60)).allMatch(e -> e.getEventType() == EventType.BUDGET_CREATED);
     }
 
-    // (2) hydration drops interior rows (expired/evicted) but later ZSET members
-    //     match → NOT treated as exhaustion; later matches still delivered.
+    // (2) DELIVERABLE matches exist BEYOND the old code's first repository
+    //     candidate window (round-4 list() fetched limit*3 = 500*3 = 1500 ZSET
+    //     ids per page), and interior hydration drops make that first window
+    //     hydrate to FEWER than the 500 page size. The round-4 collector
+    //     ("page.size() < 500 → stop") would treat the short first page as
+    //     exhaustion and MISS every tail match (deliver 0). Approach B reads the
+    //     full ordered id list up front, so hydration drops never look like
+    //     exhaustion → all tail matches ship. This is what distinguishes the two.
     @Test
-    void replay_interiorHydrationDrops_laterMatchesStillDelivered() {
+    void replay_matchesBeyondFirstCandidateWindow_withHydrationDrops_stillDelivered() {
         Instant base = Instant.parse("2026-07-11T00:00:00Z");
-        for (int i = 0; i < 10; i++) {
+        // 1500 non-matching filler at positions 0..1499 (the old limit*3 window).
+        for (int i = 0; i < 1500; i++) {
+            seedEvent(String.format("evt_fill_%05d", i), EventType.TENANT_CREATED, EventCategory.TENANT,
+                    null, base.plusMillis(i));
+        }
+        // Evict 1100 interior rows (ZSET members REMAIN) so the old first
+        // candidate window hydrates to 400 events (< 500) → round-4 stops here.
+        try (Jedis jedis = jedisPool.getResource()) {
+            for (int i = 0; i < 1100; i++) {
+                jedis.del("event:evt_fill_" + String.format("%05d", i));
+            }
+        }
+        // 30 DELIVERABLE matches AFTER the first candidate window (positions 1500+).
+        for (int i = 0; i < 30; i++) {
+            seedEvent(String.format("evt_match_%05d", i), EventType.BUDGET_CREATED, EventCategory.BUDGET,
+                    null, base.plusMillis(1500 + i));
+        }
+        seedBudgetSub();
+
+        ReplayResponse r = replay(1000, base.minusSeconds(1), base.plusSeconds(10));
+
+        // Round-4 would deliver 0 (stopped at the short first page); approach B
+        // delivers every tail match.
+        assertThat(r.getEventsQueued()).isEqualTo(30);
+        assertThat(capturedDeliveries(30)).extracting(Event::getEventId)
+                .containsExactly(java.util.stream.IntStream.range(0, 30)
+                        .mapToObj(i -> "evt_match_" + String.format("%05d", i))
+                        .toArray(String[]::new));
+    }
+
+    // (3) The old zscore(cursor)==null DUPLICATE class is STRUCTURALLY ELIMINATED
+    //     by approach B: the full ordered id list is fetched ONCE up front
+    //     (ZRANGEBYSCORE) and hydrated in batches — there is no per-page cursor
+    //     re-query, so the "cursor member vanished → re-emit the same page" path
+    //     no longer exists. This pins the actual new guarantee: a member whose
+    //     event row vanished between the id-fetch and hydration is cleanly
+    //     SKIPPED (no duplicate, no miss of later members, no crash), across a
+    //     MULTI-BATCH id list (>1 hydration batch of 500).
+    @Test
+    void replay_vanishedMembers_skippedCleanly_noDuplicate_acrossBatches() {
+        Instant base = Instant.parse("2026-07-11T00:00:00Z");
+        for (int i = 0; i < 600; i++) { // 600 members → 2 hydration batches (500 + 100)
             seedEvent(String.format("evt_%04d", i), EventType.BUDGET_CREATED, EventCategory.BUDGET, null,
                     base.plusMillis(i));
         }
-        // Evict three INTERIOR event rows (keep their ZSET members).
+        // Rows vanish (ZSET members REMAIN in the fetched id list) in BOTH
+        // batches, including at the 500-item batch boundary.
         try (Jedis jedis = jedisPool.getResource()) {
-            jedis.del("event:evt_0003", "event:evt_0004", "event:evt_0005");
+            jedis.del("event:evt_0003", "event:evt_0499", "event:evt_0500", "event:evt_0550");
         }
         seedBudgetSub();
 
-        ReplayResponse r = replay(1000, base.minusSeconds(1), base.plusSeconds(1));
+        ReplayResponse r = replay(1000, base.minusSeconds(1), base.plusSeconds(10));
 
-        assertThat(r.getEventsQueued()).isEqualTo(7); // 10 members - 3 evicted
-        assertThat(capturedDeliveries(7)).extracting(Event::getEventId)
-                .containsExactly("evt_0000", "evt_0001", "evt_0002",
-                        "evt_0006", "evt_0007", "evt_0008", "evt_0009"); // later matches present
-    }
-
-    // (3) a vanished member (its row evicted between ZRANGE and hydration) does
-    //     NOT cause a duplicate — each event is delivered at most once.
-    @Test
-    void replay_vanishedMember_noDuplicateDelivery() {
-        Instant base = Instant.parse("2026-07-11T00:00:00Z");
-        for (int i = 0; i < 5; i++) {
-            seedEvent("evt_" + i, EventType.BUDGET_CREATED, EventCategory.BUDGET, null, base.plusMillis(i));
-        }
-        try (Jedis jedis = jedisPool.getResource()) {
-            jedis.del("event:evt_2"); // middle member's row gone
-        }
-        seedBudgetSub();
-
-        ReplayResponse r = replay(1000, base.minusSeconds(1), base.plusSeconds(1));
-
-        assertThat(r.getEventsQueued()).isEqualTo(4);
-        List<Event> delivered = capturedDeliveries(4);
+        assertThat(r.getEventsQueued()).isEqualTo(596); // 600 - 4 vanished, each once
+        List<Event> delivered = capturedDeliveries(596);
         assertThat(delivered).extracting(Event::getEventId)
-                .containsExactly("evt_0", "evt_1", "evt_3", "evt_4") // no evt_2, no repeats
-                .doesNotHaveDuplicates();
+                .doesNotHaveDuplicates()
+                .doesNotContain("evt_0003", "evt_0499", "evt_0500", "evt_0550")
+                // members AFTER a vanished one (incl. in the 2nd batch) still ship:
+                .contains("evt_0551", "evt_0599");
     }
 
     // (4) scan ceiling hit → WARN logged (no silent truncation).

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/integration/WebhookReplayPaginationIntegrationTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/integration/WebhookReplayPaginationIntegrationTest.java
@@ -1,9 +1,5 @@
 package io.runcycles.admin.api.integration;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.read.ListAppender;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -27,7 +23,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.slf4j.LoggerFactory;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
@@ -238,28 +233,54 @@ class WebhookReplayPaginationIntegrationTest {
     }
 
     // (4) scan ceiling hit → WARN logged (no silent truncation).
+    // (4a) Window candidate count EXCEEDS the scan ceiling and fewer than
+    //      max_events deliverable events were found within the scanned set → the
+    //      search is genuinely incomplete → 400 returned BEFORE any enqueue (the
+    //      truncation must be caller-visible, not a silent partial + WARN).
     @Test
-    void replay_scanCeiling_logsWarning_noSilentTruncation() {
+    void replay_windowExceedsScanCeiling_incomplete_returns400_nothingEnqueued() {
         ReflectionTestUtils.setField(webhookService, "replayMaxScan", 50);
-        Instant ts = Instant.parse("2026-07-11T00:00:00Z");
-        for (int i = 0; i < 60; i++) { // 60 matching, but the id list is capped at 50
+        Instant base = Instant.parse("2026-07-11T00:00:00Z");
+        for (int i = 0; i < 60; i++) { // 60 deliverable matches; candidate count 60 > ceiling 50
             seedEvent(String.format("evt_%04d", i), EventType.BUDGET_CREATED, EventCategory.BUDGET, null,
-                    ts.plusMillis(i));
+                    base.plusMillis(i));
         }
         seedBudgetSub();
 
-        Logger logger = (Logger) LoggerFactory.getLogger(WebhookService.class);
-        ListAppender<ILoggingEvent> appender = new ListAppender<>();
-        appender.start();
-        logger.addAppender(appender);
-        try {
-            ReplayResponse r = replay(1000, ts.minusSeconds(1), ts.plusSeconds(1));
-            assertThat(r.getEventsQueued()).isEqualTo(50); // capped by the scan ceiling
-        } finally {
-            logger.detachAppender(appender);
+        // max_events (1000) not filled within the 50 scanned → incomplete → 400.
+        org.assertj.core.api.Assertions.assertThatThrownBy(
+                        () -> replay(1000, base.minusSeconds(1), base.plusSeconds(1)))
+                .isInstanceOf(io.runcycles.admin.data.exception.GovernanceException.class)
+                .satisfies(ex -> {
+                    var ge = (io.runcycles.admin.data.exception.GovernanceException) ex;
+                    assertThat(ge.getHttpStatus()).isEqualTo(400);
+                    assertThat(ge.getErrorCode())
+                            .isEqualTo(io.runcycles.admin.model.shared.ErrorCode.INVALID_REQUEST);
+                    assertThat(ge.getMessage()).contains("replay window too large").contains("narrow");
+                });
+
+        // NOTHING enqueued — fail-fast before the dispatch loop, no partial side effects.
+        verify(dispatchService, org.mockito.Mockito.never()).dispatchToSubscription(any(), any());
+        // The replay lock was released, so a subsequent replay is not blocked.
+        assertThat(webhookRepository.acquireReplayLock("whsub_1", "probe")).isTrue();
+    }
+
+    // (4b) Ceiling reached, but max_events WAS filled within the scanned set →
+    //      that is the caller's explicit pagination cap, NOT truncation → success.
+    @Test
+    void replay_windowExceedsCeiling_butMaxEventsFilledWithin_succeeds() {
+        ReflectionTestUtils.setField(webhookService, "replayMaxScan", 50);
+        Instant base = Instant.parse("2026-07-11T00:00:00Z");
+        for (int i = 0; i < 60; i++) { // candidate count 60 > ceiling 50
+            seedEvent(String.format("evt_%04d", i), EventType.BUDGET_CREATED, EventCategory.BUDGET, null,
+                    base.plusMillis(i));
         }
-        assertThat(appender.list).anyMatch(e -> e.getLevel() == Level.WARN
-                && e.getFormattedMessage().contains("scan ceiling"));
+        seedBudgetSub();
+
+        ReplayResponse r = replay(10, base.minusSeconds(1), base.plusSeconds(1)); // cap 10 < 50 scanned
+
+        assertThat(r.getEventsQueued()).isEqualTo(10); // filled the cap within the ceiling
+        verify(dispatchService, times(10)).dispatchToSubscription(any(), any());
     }
 
     // (5) chronological delivery order preserved ACROSS page boundaries (>500).

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/integration/WebhookReplayPaginationIntegrationTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/integration/WebhookReplayPaginationIntegrationTest.java
@@ -233,21 +233,21 @@ class WebhookReplayPaginationIntegrationTest {
     }
 
     // (4) scan ceiling hit → WARN logged (no silent truncation).
-    // (4a) Window candidate count EXCEEDS the scan ceiling and fewer than
-    //      max_events deliverable events were found within the scanned set → the
-    //      search is genuinely incomplete → 400 returned BEFORE any enqueue (the
-    //      truncation must be caller-visible, not a silent partial + WARN).
+    // (4) ALL-OR-NARROW: the window's candidate count exceeds the server scan
+    //     limit, so completeness over the unscanned tail can't be guaranteed →
+    //     400 (narrow the window), NOTHING enqueued. max_events is NOT a
+    //     resumable cursor, so there is no "continue" — either it fits or you
+    //     narrow.
     @Test
-    void replay_windowExceedsScanCeiling_incomplete_returns400_nothingEnqueued() {
+    void replay_windowExceedsScanLimit_returns400_narrow_nothingEnqueued() {
         ReflectionTestUtils.setField(webhookService, "replayMaxScan", 50);
         Instant base = Instant.parse("2026-07-11T00:00:00Z");
-        for (int i = 0; i < 60; i++) { // 60 deliverable matches; candidate count 60 > ceiling 50
+        for (int i = 0; i < 60; i++) { // candidate count 60 > scan limit 50
             seedEvent(String.format("evt_%04d", i), EventType.BUDGET_CREATED, EventCategory.BUDGET, null,
                     base.plusMillis(i));
         }
         seedBudgetSub();
 
-        // max_events (1000) not filled within the 50 scanned → incomplete → 400.
         org.assertj.core.api.Assertions.assertThatThrownBy(
                         () -> replay(1000, base.minusSeconds(1), base.plusSeconds(1)))
                 .isInstanceOf(io.runcycles.admin.data.exception.GovernanceException.class)
@@ -256,7 +256,8 @@ class WebhookReplayPaginationIntegrationTest {
                     assertThat(ge.getHttpStatus()).isEqualTo(400);
                     assertThat(ge.getErrorCode())
                             .isEqualTo(io.runcycles.admin.model.shared.ErrorCode.INVALID_REQUEST);
-                    assertThat(ge.getMessage()).contains("replay window too large").contains("narrow");
+                    assertThat(ge.getMessage()).contains("exceeds the replay scan limit").contains("narrow");
+                    assertThat(ge.getMessage()).doesNotContain("lower max_events"); // no continuation guidance
                 });
 
         // NOTHING enqueued — fail-fast before the dispatch loop, no partial side effects.
@@ -265,22 +266,58 @@ class WebhookReplayPaginationIntegrationTest {
         assertThat(webhookRepository.acquireReplayLock("whsub_1", "probe")).isTrue();
     }
 
-    // (4b) Ceiling reached, but max_events WAS filled within the scanned set →
-    //      that is the caller's explicit pagination cap, NOT truncation → success.
+    // (5a) ALL-OR-NARROW: the FULLY-SCANNED window holds MORE than max_events
+    //      deliverable events → 400 (narrow, or raise max_events up to 1000),
+    //      NOTHING enqueued (no partial).
     @Test
-    void replay_windowExceedsCeiling_butMaxEventsFilledWithin_succeeds() {
-        ReflectionTestUtils.setField(webhookService, "replayMaxScan", 50);
+    void replay_windowExceedsMaxEventsDeliverable_returns400_nothingEnqueued() {
         Instant base = Instant.parse("2026-07-11T00:00:00Z");
-        for (int i = 0; i < 60; i++) { // candidate count 60 > ceiling 50
+        for (int i = 0; i < 20; i++) { // 20 deliverable; candidate count << default scan limit
             seedEvent(String.format("evt_%04d", i), EventType.BUDGET_CREATED, EventCategory.BUDGET, null,
                     base.plusMillis(i));
         }
         seedBudgetSub();
 
-        ReplayResponse r = replay(10, base.minusSeconds(1), base.plusSeconds(1)); // cap 10 < 50 scanned
+        org.assertj.core.api.Assertions.assertThatThrownBy(
+                        () -> replay(10, base.minusSeconds(1), base.plusSeconds(1))) // 20 > max_events 10
+                .isInstanceOf(io.runcycles.admin.data.exception.GovernanceException.class)
+                .satisfies(ex -> {
+                    var ge = (io.runcycles.admin.data.exception.GovernanceException) ex;
+                    assertThat(ge.getHttpStatus()).isEqualTo(400);
+                    assertThat(ge.getErrorCode())
+                            .isEqualTo(io.runcycles.admin.model.shared.ErrorCode.INVALID_REQUEST);
+                    assertThat(ge.getMessage()).contains("more than max_events").contains("raise max_events");
+                });
 
-        assertThat(r.getEventsQueued()).isEqualTo(10); // filled the cap within the ceiling
-        verify(dispatchService, times(10)).dispatchToSubscription(any(), any());
+        verify(dispatchService, org.mockito.Mockito.never()).dispatchToSubscription(any(), any());
+        assertThat(webhookRepository.acquireReplayLock("whsub_1", "probe")).isTrue();
+    }
+
+    // (5b) The reviewer's same-timestamp concern under all-or-narrow: a
+    //      same-MILLISECOND cluster larger than max_events cannot be narrowed
+    //      below 1ms → 400; raising max_events to >= the cluster size makes a
+    //      SINGLE replay deliver ALL of them EXACTLY ONCE (no dup, no miss).
+    @Test
+    void replay_sameMsClusterOverMaxEvents_400_thenRaiseMaxEvents_deliversAllOnce() {
+        Instant ts = Instant.parse("2026-07-11T00:00:00Z");
+        for (int i = 0; i < 15; i++) { // 15 deliverable, ALL at the same millisecond
+            seedEvent(String.format("evt_%04d", i), EventType.BUDGET_CREATED, EventCategory.BUDGET, null, ts);
+        }
+        seedBudgetSub();
+
+        // max_events 10 < 15 in a 1ms cluster → 400, nothing enqueued.
+        org.assertj.core.api.Assertions.assertThatThrownBy(
+                        () -> replay(10, ts.minusSeconds(1), ts.plusSeconds(1)))
+                .isInstanceOf(io.runcycles.admin.data.exception.GovernanceException.class)
+                .satisfies(ex -> assertThat(
+                        ((io.runcycles.admin.data.exception.GovernanceException) ex).getHttpStatus())
+                        .isEqualTo(400));
+        verify(dispatchService, org.mockito.Mockito.never()).dispatchToSubscription(any(), any());
+
+        // Raise max_events >= cluster size → ONE replay delivers all 15 exactly once.
+        ReplayResponse r = replay(20, ts.minusSeconds(1), ts.plusSeconds(1));
+        assertThat(r.getEventsQueued()).isEqualTo(15);
+        assertThat(capturedDeliveries(15)).extracting(Event::getEventId).doesNotHaveDuplicates();
     }
 
     // (5) chronological delivery order preserved ACROSS page boundaries (>500).
@@ -305,27 +342,28 @@ class WebhookReplayPaginationIntegrationTest {
         assertThat(delivered.get(599).getEventId()).isEqualTo("evt_0599");
     }
 
-    // (6) max_events counts DELIVERABLE events (after all filters), and they are
-    //     the earliest matching ones in chronological order.
+    // (6) A fully-scanned window with <= max_events DELIVERABLE events — INCLUDING
+    //     a same-millisecond cluster — delivers ALL of them exactly once, with
+    //     non-matching events filtered out (deliverable-after-filters, complete).
     @Test
-    void replay_maxEvents_countsDeliverableAfterFilters() {
-        Instant base = Instant.parse("2026-07-11T00:00:00Z");
-        for (int i = 0; i < 20; i++) {
-            // interleave one matching + one non-matching at increasing timestamps
-            seedEvent(String.format("evt_ok_%04d", i), EventType.BUDGET_CREATED, EventCategory.BUDGET, null,
-                    base.plusMillis(2 * i));
-            seedEvent(String.format("evt_no_%04d", i), EventType.TENANT_CREATED, EventCategory.TENANT, null,
-                    base.plusMillis(2 * i + 1));
+    void replay_windowWithinMaxEvents_inclSameMsCluster_allDeliveredOnce() {
+        Instant ts = Instant.parse("2026-07-11T00:00:00Z");
+        // 8 deliverable + 4 non-matching, ALL at the same millisecond.
+        for (int i = 0; i < 8; i++) {
+            seedEvent(String.format("evt_ok_%04d", i), EventType.BUDGET_CREATED, EventCategory.BUDGET, null, ts);
+        }
+        for (int i = 0; i < 4; i++) {
+            seedEvent(String.format("evt_no_%04d", i), EventType.TENANT_CREATED, EventCategory.TENANT, null, ts);
         }
         seedBudgetSub();
 
-        ReplayResponse r = replay(5, base.minusSeconds(1), base.plusSeconds(1));
+        ReplayResponse r = replay(10, ts.minusSeconds(1), ts.plusSeconds(1)); // 8 deliverable <= 10
 
-        assertThat(r.getEventsQueued()).isEqualTo(5); // 5 DELIVERABLE, not 5 scanned
-        List<Event> delivered = capturedDeliveries(5);
-        assertThat(delivered).allMatch(e -> e.getEventType() == EventType.BUDGET_CREATED);
-        assertThat(delivered).extracting(Event::getEventId)
-                .containsExactly("evt_ok_0000", "evt_ok_0001", "evt_ok_0002",
-                        "evt_ok_0003", "evt_ok_0004"); // earliest 5 matches, chronological
+        assertThat(r.getEventsQueued()).isEqualTo(8);
+        List<Event> delivered = capturedDeliveries(8);
+        assertThat(delivered).allMatch(e -> e.getEventType() == EventType.BUDGET_CREATED); // non-matching filtered
+        assertThat(delivered).extracting(Event::getEventId).doesNotHaveDuplicates()
+                .containsExactlyInAnyOrder("evt_ok_0000", "evt_ok_0001", "evt_ok_0002", "evt_ok_0003",
+                        "evt_ok_0004", "evt_ok_0005", "evt_ok_0006", "evt_ok_0007");
     }
 }

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/integration/WebhookReplayPaginationIntegrationTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/integration/WebhookReplayPaginationIntegrationTest.java
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.when;
  * Approach B: {@link WebhookService#replay} pulls one bounded ordered id list
  * ({@link EventRepository#listEventIdsInRange}) then hydrates+filters batches.
  * {@link WebhookDispatchService} is mocked (delivery is not where the paging
- * bugs are); its {@code dispatchToSubscription} returns true so
+ * bugs are); its {@code dispatchToSubscription} returns ENQUEUED so
  * {@code events_queued} counts deliverable events and we capture delivery order.
  */
 class WebhookReplayPaginationIntegrationTest {
@@ -100,7 +100,8 @@ class WebhookReplayPaginationIntegrationTest {
             jedis.flushAll();
         }
         dispatchService = mock(WebhookDispatchService.class);
-        when(dispatchService.dispatchToSubscription(any(), any())).thenReturn(true);
+        when(dispatchService.dispatchToSubscription(any(), any()))
+                .thenReturn(WebhookDispatchService.DispatchOutcome.ENQUEUED);
         // boundary default: not blocked (false) — Mockito default for boolean.
         webhookService = new WebhookService(
                 webhookRepository, mock(WebhookDeliveryRepository.class),

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/integration/WebhookReplayPaginationIntegrationTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/integration/WebhookReplayPaginationIntegrationTest.java
@@ -1,0 +1,281 @@
+package io.runcycles.admin.api.integration;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.runcycles.admin.api.service.WebhookDispatchService;
+import io.runcycles.admin.api.service.WebhookService;
+import io.runcycles.admin.data.repository.EventRepository;
+import io.runcycles.admin.data.repository.WebhookDeliveryRepository;
+import io.runcycles.admin.data.repository.WebhookRepository;
+import io.runcycles.admin.data.repository.WebhookSecurityConfigRepository;
+import io.runcycles.admin.data.service.CryptoService;
+import io.runcycles.admin.model.event.Event;
+import io.runcycles.admin.model.event.EventCategory;
+import io.runcycles.admin.model.event.EventType;
+import io.runcycles.admin.model.webhook.ReplayRequest;
+import io.runcycles.admin.model.webhook.ReplayResponse;
+import io.runcycles.admin.model.webhook.WebhookStatus;
+import io.runcycles.admin.model.webhook.WebhookSubscription;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.slf4j.LoggerFactory;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.testcontainers.containers.GenericContainer;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * #209 round-3 P2 — REAL-Redis / real {@link EventRepository} replay pagination
+ * tests. These exercise the ZRANGEBYSCORE contract that the round-3 cursor
+ * rewrite's three bugs lived in (equal-timestamp skip, hydration-thinned page
+ * misread as exhaustion, vanished-cursor duplicate) — mocked pages cannot.
+ * Approach B: {@link WebhookService#replay} pulls one bounded ordered id list
+ * ({@link EventRepository#listEventIdsInRange}) then hydrates+filters batches.
+ * {@link WebhookDispatchService} is mocked (delivery is not where the paging
+ * bugs are); its {@code dispatchToSubscription} returns true so
+ * {@code events_queued} counts deliverable events and we capture delivery order.
+ */
+class WebhookReplayPaginationIntegrationTest {
+
+    static final GenericContainer<?> redis =
+            new GenericContainer<>("redis:7-alpine").withExposedPorts(6379);
+
+    static {
+        redis.start();
+    }
+
+    private static JedisPool jedisPool;
+    private static ObjectMapper objectMapper;
+    private static EventRepository eventRepository;
+    private static WebhookRepository webhookRepository;
+
+    private WebhookDispatchService dispatchService;
+    private WebhookService webhookService;
+
+    @BeforeAll
+    static void setupAll() {
+        JedisPoolConfig config = new JedisPoolConfig();
+        config.setMaxTotal(16);
+        jedisPool = new JedisPool(config, redis.getHost(), redis.getMappedPort(6379));
+
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+        eventRepository = new EventRepository();
+        ReflectionTestUtils.setField(eventRepository, "jedisPool", jedisPool);
+        ReflectionTestUtils.setField(eventRepository, "objectMapper", objectMapper);
+        ReflectionTestUtils.setField(eventRepository, "eventTtlDays", 90);
+
+        webhookRepository = new WebhookRepository();
+        ReflectionTestUtils.setField(webhookRepository, "jedisPool", jedisPool);
+        ReflectionTestUtils.setField(webhookRepository, "objectMapper", objectMapper);
+        ReflectionTestUtils.setField(webhookRepository, "cryptoService", new CryptoService(""));
+    }
+
+    @AfterAll
+    static void tearDownAll() {
+        if (jedisPool != null) jedisPool.close();
+    }
+
+    @BeforeEach
+    void setup() {
+        try (Jedis jedis = jedisPool.getResource()) {
+            jedis.flushAll();
+        }
+        dispatchService = mock(WebhookDispatchService.class);
+        when(dispatchService.dispatchToSubscription(any(), any())).thenReturn(true);
+        // boundary default: not blocked (false) — Mockito default for boolean.
+        webhookService = new WebhookService(
+                webhookRepository, mock(WebhookDeliveryRepository.class),
+                mock(WebhookSecurityConfigRepository.class), mock(io.runcycles.admin.api.service.WebhookUrlValidator.class),
+                dispatchService, eventRepository, objectMapper);
+        ReflectionTestUtils.setField(webhookService, "replayMaxScan", 20_000);
+    }
+
+    // ---- helpers ----
+
+    private void seedEvent(String id, EventType type, EventCategory cat, String scope, Instant ts) {
+        Event e = Event.builder().eventId(id).eventType(type).category(cat)
+                .tenantId("tenant-1").source("admin").scope(scope).timestamp(ts).build();
+        eventRepository.save(e);
+    }
+
+    private WebhookSubscription seedBudgetSub() {
+        WebhookSubscription sub = WebhookSubscription.builder()
+                .subscriptionId("whsub_1").tenantId("tenant-1")
+                .url("https://example.com/webhook")
+                .eventTypes(List.of(EventType.BUDGET_CREATED))
+                .status(WebhookStatus.ACTIVE).consecutiveFailures(0)
+                .createdAt(Instant.now()).build();
+        webhookRepository.save(sub);
+        return sub;
+    }
+
+    private ReplayResponse replay(int maxEvents, Instant from, Instant to) {
+        return webhookService.replay("whsub_1",
+                ReplayRequest.builder().from(from).to(to).maxEvents(maxEvents).build());
+    }
+
+    private List<Event> capturedDeliveries(int count) {
+        ArgumentCaptor<Event> cap = ArgumentCaptor.forClass(Event.class);
+        verify(dispatchService, times(count)).dispatchToSubscription(cap.capture(), any());
+        return cap.getAllValues();
+    }
+
+    // (1) >500 events sharing the SAME millisecond, matches only in the tail →
+    //     ALL delivered (the old cursor advanced by score+1 and skipped them).
+    @Test
+    void replay_equalTimestampWindow_tailMatches_allDelivered_noneSkipped() {
+        Instant ts = Instant.parse("2026-07-11T00:00:00Z");
+        for (int i = 0; i < 550; i++) { // non-matching, sort BEFORE matches
+            seedEvent(String.format("evt_a_%04d", i), EventType.TENANT_CREATED, EventCategory.TENANT, null, ts);
+        }
+        for (int i = 0; i < 60; i++) {  // matching, sort AFTER (tail past position 500)
+            seedEvent(String.format("evt_z_%04d", i), EventType.BUDGET_CREATED, EventCategory.BUDGET, null, ts);
+        }
+        seedBudgetSub();
+
+        ReplayResponse r = replay(1000, ts.minusSeconds(1), ts.plusSeconds(1));
+
+        assertThat(r.getEventsQueued()).isEqualTo(60); // all tail matches delivered
+        assertThat(capturedDeliveries(60)).allMatch(e -> e.getEventType() == EventType.BUDGET_CREATED);
+    }
+
+    // (2) hydration drops interior rows (expired/evicted) but later ZSET members
+    //     match → NOT treated as exhaustion; later matches still delivered.
+    @Test
+    void replay_interiorHydrationDrops_laterMatchesStillDelivered() {
+        Instant base = Instant.parse("2026-07-11T00:00:00Z");
+        for (int i = 0; i < 10; i++) {
+            seedEvent(String.format("evt_%04d", i), EventType.BUDGET_CREATED, EventCategory.BUDGET, null,
+                    base.plusMillis(i));
+        }
+        // Evict three INTERIOR event rows (keep their ZSET members).
+        try (Jedis jedis = jedisPool.getResource()) {
+            jedis.del("event:evt_0003", "event:evt_0004", "event:evt_0005");
+        }
+        seedBudgetSub();
+
+        ReplayResponse r = replay(1000, base.minusSeconds(1), base.plusSeconds(1));
+
+        assertThat(r.getEventsQueued()).isEqualTo(7); // 10 members - 3 evicted
+        assertThat(capturedDeliveries(7)).extracting(Event::getEventId)
+                .containsExactly("evt_0000", "evt_0001", "evt_0002",
+                        "evt_0006", "evt_0007", "evt_0008", "evt_0009"); // later matches present
+    }
+
+    // (3) a vanished member (its row evicted between ZRANGE and hydration) does
+    //     NOT cause a duplicate — each event is delivered at most once.
+    @Test
+    void replay_vanishedMember_noDuplicateDelivery() {
+        Instant base = Instant.parse("2026-07-11T00:00:00Z");
+        for (int i = 0; i < 5; i++) {
+            seedEvent("evt_" + i, EventType.BUDGET_CREATED, EventCategory.BUDGET, null, base.plusMillis(i));
+        }
+        try (Jedis jedis = jedisPool.getResource()) {
+            jedis.del("event:evt_2"); // middle member's row gone
+        }
+        seedBudgetSub();
+
+        ReplayResponse r = replay(1000, base.minusSeconds(1), base.plusSeconds(1));
+
+        assertThat(r.getEventsQueued()).isEqualTo(4);
+        List<Event> delivered = capturedDeliveries(4);
+        assertThat(delivered).extracting(Event::getEventId)
+                .containsExactly("evt_0", "evt_1", "evt_3", "evt_4") // no evt_2, no repeats
+                .doesNotHaveDuplicates();
+    }
+
+    // (4) scan ceiling hit → WARN logged (no silent truncation).
+    @Test
+    void replay_scanCeiling_logsWarning_noSilentTruncation() {
+        ReflectionTestUtils.setField(webhookService, "replayMaxScan", 50);
+        Instant ts = Instant.parse("2026-07-11T00:00:00Z");
+        for (int i = 0; i < 60; i++) { // 60 matching, but the id list is capped at 50
+            seedEvent(String.format("evt_%04d", i), EventType.BUDGET_CREATED, EventCategory.BUDGET, null,
+                    ts.plusMillis(i));
+        }
+        seedBudgetSub();
+
+        Logger logger = (Logger) LoggerFactory.getLogger(WebhookService.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            ReplayResponse r = replay(1000, ts.minusSeconds(1), ts.plusSeconds(1));
+            assertThat(r.getEventsQueued()).isEqualTo(50); // capped by the scan ceiling
+        } finally {
+            logger.detachAppender(appender);
+        }
+        assertThat(appender.list).anyMatch(e -> e.getLevel() == Level.WARN
+                && e.getFormattedMessage().contains("scan ceiling"));
+    }
+
+    // (5) chronological delivery order preserved ACROSS page boundaries (>500).
+    @Test
+    void replay_chronologicalOrder_preservedAcrossPageBoundaries() {
+        Instant base = Instant.parse("2026-07-11T00:00:00Z");
+        for (int i = 0; i < 600; i++) { // strictly increasing timestamps
+            seedEvent(String.format("evt_%04d", i), EventType.BUDGET_CREATED, EventCategory.BUDGET, null,
+                    base.plusMillis(i));
+        }
+        seedBudgetSub();
+
+        ReplayResponse r = replay(1000, base.minusSeconds(1), base.plusSeconds(10));
+
+        assertThat(r.getEventsQueued()).isEqualTo(600);
+        List<Event> delivered = capturedDeliveries(600);
+        for (int i = 1; i < delivered.size(); i++) {
+            assertThat(delivered.get(i).getTimestamp())
+                    .isAfterOrEqualTo(delivered.get(i - 1).getTimestamp()); // ascending, no reorder
+        }
+        assertThat(delivered.get(0).getEventId()).isEqualTo("evt_0000");
+        assertThat(delivered.get(599).getEventId()).isEqualTo("evt_0599");
+    }
+
+    // (6) max_events counts DELIVERABLE events (after all filters), and they are
+    //     the earliest matching ones in chronological order.
+    @Test
+    void replay_maxEvents_countsDeliverableAfterFilters() {
+        Instant base = Instant.parse("2026-07-11T00:00:00Z");
+        for (int i = 0; i < 20; i++) {
+            // interleave one matching + one non-matching at increasing timestamps
+            seedEvent(String.format("evt_ok_%04d", i), EventType.BUDGET_CREATED, EventCategory.BUDGET, null,
+                    base.plusMillis(2 * i));
+            seedEvent(String.format("evt_no_%04d", i), EventType.TENANT_CREATED, EventCategory.TENANT, null,
+                    base.plusMillis(2 * i + 1));
+        }
+        seedBudgetSub();
+
+        ReplayResponse r = replay(5, base.minusSeconds(1), base.plusSeconds(1));
+
+        assertThat(r.getEventsQueued()).isEqualTo(5); // 5 DELIVERABLE, not 5 scanned
+        List<Event> delivered = capturedDeliveries(5);
+        assertThat(delivered).allMatch(e -> e.getEventType() == EventType.BUDGET_CREATED);
+        assertThat(delivered).extracting(Event::getEventId)
+                .containsExactly("evt_ok_0000", "evt_ok_0001", "evt_ok_0002",
+                        "evt_ok_0003", "evt_ok_0004"); // earliest 5 matches, chronological
+    }
+}

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookCategoryBoundaryReconcilerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookCategoryBoundaryReconcilerTest.java
@@ -1,0 +1,86 @@
+package io.runcycles.admin.api.service;
+
+import io.runcycles.admin.data.repository.WebhookRepository;
+import io.runcycles.admin.data.repository.WebhookRepository.CategoryBoundaryAction;
+import io.runcycles.admin.data.repository.WebhookRepository.CategoryBoundaryRepairOutcome;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class WebhookCategoryBoundaryReconcilerTest {
+
+    @Mock private WebhookRepository webhookRepository;
+    @InjectMocks private WebhookCategoryBoundaryReconciler reconciler;
+
+    @Test
+    void run_flagEnabled_invokesReconcile_notDryRunByDefault() {
+        ReflectionTestUtils.setField(reconciler, "reconcileOnStartup", true);
+        ReflectionTestUtils.setField(reconciler, "dryRun", false);
+        when(webhookRepository.reconcileTenantCategoryBoundary(false)).thenReturn(List.of());
+
+        reconciler.run(mock(ApplicationArguments.class));
+
+        verify(webhookRepository).reconcileTenantCategoryBoundary(false);
+    }
+
+    @Test
+    void run_dryRunFlag_passesDryRunTrue() {
+        ReflectionTestUtils.setField(reconciler, "reconcileOnStartup", true);
+        ReflectionTestUtils.setField(reconciler, "dryRun", true);
+        when(webhookRepository.reconcileTenantCategoryBoundary(true)).thenReturn(List.of());
+
+        reconciler.run(mock(ApplicationArguments.class));
+
+        verify(webhookRepository).reconcileTenantCategoryBoundary(true);
+    }
+
+    @Test
+    void run_flagDisabled_skipsReconcile() {
+        ReflectionTestUtils.setField(reconciler, "reconcileOnStartup", false);
+
+        reconciler.run(mock(ApplicationArguments.class));
+
+        verifyNoInteractions(webhookRepository);
+    }
+
+    @Test
+    void reconcile_returnsOutcomes_andLogsSummary() {
+        ReflectionTestUtils.setField(reconciler, "dryRun", false);
+        when(webhookRepository.reconcileTenantCategoryBoundary(false)).thenReturn(List.of(
+                new CategoryBoundaryRepairOutcome("wh1", "t1", CategoryBoundaryAction.DISABLED_ADMIN_CATEGORIES, List.of("api_key")),
+                new CategoryBoundaryRepairOutcome("wh2", "t2", CategoryBoundaryAction.DISABLED_ADMIN_CATEGORIES, List.of("policy")),
+                new CategoryBoundaryRepairOutcome("wh3", "t3", CategoryBoundaryAction.DISABLED_EMPTY_BOTH, List.of())));
+
+        List<CategoryBoundaryRepairOutcome> outcomes = reconciler.reconcile();
+
+        assertThat(outcomes).hasSize(3);
+    }
+
+    @Test
+    void reconcile_noOutcomes_returnsEmpty() {
+        ReflectionTestUtils.setField(reconciler, "dryRun", false);
+        when(webhookRepository.reconcileTenantCategoryBoundary(false)).thenReturn(List.of());
+
+        assertThat(reconciler.reconcile()).isEmpty();
+    }
+
+    @Test
+    void reconcile_repositoryThrows_swallowedReturnsEmpty() {
+        // A cleanup failure must never block startup.
+        ReflectionTestUtils.setField(reconciler, "dryRun", false);
+        when(webhookRepository.reconcileTenantCategoryBoundary(false))
+                .thenThrow(new RuntimeException("redis down"));
+
+        assertThat(reconciler.reconcile()).isEmpty();
+    }
+}

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookCategoryBoundaryReconcilerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookCategoryBoundaryReconcilerTest.java
@@ -3,6 +3,7 @@ package io.runcycles.admin.api.service;
 import io.runcycles.admin.data.repository.WebhookRepository;
 import io.runcycles.admin.data.repository.WebhookRepository.CategoryBoundaryAction;
 import io.runcycles.admin.data.repository.WebhookRepository.CategoryBoundaryRepairOutcome;
+import io.runcycles.admin.data.repository.WebhookRepository.ReconcileResult;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -22,65 +23,100 @@ class WebhookCategoryBoundaryReconcilerTest {
     @Mock private WebhookRepository webhookRepository;
     @InjectMocks private WebhookCategoryBoundaryReconciler reconciler;
 
-    @Test
-    void run_flagEnabled_invokesReconcile_notDryRunByDefault() {
-        ReflectionTestUtils.setField(reconciler, "reconcileOnStartup", true);
-        ReflectionTestUtils.setField(reconciler, "dryRun", false);
-        when(webhookRepository.reconcileTenantCategoryBoundary(false)).thenReturn(List.of());
-
-        reconciler.run(mock(ApplicationArguments.class));
-
-        verify(webhookRepository).reconcileTenantCategoryBoundary(false);
+    private ReconcileResult complete(CategoryBoundaryRepairOutcome... outcomes) {
+        return new ReconcileResult(List.of(outcomes), 0);
     }
 
-    @Test
-    void run_dryRunFlag_passesDryRunTrue() {
-        ReflectionTestUtils.setField(reconciler, "reconcileOnStartup", true);
-        ReflectionTestUtils.setField(reconciler, "dryRun", true);
-        when(webhookRepository.reconcileTenantCategoryBoundary(true)).thenReturn(List.of());
-
-        reconciler.run(mock(ApplicationArguments.class));
-
-        verify(webhookRepository).reconcileTenantCategoryBoundary(true);
+    private void tune(boolean dryRun, int maxAttempts) {
+        ReflectionTestUtils.setField(reconciler, "dryRun", dryRun);
+        ReflectionTestUtils.setField(reconciler, "maxAttempts", maxAttempts);
+        ReflectionTestUtils.setField(reconciler, "initialBackoffMs", 0L); // no sleep in tests
     }
 
     @Test
     void run_flagDisabled_skipsReconcile() {
         ReflectionTestUtils.setField(reconciler, "reconcileOnStartup", false);
-
         reconciler.run(mock(ApplicationArguments.class));
-
         verifyNoInteractions(webhookRepository);
     }
 
     @Test
+    void run_flagEnabled_startsBackgroundReconcile() {
+        ReflectionTestUtils.setField(reconciler, "reconcileOnStartup", true);
+        tune(false, 1);
+        when(webhookRepository.reconcileTenantCategoryBoundary(false)).thenReturn(complete());
+
+        reconciler.run(mock(ApplicationArguments.class));
+
+        // Runs on a daemon thread; give it a moment to invoke the repo.
+        verify(webhookRepository, timeout(2000)).reconcileTenantCategoryBoundary(false);
+    }
+
+    @Test
+    void reconcile_passesDryRunFlag() {
+        tune(true, 1);
+        when(webhookRepository.reconcileTenantCategoryBoundary(true)).thenReturn(complete());
+
+        reconciler.reconcile();
+
+        verify(webhookRepository).reconcileTenantCategoryBoundary(true);
+    }
+
+    @Test
     void reconcile_returnsOutcomes_andLogsSummary() {
-        ReflectionTestUtils.setField(reconciler, "dryRun", false);
-        when(webhookRepository.reconcileTenantCategoryBoundary(false)).thenReturn(List.of(
-                new CategoryBoundaryRepairOutcome("wh1", "t1", CategoryBoundaryAction.DISABLED_ADMIN_CATEGORIES, List.of("api_key")),
-                new CategoryBoundaryRepairOutcome("wh2", "t2", CategoryBoundaryAction.DISABLED_ADMIN_CATEGORIES, List.of("policy")),
-                new CategoryBoundaryRepairOutcome("wh3", "t3", CategoryBoundaryAction.DISABLED_EMPTY_BOTH, List.of())));
+        tune(false, 1);
+        when(webhookRepository.reconcileTenantCategoryBoundary(false)).thenReturn(complete(
+                new CategoryBoundaryRepairOutcome("wh1", "t1", CategoryBoundaryAction.DISABLED_ADMIN_SELECTORS, List.of("api_key")),
+                new CategoryBoundaryRepairOutcome("wh2", "t2", CategoryBoundaryAction.DISABLED_EMPTY_BOTH, List.of())));
 
-        List<CategoryBoundaryRepairOutcome> outcomes = reconciler.reconcile();
+        ReconcileResult r = reconciler.reconcile();
 
-        assertThat(outcomes).hasSize(3);
+        assertThat(r.repaired()).hasSize(2);
+        assertThat(r.isComplete()).isTrue();
     }
 
     @Test
-    void reconcile_noOutcomes_returnsEmpty() {
-        ReflectionTestUtils.setField(reconciler, "dryRun", false);
-        when(webhookRepository.reconcileTenantCategoryBoundary(false)).thenReturn(List.of());
+    void reconcile_noOutcomes_returnsComplete() {
+        tune(false, 1);
+        when(webhookRepository.reconcileTenantCategoryBoundary(false)).thenReturn(complete());
 
-        assertThat(reconciler.reconcile()).isEmpty();
+        assertThat(reconciler.reconcile().repaired()).isEmpty();
     }
 
     @Test
-    void reconcile_repositoryThrows_swallowedReturnsEmpty() {
-        // A cleanup failure must never block startup.
-        ReflectionTestUtils.setField(reconciler, "dryRun", false);
+    void reconcile_repositoryThrows_swallowed_returnsIncomplete() {
+        tune(false, 1);
         when(webhookRepository.reconcileTenantCategoryBoundary(false))
                 .thenThrow(new RuntimeException("redis down"));
 
-        assertThat(reconciler.reconcile()).isEmpty();
+        ReconcileResult r = reconciler.reconcile();
+
+        assertThat(r.repaired()).isEmpty();
+        assertThat(r.isComplete()).isFalse(); // failure recorded → caller retries
+    }
+
+    @Test
+    void reconcileWithRetry_retriesUntilComplete() {
+        tune(false, 3);
+        when(webhookRepository.reconcileTenantCategoryBoundary(false))
+                .thenReturn(new ReconcileResult(List.of(), 1))   // incomplete
+                .thenReturn(new ReconcileResult(List.of(), 1))   // incomplete
+                .thenReturn(complete());                          // done
+
+        reconciler.reconcileWithRetry();
+
+        verify(webhookRepository, times(3)).reconcileTenantCategoryBoundary(false);
+    }
+
+    @Test
+    void reconcileWithRetry_givesUpAfterMaxAttempts_alerts() {
+        tune(false, 2);
+        when(webhookRepository.reconcileTenantCategoryBoundary(false))
+                .thenReturn(new ReconcileResult(List.of(), 1)); // always incomplete
+
+        reconciler.reconcileWithRetry();
+
+        // Exactly maxAttempts calls, then gives up (logs ERROR alert) — never throws.
+        verify(webhookRepository, times(2)).reconcileTenantCategoryBoundary(false);
     }
 }

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookCategoryBoundaryReconcilerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookCategoryBoundaryReconcilerTest.java
@@ -11,6 +11,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.test.util.ReflectionTestUtils;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 
 import java.util.List;
 
@@ -66,7 +69,7 @@ class WebhookCategoryBoundaryReconcilerTest {
     void reconcile_returnsOutcomes_andLogsSummary() {
         tune(false, 1);
         when(webhookRepository.reconcileTenantCategoryBoundary(false)).thenReturn(complete(
-                new CategoryBoundaryRepairOutcome("wh1", "t1", CategoryBoundaryAction.DISABLED_ADMIN_SELECTORS, List.of("api_key")),
+                new CategoryBoundaryRepairOutcome("wh1", "t1", CategoryBoundaryAction.STRIPPED_ADMIN_SELECTORS, List.of("api_key")),
                 new CategoryBoundaryRepairOutcome("wh2", "t2", CategoryBoundaryAction.DISABLED_EMPTY_BOTH, List.of())));
 
         ReconcileResult r = reconciler.reconcile();
@@ -118,5 +121,50 @@ class WebhookCategoryBoundaryReconcilerTest {
 
         // Exactly maxAttempts calls, then gives up (logs ERROR alert) — never throws.
         verify(webhookRepository, times(2)).reconcileTenantCategoryBoundary(false);
+    }
+
+    @Test
+    void reconcileWithRetry_exhaustedRetries_logsErrorAlert_neverThrows() {
+        // Capture the reconciler's ERROR log to assert the alert fires on giving up.
+        ch.qos.logback.classic.Logger logger =
+            (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(WebhookCategoryBoundaryReconciler.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            tune(false, 2);
+            when(webhookRepository.reconcileTenantCategoryBoundary(false))
+                    .thenReturn(new ReconcileResult(List.of(), 1));
+
+            reconciler.reconcileWithRetry(); // must not throw
+
+            assertThat(appender.list).anySatisfy(e -> {
+                assertThat(e.getLevel()).isEqualTo(Level.ERROR);
+                assertThat(e.getFormattedMessage()).contains("did NOT complete");
+            });
+        } finally {
+            logger.detachAppender(appender);
+        }
+    }
+
+    @Test
+    void run_thenShutdown_interruptsBackoff_stopsCleanly() {
+        ReflectionTestUtils.setField(reconciler, "reconcileOnStartup", true);
+        ReflectionTestUtils.setField(reconciler, "dryRun", false);
+        ReflectionTestUtils.setField(reconciler, "maxAttempts", 5);
+        // Long backoff so the daemon is asleep between retries when we shut down.
+        ReflectionTestUtils.setField(reconciler, "initialBackoffMs", 60_000L);
+        when(webhookRepository.reconcileTenantCategoryBoundary(false))
+                .thenReturn(new ReconcileResult(List.of(), 1)); // always incomplete → will sleep
+
+        reconciler.run(mock(ApplicationArguments.class));
+        // Wait until the first pass has run (daemon is now sleeping the 60s backoff).
+        verify(webhookRepository, timeout(2000).atLeastOnce()).reconcileTenantCategoryBoundary(false);
+
+        // shutdownNow interrupts the backoff and awaitTermination returns promptly.
+        long start = System.currentTimeMillis();
+        ReflectionTestUtils.invokeMethod(reconciler, "shutdown");
+        long elapsed = System.currentTimeMillis() - start;
+        assertThat(elapsed).isLessThan(5_000L); // did NOT wait out the 60s backoff
     }
 }

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookCategoryBoundaryValidatorTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookCategoryBoundaryValidatorTest.java
@@ -19,15 +19,26 @@ class WebhookCategoryBoundaryValidatorTest {
     // ---- isSystemTarget ----
 
     @Test
-    void isSystemTarget_trueForSentinelNullBlank() {
+    void isSystemTarget_trueForSentinelAndNull() {
         assertThat(validator.isSystemTarget("__system__")).isTrue();
         assertThat(validator.isSystemTarget(null)).isTrue();
-        assertThat(validator.isSystemTarget("  ")).isTrue();
     }
 
     @Test
-    void isSystemTarget_falseForConcreteTenant() {
+    void isSystemTarget_falseForConcreteTenant_andBlank() {
+        // #209 finding 5: a blank (whitespace-only) tenant_id is NOT
+        // system-exempt — it is treated as concrete and validated.
         assertThat(validator.isSystemTarget("tenant-1")).isFalse();
+        assertThat(validator.isSystemTarget("   ")).isFalse();
+        assertThat(validator.isSystemTarget("")).isFalse();
+    }
+
+    @Test
+    void validateForTarget_blankTenant_adminCategory_throws400() {
+        assertThatThrownBy(() -> validator.validateForTarget("   ",
+            List.of(EventType.BUDGET_CREATED), List.of(EventCategory.API_KEY)))
+            .isInstanceOf(GovernanceException.class)
+            .hasFieldOrPropertyWithValue("httpStatus", 400);
     }
 
     // ---- validateEventTypes ----

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookCategoryBoundaryValidatorTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookCategoryBoundaryValidatorTest.java
@@ -1,0 +1,109 @@
+package io.runcycles.admin.api.service;
+
+import io.runcycles.admin.data.exception.GovernanceException;
+import io.runcycles.admin.model.event.EventCategory;
+import io.runcycles.admin.model.event.EventType;
+import io.runcycles.admin.model.shared.ErrorCode;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class WebhookCategoryBoundaryValidatorTest {
+
+    private final WebhookCategoryBoundaryValidator validator = new WebhookCategoryBoundaryValidator();
+
+    // ---- isSystemTarget ----
+
+    @Test
+    void isSystemTarget_trueForSentinelNullBlank() {
+        assertThat(validator.isSystemTarget("__system__")).isTrue();
+        assertThat(validator.isSystemTarget(null)).isTrue();
+        assertThat(validator.isSystemTarget("  ")).isTrue();
+    }
+
+    @Test
+    void isSystemTarget_falseForConcreteTenant() {
+        assertThat(validator.isSystemTarget("tenant-1")).isFalse();
+    }
+
+    // ---- validateEventTypes ----
+
+    @Test
+    void validateEventTypes_adminOnly_throws400() {
+        assertThatThrownBy(() -> validator.validateEventTypes(List.of(EventType.API_KEY_CREATED)))
+            .isInstanceOf(GovernanceException.class)
+            .hasFieldOrPropertyWithValue("httpStatus", 400)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_REQUEST)
+            .hasMessageContaining("admin-only");
+    }
+
+    @Test
+    void validateEventTypes_tenantAccessible_ok_andNullNoop() {
+        assertThatCode(() -> validator.validateEventTypes(
+            List.of(EventType.BUDGET_CREATED, EventType.RESERVATION_DENIED, EventType.TENANT_CREATED)))
+            .doesNotThrowAnyException();
+        assertThatCode(() -> validator.validateEventTypes(null)).doesNotThrowAnyException();
+    }
+
+    // ---- validateEventCategories ----
+
+    @Test
+    void validateEventCategories_adminOnly_throws400() {
+        for (EventCategory admin : List.of(EventCategory.API_KEY, EventCategory.POLICY,
+                EventCategory.WEBHOOK, EventCategory.SYSTEM)) {
+            assertThatThrownBy(() -> validator.validateEventCategories(List.of(admin)))
+                .as(admin.name())
+                .isInstanceOf(GovernanceException.class)
+                .hasFieldOrPropertyWithValue("httpStatus", 400)
+                .hasMessageContaining("admin-only");
+        }
+    }
+
+    @Test
+    void validateEventCategories_tenantAccessible_ok_andNullNoop() {
+        assertThatCode(() -> validator.validateEventCategories(
+            List.of(EventCategory.BUDGET, EventCategory.RESERVATION, EventCategory.TENANT)))
+            .doesNotThrowAnyException();
+        assertThatCode(() -> validator.validateEventCategories(null)).doesNotThrowAnyException();
+    }
+
+    // ---- validateForTarget: the admin-plane gate ----
+
+    @Test
+    void validateForTarget_systemTarget_skipsValidation() {
+        // Admin-only on __system__ is allowed (not tenant-owned).
+        assertThatCode(() -> validator.validateForTarget("__system__",
+            List.of(EventType.API_KEY_CREATED), List.of(EventCategory.SYSTEM)))
+            .doesNotThrowAnyException();
+        assertThatCode(() -> validator.validateForTarget(null,
+            null, List.of(EventCategory.WEBHOOK)))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void validateForTarget_concreteTenant_adminCategory_throws400() {
+        assertThatThrownBy(() -> validator.validateForTarget("tenant-1",
+            List.of(EventType.BUDGET_CREATED), List.of(EventCategory.API_KEY)))
+            .isInstanceOf(GovernanceException.class)
+            .hasFieldOrPropertyWithValue("httpStatus", 400);
+    }
+
+    @Test
+    void validateForTarget_concreteTenant_adminEventType_throws400() {
+        assertThatThrownBy(() -> validator.validateForTarget("tenant-1",
+            List.of(EventType.POLICY_CREATED), null))
+            .isInstanceOf(GovernanceException.class)
+            .hasFieldOrPropertyWithValue("httpStatus", 400);
+    }
+
+    @Test
+    void validateForTarget_concreteTenant_tenantAccessible_ok() {
+        assertThatCode(() -> validator.validateForTarget("tenant-1",
+            List.of(EventType.BUDGET_CREATED), List.of(EventCategory.RESERVATION)))
+            .doesNotThrowAnyException();
+    }
+}

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookDispatchServiceTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookDispatchServiceTest.java
@@ -238,8 +238,13 @@ class WebhookDispatchServiceTest {
 
     @Test
     void dispatchToSubscription_disabledConcurrently_reReadsStatus_skips() {
-        // Stale snapshot is ACTIVE, but the row is now DISABLED (concurrent disable).
-        WebhookSubscription staleActive = buildSubscription("whsub_1"); // ACTIVE, tenant-accessible event
+        // The INPUT snapshot is ACTIVE; the fresh re-read at dispatch time returns
+        // the now-DISABLED row (a concurrent disable). This exercises the re-read
+        // gate meaningfully — the decision comes from the re-read, not the stale
+        // snapshot. (The durable close under true interleaving lives in the
+        // cycles-server-events delivery worker's own status re-check.)
+        WebhookSubscription staleActive = buildSubscription("whsub_1"); // ACTIVE snapshot
+        assertThat(staleActive.getStatus()).isEqualTo(WebhookStatus.ACTIVE);
         WebhookSubscription nowDisabled = buildSubscription("whsub_1");
         nowDisabled.setStatus(WebhookStatus.DISABLED);
         when(webhookRepository.findById("whsub_1")).thenReturn(nowDisabled);
@@ -247,6 +252,7 @@ class WebhookDispatchServiceTest {
         boolean queued = webhookDispatchService.dispatchToSubscription(buildEvent(), staleActive);
 
         assertThat(queued).isFalse();
+        verify(webhookRepository).findById("whsub_1"); // the re-read actually happened
         verify(deliveryRepository, never()).save(any());
     }
 
@@ -275,6 +281,65 @@ class WebhookDispatchServiceTest {
 
         assertThat(queued).isTrue();
         verify(deliveryRepository).save(any());
+    }
+
+    // #209 finding 1: the boundary checks the (independent) CATEGORY too, and
+    // fail-closes an unclassifiable record — not only the event TYPE.
+    @Test
+    void dispatchToSubscription_concreteTenant_tenantTypeButAdminCategory_blocked() {
+        WebhookSubscription concrete = sub("whsub_c", "tenant-1", WebhookStatus.ACTIVE);
+        // Inconsistent record: tenant-accessible TYPE, admin-only CATEGORY.
+        Event inconsistent = Event.builder().eventId("evt_incon")
+            .eventType(EventType.BUDGET_CREATED).category(EventCategory.API_KEY)
+            .tenantId("tenant-1").timestamp(Instant.now()).build();
+
+        boolean queued = webhookDispatchService.dispatchToSubscription(inconsistent, concrete);
+
+        assertThat(queued).isFalse();
+        verify(deliveryRepository, never()).save(any());
+        verify(webhookRepository, never()).findById(anyString()); // short-circuits
+    }
+
+    @Test
+    void dispatchToSubscription_concreteTenant_unclassifiableEvent_blocked() {
+        WebhookSubscription concrete = sub("whsub_c", "tenant-1", WebhookStatus.ACTIVE);
+        Event unclassifiable = Event.builder().eventId("evt_null")
+            .eventType(null).category(null)
+            .tenantId("tenant-1").timestamp(Instant.now()).build();
+
+        boolean queued = webhookDispatchService.dispatchToSubscription(unclassifiable, concrete);
+
+        assertThat(queued).isFalse();
+        verify(deliveryRepository, never()).save(any());
+    }
+
+    @Test
+    void dispatchToSubscription_systemSub_inconsistentEvent_stillDelivered() {
+        WebhookSubscription system = sub("whsub_s", "__system__", WebhookStatus.ACTIVE);
+        when(webhookRepository.findById("whsub_s")).thenReturn(system);
+        Event inconsistent = Event.builder().eventId("evt_incon")
+            .eventType(EventType.BUDGET_CREATED).category(EventCategory.API_KEY)
+            .tenantId("tenant-1").timestamp(Instant.now()).build();
+
+        boolean queued = webhookDispatchService.dispatchToSubscription(inconsistent, system);
+
+        assertThat(queued).isTrue(); // system-owned: boundary does not apply
+        verify(deliveryRepository).save(any());
+    }
+
+    // #209 finding 4: an honest boolean — a saved-but-not-enqueued delivery
+    // (LPUSH failed) returns false so replay's eventsQueued does not over-report.
+    @Test
+    void dispatchToSubscription_enqueueFails_returnsFalse_evenThoughSaved() {
+        WebhookSubscription sub = buildSubscription("whsub_1"); // ACTIVE, tenant-accessible event
+        when(webhookRepository.findById("whsub_1")).thenReturn(sub);
+        when(jedis.lpush(eq("dispatch:pending"), anyString()))
+            .thenThrow(new RuntimeException("redis down"));
+
+        boolean queued = webhookDispatchService.dispatchToSubscription(buildEvent(), sub);
+
+        assertThat(queued).isFalse();       // not enqueued → honest false
+        verify(deliveryRepository).save(any()); // row still persisted
     }
 
     @Test

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookDispatchServiceTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookDispatchServiceTest.java
@@ -257,7 +257,9 @@ class WebhookDispatchServiceTest {
     }
 
     @Test
-    void dispatchToSubscription_subscriptionDeletedMidReplay_skips() {
+    void dispatchToSubscription_subscriptionDeletedMidReplay_inactive() {
+        // Genuinely deleted → findById throws WEBHOOK_NOT_FOUND → INACTIVE
+        // (intended lifecycle change).
         WebhookSubscription stale = buildSubscription("whsub_gone");
         when(webhookRepository.findById("whsub_gone"))
             .thenThrow(io.runcycles.admin.data.exception.GovernanceException.webhookNotFound("whsub_gone"));
@@ -265,6 +267,37 @@ class WebhookDispatchServiceTest {
         WebhookDispatchService.DispatchOutcome outcome = webhookDispatchService.dispatchToSubscription(buildEvent(), stale);
 
         assertThat(outcome).isEqualTo(WebhookDispatchService.DispatchOutcome.INACTIVE);
+        verify(deliveryRepository, never()).save(any());
+    }
+
+    @Test
+    void dispatchToSubscription_reReadBackendError_enqueueFailed_notInactive() {
+        // #209 P2: a Redis/deserialization failure during the dispatch-time
+        // re-read is a real backend DEGRADATION — it must classify as
+        // ENQUEUE_FAILED (→ degraded WARN), NOT be hidden as INACTIVE.
+        WebhookSubscription stale = buildSubscription("whsub_1");
+        when(webhookRepository.findById("whsub_1"))
+            .thenThrow(new RuntimeException("Failed to find webhook subscription",
+                new redis.clients.jedis.exceptions.JedisConnectionException("redis down")));
+
+        WebhookDispatchService.DispatchOutcome outcome = webhookDispatchService.dispatchToSubscription(buildEvent(), stale);
+
+        assertThat(outcome).isEqualTo(WebhookDispatchService.DispatchOutcome.ENQUEUE_FAILED);
+        verify(deliveryRepository, never()).save(any());
+    }
+
+    @Test
+    void dispatchToSubscription_reReadNonNotFoundGovernanceError_enqueueFailed() {
+        // A governance exception that is NOT WEBHOOK_NOT_FOUND is unexpected →
+        // treated as degradation, not a benign lifecycle change.
+        WebhookSubscription stale = buildSubscription("whsub_1");
+        when(webhookRepository.findById("whsub_1"))
+            .thenThrow(new io.runcycles.admin.data.exception.GovernanceException(
+                io.runcycles.admin.model.shared.ErrorCode.INTERNAL_ERROR, "boom", 500));
+
+        WebhookDispatchService.DispatchOutcome outcome = webhookDispatchService.dispatchToSubscription(buildEvent(), stale);
+
+        assertThat(outcome).isEqualTo(WebhookDispatchService.DispatchOutcome.ENQUEUE_FAILED);
         verify(deliveryRepository, never()).save(any());
     }
 

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookDispatchServiceTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookDispatchServiceTest.java
@@ -6,6 +6,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.runcycles.admin.data.repository.WebhookDeliveryRepository;
 import io.runcycles.admin.data.repository.WebhookRepository;
 import io.runcycles.admin.model.event.Event;
+import io.runcycles.admin.model.event.EventCategory;
 import io.runcycles.admin.model.event.EventType;
 import io.runcycles.admin.model.webhook.DeliveryStatus;
 import io.runcycles.admin.model.webhook.WebhookStatus;
@@ -41,7 +42,7 @@ class WebhookDispatchServiceTest {
     void setUp() {
         lenient().when(jedisPool.getResource()).thenReturn(jedis);
         meterRegistry = new SimpleMeterRegistry();
-        webhookDispatchService = new WebhookDispatchService(webhookRepository, deliveryRepository, objectMapper, jedisPool, meterRegistry);
+        webhookDispatchService = new WebhookDispatchService(webhookRepository, deliveryRepository, objectMapper, jedisPool, meterRegistry, new WebhookCategoryBoundaryValidator());
     }
 
     private Event buildEvent() {
@@ -158,14 +159,122 @@ class WebhookDispatchServiceTest {
     void dispatchToSubscription_createsDeliveryAndEnqueues() {
         Event event = buildEvent();
         WebhookSubscription sub = buildSubscription("whsub_1");
+        when(webhookRepository.findById("whsub_1")).thenReturn(sub); // fresh status re-read (ACTIVE)
 
-        webhookDispatchService.dispatchToSubscription(event, sub);
+        boolean queued = webhookDispatchService.dispatchToSubscription(event, sub);
 
+        assertThat(queued).isTrue();
         verify(deliveryRepository).save(argThat(d ->
             d.getSubscriptionId().equals("whsub_1") &&
             d.getEventId().equals("evt_1") &&
             d.getStatus() == DeliveryStatus.PENDING));
         verify(jedis).lpush(eq("dispatch:pending"), anyString());
+    }
+
+    // ---- #209 fail-closed ownership boundary (live dispatch + replay) ----
+
+    private Event adminEvent() {
+        return Event.builder().eventId("evt_admin").eventType(EventType.API_KEY_CREATED)
+            .tenantId("tenant-1").scope(null).timestamp(Instant.now()).build();
+    }
+
+    private WebhookSubscription sub(String id, String tenantId, WebhookStatus status) {
+        return WebhookSubscription.builder().subscriptionId(id).tenantId(tenantId)
+            .url("https://example.com/wh").eventTypes(List.of(EventType.BUDGET_CREATED))
+            .eventCategories(List.of(EventCategory.API_KEY)) // offender-style: subscribes to admin cat
+            .status(status).createdAt(Instant.now()).build();
+    }
+
+    @Test
+    void dispatch_liveConcreteTenantSub_doesNotReceiveAdminEvent_butDoesReceiveTenantEvent() {
+        WebhookSubscription concrete = sub("whsub_c", "tenant-1", WebhookStatus.ACTIVE);
+        // Admin event to a concrete-tenant sub → boundary-blocked (no delivery).
+        when(webhookRepository.findMatchingSubscriptions("tenant-1", EventType.API_KEY_CREATED, null))
+            .thenReturn(List.of(concrete));
+        webhookDispatchService.dispatch(adminEvent());
+        verify(deliveryRepository, never()).save(any());
+
+        // Tenant-accessible event to the same sub → delivered.
+        reset(deliveryRepository);
+        Event budget = buildEvent(); // BUDGET_CREATED, scope org/team1
+        when(webhookRepository.findMatchingSubscriptions("tenant-1", EventType.BUDGET_CREATED, "org/team1"))
+            .thenReturn(List.of(concrete));
+        webhookDispatchService.dispatch(budget);
+        verify(deliveryRepository).save(any());
+    }
+
+    @Test
+    void dispatch_liveSystemSub_doesReceiveAdminEvent() {
+        WebhookSubscription system = sub("whsub_s", "__system__", WebhookStatus.ACTIVE);
+        when(webhookRepository.findMatchingSubscriptions(any(), eq(EventType.API_KEY_CREATED), any()))
+            .thenReturn(List.of(system));
+
+        webhookDispatchService.dispatch(adminEvent());
+
+        verify(deliveryRepository).save(any()); // system subs CAN receive admin events
+    }
+
+    @Test
+    void dispatchToSubscription_concreteTenant_adminEvent_blocked_returnsFalse() {
+        WebhookSubscription concrete = sub("whsub_c", "tenant-1", WebhookStatus.ACTIVE);
+
+        boolean queued = webhookDispatchService.dispatchToSubscription(adminEvent(), concrete);
+
+        assertThat(queued).isFalse();
+        verify(deliveryRepository, never()).save(any());
+        verify(webhookRepository, never()).findById(anyString()); // short-circuits before status re-read
+    }
+
+    @Test
+    void dispatchToSubscription_systemSub_adminEvent_delivered() {
+        WebhookSubscription system = sub("whsub_s", "__system__", WebhookStatus.ACTIVE);
+        when(webhookRepository.findById("whsub_s")).thenReturn(system);
+
+        boolean queued = webhookDispatchService.dispatchToSubscription(adminEvent(), system);
+
+        assertThat(queued).isTrue();
+        verify(deliveryRepository).save(any());
+    }
+
+    @Test
+    void dispatchToSubscription_disabledConcurrently_reReadsStatus_skips() {
+        // Stale snapshot is ACTIVE, but the row is now DISABLED (concurrent disable).
+        WebhookSubscription staleActive = buildSubscription("whsub_1"); // ACTIVE, tenant-accessible event
+        WebhookSubscription nowDisabled = buildSubscription("whsub_1");
+        nowDisabled.setStatus(WebhookStatus.DISABLED);
+        when(webhookRepository.findById("whsub_1")).thenReturn(nowDisabled);
+
+        boolean queued = webhookDispatchService.dispatchToSubscription(buildEvent(), staleActive);
+
+        assertThat(queued).isFalse();
+        verify(deliveryRepository, never()).save(any());
+    }
+
+    @Test
+    void dispatchToSubscription_subscriptionDeletedMidReplay_skips() {
+        WebhookSubscription stale = buildSubscription("whsub_gone");
+        when(webhookRepository.findById("whsub_gone"))
+            .thenThrow(io.runcycles.admin.data.exception.GovernanceException.webhookNotFound("whsub_gone"));
+
+        boolean queued = webhookDispatchService.dispatchToSubscription(buildEvent(), stale);
+
+        assertThat(queued).isFalse();
+        verify(deliveryRepository, never()).save(any());
+    }
+
+    @Test
+    void dispatchToSubscription_nullOwner_treatedAsSystem_adminEvent_delivered() {
+        // Null-owner classifies as system (null-safe) → admin event allowed; no NPE.
+        WebhookSubscription nullOwner = WebhookSubscription.builder()
+            .subscriptionId("whsub_null").tenantId(null).url("https://example.com/wh")
+            .eventTypes(List.of(EventType.API_KEY_CREATED)).status(WebhookStatus.ACTIVE)
+            .createdAt(Instant.now()).build();
+        when(webhookRepository.findById("whsub_null")).thenReturn(nullOwner);
+
+        boolean queued = webhookDispatchService.dispatchToSubscription(adminEvent(), nullOwner);
+
+        assertThat(queued).isTrue();
+        verify(deliveryRepository).save(any());
     }
 
     @Test

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookDispatchServiceTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookDispatchServiceTest.java
@@ -161,9 +161,9 @@ class WebhookDispatchServiceTest {
         WebhookSubscription sub = buildSubscription("whsub_1");
         when(webhookRepository.findById("whsub_1")).thenReturn(sub); // fresh status re-read (ACTIVE)
 
-        boolean queued = webhookDispatchService.dispatchToSubscription(event, sub);
+        WebhookDispatchService.DispatchOutcome outcome = webhookDispatchService.dispatchToSubscription(event, sub);
 
-        assertThat(queued).isTrue();
+        assertThat(outcome).isEqualTo(WebhookDispatchService.DispatchOutcome.ENQUEUED);
         verify(deliveryRepository).save(argThat(d ->
             d.getSubscriptionId().equals("whsub_1") &&
             d.getEventId().equals("evt_1") &&
@@ -218,9 +218,9 @@ class WebhookDispatchServiceTest {
     void dispatchToSubscription_concreteTenant_adminEvent_blocked_returnsFalse() {
         WebhookSubscription concrete = sub("whsub_c", "tenant-1", WebhookStatus.ACTIVE);
 
-        boolean queued = webhookDispatchService.dispatchToSubscription(adminEvent(), concrete);
+        WebhookDispatchService.DispatchOutcome outcome = webhookDispatchService.dispatchToSubscription(adminEvent(), concrete);
 
-        assertThat(queued).isFalse();
+        assertThat(outcome).isEqualTo(WebhookDispatchService.DispatchOutcome.BLOCKED);
         verify(deliveryRepository, never()).save(any());
         verify(webhookRepository, never()).findById(anyString()); // short-circuits before status re-read
     }
@@ -230,9 +230,9 @@ class WebhookDispatchServiceTest {
         WebhookSubscription system = sub("whsub_s", "__system__", WebhookStatus.ACTIVE);
         when(webhookRepository.findById("whsub_s")).thenReturn(system);
 
-        boolean queued = webhookDispatchService.dispatchToSubscription(adminEvent(), system);
+        WebhookDispatchService.DispatchOutcome outcome = webhookDispatchService.dispatchToSubscription(adminEvent(), system);
 
-        assertThat(queued).isTrue();
+        assertThat(outcome).isEqualTo(WebhookDispatchService.DispatchOutcome.ENQUEUED);
         verify(deliveryRepository).save(any());
     }
 
@@ -249,9 +249,9 @@ class WebhookDispatchServiceTest {
         nowDisabled.setStatus(WebhookStatus.DISABLED);
         when(webhookRepository.findById("whsub_1")).thenReturn(nowDisabled);
 
-        boolean queued = webhookDispatchService.dispatchToSubscription(buildEvent(), staleActive);
+        WebhookDispatchService.DispatchOutcome outcome = webhookDispatchService.dispatchToSubscription(buildEvent(), staleActive);
 
-        assertThat(queued).isFalse();
+        assertThat(outcome).isEqualTo(WebhookDispatchService.DispatchOutcome.INACTIVE);
         verify(webhookRepository).findById("whsub_1"); // the re-read actually happened
         verify(deliveryRepository, never()).save(any());
     }
@@ -262,9 +262,9 @@ class WebhookDispatchServiceTest {
         when(webhookRepository.findById("whsub_gone"))
             .thenThrow(io.runcycles.admin.data.exception.GovernanceException.webhookNotFound("whsub_gone"));
 
-        boolean queued = webhookDispatchService.dispatchToSubscription(buildEvent(), stale);
+        WebhookDispatchService.DispatchOutcome outcome = webhookDispatchService.dispatchToSubscription(buildEvent(), stale);
 
-        assertThat(queued).isFalse();
+        assertThat(outcome).isEqualTo(WebhookDispatchService.DispatchOutcome.INACTIVE);
         verify(deliveryRepository, never()).save(any());
     }
 
@@ -277,9 +277,9 @@ class WebhookDispatchServiceTest {
             .createdAt(Instant.now()).build();
         when(webhookRepository.findById("whsub_null")).thenReturn(nullOwner);
 
-        boolean queued = webhookDispatchService.dispatchToSubscription(adminEvent(), nullOwner);
+        WebhookDispatchService.DispatchOutcome outcome = webhookDispatchService.dispatchToSubscription(adminEvent(), nullOwner);
 
-        assertThat(queued).isTrue();
+        assertThat(outcome).isEqualTo(WebhookDispatchService.DispatchOutcome.ENQUEUED);
         verify(deliveryRepository).save(any());
     }
 
@@ -293,9 +293,9 @@ class WebhookDispatchServiceTest {
             .eventType(EventType.BUDGET_CREATED).category(EventCategory.API_KEY)
             .tenantId("tenant-1").timestamp(Instant.now()).build();
 
-        boolean queued = webhookDispatchService.dispatchToSubscription(inconsistent, concrete);
+        WebhookDispatchService.DispatchOutcome outcome = webhookDispatchService.dispatchToSubscription(inconsistent, concrete);
 
-        assertThat(queued).isFalse();
+        assertThat(outcome).isEqualTo(WebhookDispatchService.DispatchOutcome.BLOCKED);
         verify(deliveryRepository, never()).save(any());
         verify(webhookRepository, never()).findById(anyString()); // short-circuits
     }
@@ -307,9 +307,9 @@ class WebhookDispatchServiceTest {
             .eventType(null).category(null)
             .tenantId("tenant-1").timestamp(Instant.now()).build();
 
-        boolean queued = webhookDispatchService.dispatchToSubscription(unclassifiable, concrete);
+        WebhookDispatchService.DispatchOutcome outcome = webhookDispatchService.dispatchToSubscription(unclassifiable, concrete);
 
-        assertThat(queued).isFalse();
+        assertThat(outcome).isEqualTo(WebhookDispatchService.DispatchOutcome.BLOCKED);
         verify(deliveryRepository, never()).save(any());
     }
 
@@ -321,9 +321,9 @@ class WebhookDispatchServiceTest {
             .eventType(EventType.BUDGET_CREATED).category(EventCategory.API_KEY)
             .tenantId("tenant-1").timestamp(Instant.now()).build();
 
-        boolean queued = webhookDispatchService.dispatchToSubscription(inconsistent, system);
+        WebhookDispatchService.DispatchOutcome outcome = webhookDispatchService.dispatchToSubscription(inconsistent, system);
 
-        assertThat(queued).isTrue(); // system-owned: boundary does not apply
+        assertThat(outcome).isEqualTo(WebhookDispatchService.DispatchOutcome.ENQUEUED); // system-owned: boundary does not apply
         verify(deliveryRepository).save(any());
     }
 
@@ -336,9 +336,9 @@ class WebhookDispatchServiceTest {
         when(jedis.lpush(eq("dispatch:pending"), anyString()))
             .thenThrow(new RuntimeException("redis down"));
 
-        boolean queued = webhookDispatchService.dispatchToSubscription(buildEvent(), sub);
+        WebhookDispatchService.DispatchOutcome outcome = webhookDispatchService.dispatchToSubscription(buildEvent(), sub);
 
-        assertThat(queued).isFalse();       // not enqueued → honest false
+        assertThat(outcome).isEqualTo(WebhookDispatchService.DispatchOutcome.ENQUEUE_FAILED);       // not enqueued → honest false
         verify(deliveryRepository).save(any()); // row still persisted
     }
 

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookServiceTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookServiceTest.java
@@ -418,6 +418,52 @@ class WebhookServiceTest {
         verify(dispatchService, never()).dispatchToSubscription(eq(tenantEvt), any());
     }
 
+    // #209 finding 1: replay MUST intersect with the SUBSCRIPTION's own
+    // event_types/event_categories (spec replayEvents: "all event types the
+    // subscription is subscribed to"), or a concrete-tenant budget-only
+    // subscription could replay historical ADMIN-only events to its endpoint.
+    @Test
+    void replay_doesNotDeliverEventsOutsideSubscriptionSelectors() {
+        WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1"); // subscribed to BUDGET_CREATED only
+        when(webhookRepository.findById("whsub_1")).thenReturn(sub);
+        when(webhookRepository.acquireReplayLock(eq("whsub_1"), any())).thenReturn(true);
+        io.runcycles.admin.model.event.Event budgetEvt = io.runcycles.admin.model.event.Event.builder()
+            .eventId("evt_ok").eventType(io.runcycles.admin.model.event.EventType.BUDGET_CREATED)
+            .category(io.runcycles.admin.model.event.EventCategory.BUDGET)
+            .tenantId("tenant-1").source("admin").timestamp(Instant.now()).build();
+        io.runcycles.admin.model.event.Event adminEvt = io.runcycles.admin.model.event.Event.builder()
+            .eventId("evt_admin").eventType(io.runcycles.admin.model.event.EventType.API_KEY_CREATED)
+            .category(io.runcycles.admin.model.event.EventCategory.API_KEY)
+            .tenantId("tenant-1").source("admin").timestamp(Instant.now()).build();
+        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt()))
+            .thenReturn(List.of(budgetEvt, adminEvt));
+
+        ReplayRequest request = ReplayRequest.builder()
+            .from(Instant.now().minusSeconds(3600)).to(Instant.now()).build();
+
+        ReplayResponse response = webhookService.replay("whsub_1", request);
+
+        assertThat(response.getEventsQueued()).isEqualTo(1);
+        verify(dispatchService).dispatchToSubscription(budgetEvt, sub);
+        // The admin-only event is NOT in the subscription's selectors → not delivered.
+        verify(dispatchService, never()).dispatchToSubscription(eq(adminEvt), any());
+    }
+
+    @Test
+    void replay_disabledSubscription_deliversNothing_noLock() {
+        WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1");
+        sub.setStatus(WebhookStatus.DISABLED);
+        when(webhookRepository.findById("whsub_1")).thenReturn(sub);
+
+        ReplayResponse response = webhookService.replay("whsub_1",
+            ReplayRequest.builder().from(Instant.now().minusSeconds(3600)).to(Instant.now()).build());
+
+        assertThat(response.getEventsQueued()).isEqualTo(0);
+        // Short-circuits before acquiring the lock or dispatching anything.
+        verify(webhookRepository, never()).acquireReplayLock(anyString(), any());
+        verify(dispatchService, never()).dispatchToSubscription(any(), any());
+    }
+
     @Test
     void replay_systemSubscription_queriesAllTenants() {
         WebhookSubscription sub = WebhookSubscription.builder()
@@ -654,6 +700,8 @@ class WebhookServiceTest {
     @Test
     void replay_dispatchFailure_continuesAndCounts() {
         WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1");
+        // Subscribe to both budget events so both pass the #209 selector filter.
+        sub.setEventTypes(List.of(EventType.BUDGET_CREATED, EventType.BUDGET_FUNDED));
         when(webhookRepository.findById("whsub_1")).thenReturn(sub);
         when(webhookRepository.acquireReplayLock(eq("whsub_1"), any())).thenReturn(true);
 

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookServiceTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookServiceTest.java
@@ -34,6 +34,15 @@ class WebhookServiceTest {
     @Mock private com.fasterxml.jackson.databind.ObjectMapper objectMapper;
     @InjectMocks private WebhookService webhookService;
 
+    @org.junit.jupiter.api.BeforeEach
+    void dispatchDeliversByDefault() {
+        // dispatchToSubscription now returns whether a delivery was enqueued;
+        // default to true so replay-counting tests behave as before (a guard
+        // that skips delivery is exercised explicitly where relevant).
+        org.mockito.Mockito.lenient()
+            .when(dispatchService.dispatchToSubscription(any(), any())).thenReturn(true);
+    }
+
     private WebhookCreateRequest createRequest() {
         return WebhookCreateRequest.builder()
             .name("Test Webhook")
@@ -716,7 +725,6 @@ class WebhookServiceTest {
             .thenReturn(List.of(evt1, evt2));
         doThrow(new RuntimeException("dispatch error")).when(dispatchService)
             .dispatchToSubscription(eq(evt1), any());
-        doNothing().when(dispatchService).dispatchToSubscription(eq(evt2), any());
 
         ReplayRequest request = ReplayRequest.builder()
             .from(Instant.now().minusSeconds(3600))

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookServiceTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -360,7 +361,7 @@ class WebhookServiceTest {
         WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1");
         when(webhookRepository.findById("whsub_1")).thenReturn(sub);
         when(webhookRepository.acquireReplayLock(eq("whsub_1"), any())).thenReturn(true);
-        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt()))
+        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
             .thenReturn(List.of());
 
         ReplayRequest request = ReplayRequest.builder()
@@ -383,7 +384,7 @@ class WebhookServiceTest {
             .eventId("evt_1").eventType(io.runcycles.admin.model.event.EventType.BUDGET_CREATED)
             .category(io.runcycles.admin.model.event.EventCategory.BUDGET)
             .tenantId("tenant-1").source("admin").timestamp(Instant.now()).build();
-        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt()))
+        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
             .thenReturn(List.of(event));
 
         ReplayRequest request = ReplayRequest.builder()
@@ -411,7 +412,7 @@ class WebhookServiceTest {
             .eventId("evt_2").eventType(io.runcycles.admin.model.event.EventType.TENANT_CREATED)
             .category(io.runcycles.admin.model.event.EventCategory.TENANT)
             .tenantId("tenant-1").source("admin").timestamp(Instant.now()).build();
-        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt()))
+        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
             .thenReturn(List.of(budgetEvt, tenantEvt));
 
         ReplayRequest request = ReplayRequest.builder()
@@ -444,7 +445,7 @@ class WebhookServiceTest {
             .eventId("evt_admin").eventType(io.runcycles.admin.model.event.EventType.API_KEY_CREATED)
             .category(io.runcycles.admin.model.event.EventCategory.API_KEY)
             .tenantId("tenant-1").source("admin").timestamp(Instant.now()).build();
-        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt()))
+        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
             .thenReturn(List.of(budgetEvt, adminEvt));
 
         ReplayRequest request = ReplayRequest.builder()
@@ -456,6 +457,122 @@ class WebhookServiceTest {
         verify(dispatchService).dispatchToSubscription(budgetEvt, sub);
         // The admin-only event is NOT in the subscription's selectors → not delivered.
         verify(dispatchService, never()).dispatchToSubscription(eq(adminEvt), any());
+    }
+
+    private io.runcycles.admin.model.event.Event evt(String id,
+            io.runcycles.admin.model.event.EventType type,
+            io.runcycles.admin.model.event.EventCategory cat) {
+        return io.runcycles.admin.model.event.Event.builder()
+            .eventId(id).eventType(type).category(cat)
+            .tenantId("tenant-1").source("admin").timestamp(Instant.now()).build();
+    }
+
+    // #209 P2: the repository query is PAGED and filtered DURING pagination, so
+    // a matching event that falls AFTER a full first page of non-matching events
+    // is still delivered (no "cap-then-filter" under-delivery).
+    @Test
+    void replay_pagesPastNonMatchingFirstBatch_stillQueuesLaterMatches() {
+        WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1"); // BUDGET_CREATED only
+        when(webhookRepository.findById("whsub_1")).thenReturn(sub);
+        when(webhookRepository.acquireReplayLock(eq("whsub_1"), any())).thenReturn(true);
+        // First page: 500 non-matching TENANT_CREATED events (a full page).
+        List<io.runcycles.admin.model.event.Event> firstPage = new ArrayList<>();
+        for (int i = 0; i < 500; i++) {
+            firstPage.add(evt("evt_non_" + i, io.runcycles.admin.model.event.EventType.TENANT_CREATED,
+                io.runcycles.admin.model.event.EventCategory.TENANT));
+        }
+        io.runcycles.admin.model.event.Event match =
+            evt("evt_match", io.runcycles.admin.model.event.EventType.BUDGET_CREATED,
+                io.runcycles.admin.model.event.EventCategory.BUDGET);
+        // cursor=null → first page; cursor=last-of-first-page → second page with the match.
+        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), isNull(), anyInt(), any()))
+            .thenReturn(firstPage);
+        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), eq("evt_non_499"), anyInt(), any()))
+            .thenReturn(List.of(match));
+
+        ReplayResponse response = webhookService.replay("whsub_1",
+            ReplayRequest.builder().from(Instant.now().minusSeconds(3600)).to(Instant.now()).build());
+
+        assertThat(response.getEventsQueued()).isEqualTo(1);
+        verify(dispatchService).dispatchToSubscription(match, sub);
+    }
+
+    // Cap counts MATCHING events; delivery preserves chronological order.
+    @Test
+    void replay_capsAtMaxEventsMatching_preservesChronologicalOrder() {
+        WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1");
+        when(webhookRepository.findById("whsub_1")).thenReturn(sub);
+        when(webhookRepository.acquireReplayLock(eq("whsub_1"), any())).thenReturn(true);
+        io.runcycles.admin.model.event.Event a = evt("evt_a", io.runcycles.admin.model.event.EventType.BUDGET_CREATED, io.runcycles.admin.model.event.EventCategory.BUDGET);
+        io.runcycles.admin.model.event.Event b = evt("evt_b", io.runcycles.admin.model.event.EventType.BUDGET_CREATED, io.runcycles.admin.model.event.EventCategory.BUDGET);
+        io.runcycles.admin.model.event.Event c = evt("evt_c", io.runcycles.admin.model.event.EventType.BUDGET_CREATED, io.runcycles.admin.model.event.EventCategory.BUDGET);
+        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
+            .thenReturn(List.of(a, b, c)); // chronological order
+
+        ReplayResponse response = webhookService.replay("whsub_1",
+            ReplayRequest.builder().from(Instant.now().minusSeconds(3600)).to(Instant.now())
+                .maxEvents(2).build());
+
+        assertThat(response.getEventsQueued()).isEqualTo(2);
+        org.mockito.InOrder inOrder = org.mockito.Mockito.inOrder(dispatchService);
+        inOrder.verify(dispatchService).dispatchToSubscription(a, sub);
+        inOrder.verify(dispatchService).dispatchToSubscription(b, sub);
+        verify(dispatchService, never()).dispatchToSubscription(eq(c), any());
+    }
+
+    // The fail-closed ownership boundary is applied DURING collection, so an
+    // admin event a concrete-tenant OFFENDER still matches by selector does not
+    // consume cap budget and is not delivered.
+    @Test
+    void replay_ownershipBoundaryExcludesAdminEventDuringCollection() {
+        WebhookSubscription offender = WebhookSubscription.builder()
+            .subscriptionId("whsub_1").tenantId("tenant-1")
+            .url("https://example.com/webhook")
+            .eventTypes(List.of(io.runcycles.admin.model.event.EventType.BUDGET_CREATED,
+                                io.runcycles.admin.model.event.EventType.API_KEY_CREATED))
+            .status(WebhookStatus.ACTIVE).consecutiveFailures(0).createdAt(Instant.now()).build();
+        when(webhookRepository.findById("whsub_1")).thenReturn(offender);
+        when(webhookRepository.acquireReplayLock(eq("whsub_1"), any())).thenReturn(true);
+        io.runcycles.admin.model.event.Event budgetEvt = evt("evt_ok", io.runcycles.admin.model.event.EventType.BUDGET_CREATED, io.runcycles.admin.model.event.EventCategory.BUDGET);
+        io.runcycles.admin.model.event.Event adminEvt = evt("evt_admin", io.runcycles.admin.model.event.EventType.API_KEY_CREATED, io.runcycles.admin.model.event.EventCategory.API_KEY);
+        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
+            .thenReturn(List.of(budgetEvt, adminEvt));
+        // Boundary blocks the admin event for this concrete-tenant sub (the
+        // budgetEvt call is left at the mock default, false → deliverable).
+        lenient().when(dispatchService.isBlockedByOwnershipBoundary(adminEvt, offender)).thenReturn(true);
+
+        ReplayResponse response = webhookService.replay("whsub_1",
+            ReplayRequest.builder().from(Instant.now().minusSeconds(3600)).to(Instant.now()).build());
+
+        assertThat(response.getEventsQueued()).isEqualTo(1);
+        verify(dispatchService).dispatchToSubscription(budgetEvt, offender);
+        verify(dispatchService, never()).dispatchToSubscription(eq(adminEvt), any());
+    }
+
+    // A very sparse window can't scan unbounded: the scan ceiling stops
+    // collection (and terminates the paging loop) rather than looping forever.
+    @Test
+    void replay_scanCeiling_stopsCollection_noInfiniteLoop() {
+        WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1"); // BUDGET_CREATED only
+        when(webhookRepository.findById("whsub_1")).thenReturn(sub);
+        when(webhookRepository.acquireReplayLock(eq("whsub_1"), any())).thenReturn(true);
+        // Every page is a FULL page of non-matching events → never exhausts by
+        // partial page; only the scan ceiling can stop it.
+        List<io.runcycles.admin.model.event.Event> fullNonMatchingPage = new ArrayList<>();
+        for (int i = 0; i < 500; i++) {
+            fullNonMatchingPage.add(evt("evt_" + i, io.runcycles.admin.model.event.EventType.TENANT_CREATED,
+                io.runcycles.admin.model.event.EventCategory.TENANT));
+        }
+        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
+            .thenReturn(fullNonMatchingPage);
+
+        ReplayResponse response = webhookService.replay("whsub_1",
+            ReplayRequest.builder().from(Instant.now().minusSeconds(3600)).to(Instant.now()).build());
+
+        assertThat(response.getEventsQueued()).isEqualTo(0);
+        verify(dispatchService, never()).dispatchToSubscription(any(), any());
+        // 20_000 scan ceiling / 500 page = 40 pages, then stop.
+        verify(eventRepository, times(40)).list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt(), any());
     }
 
     @Test
@@ -482,7 +599,7 @@ class WebhookServiceTest {
             .status(WebhookStatus.ACTIVE).consecutiveFailures(0).disableAfterFailures(10).build();
         when(webhookRepository.findById("whsub_sys")).thenReturn(sub);
         when(webhookRepository.acquireReplayLock(eq("whsub_sys"), any())).thenReturn(true);
-        when(eventRepository.list(isNull(), any(), any(), any(), any(), any(), any(), any(), anyInt()))
+        when(eventRepository.list(isNull(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
             .thenReturn(List.of());
 
         ReplayRequest request = ReplayRequest.builder()
@@ -493,7 +610,7 @@ class WebhookServiceTest {
         webhookService.replay("whsub_sys", request);
 
         // Should pass null for tenantId to query all tenants
-        verify(eventRepository).list(isNull(), any(), any(), any(), any(), any(), any(), any(), anyInt());
+        verify(eventRepository, atLeastOnce()).list(isNull(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any());
     }
 
     // ---- replay scope_filter conformance (same matcher as live dispatch) ----
@@ -516,7 +633,7 @@ class WebhookServiceTest {
         io.runcycles.admin.model.event.Event matching = scopedEvent("evt_match", "tenant:a/workspace:b");
         io.runcycles.admin.model.event.Event otherScope = scopedEvent("evt_other", "tenant:b/workspace:c");
         io.runcycles.admin.model.event.Event unscoped = scopedEvent("evt_null", null);
-        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt()))
+        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
             .thenReturn(List.of(matching, otherScope, unscoped));
 
         ReplayRequest request = ReplayRequest.builder()
@@ -540,7 +657,7 @@ class WebhookServiceTest {
         sub.setScopeFilter("tenant:a/workspace:b");
         when(webhookRepository.findById("whsub_1")).thenReturn(sub);
         when(webhookRepository.acquireReplayLock(eq("whsub_1"), any())).thenReturn(true);
-        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt()))
+        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
             .thenReturn(List.of(scopedEvent("evt_null", null)));
 
         ReplayRequest request = ReplayRequest.builder()
@@ -563,7 +680,7 @@ class WebhookServiceTest {
 
         io.runcycles.admin.model.event.Event scoped = scopedEvent("evt_scoped", "tenant:a/workspace:b");
         io.runcycles.admin.model.event.Event unscoped = scopedEvent("evt_null", null);
-        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt()))
+        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
             .thenReturn(List.of(scoped, unscoped));
 
         ReplayRequest request = ReplayRequest.builder()
@@ -586,7 +703,7 @@ class WebhookServiceTest {
 
         io.runcycles.admin.model.event.Event scoped = scopedEvent("evt_scoped", "tenant:a/workspace:b");
         io.runcycles.admin.model.event.Event unscoped = scopedEvent("evt_null", null);
-        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt()))
+        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
             .thenReturn(List.of(scoped, unscoped));
 
         ReplayRequest request = ReplayRequest.builder()
@@ -616,7 +733,7 @@ class WebhookServiceTest {
             .timestamp(Instant.now()).build();
         // Matches both:
         io.runcycles.admin.model.event.Event matchesBoth = scopedEvent("evt_both", "tenant:a/workspace:b");
-        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt()))
+        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
             .thenReturn(List.of(wrongType, matchesBoth));
 
         ReplayRequest request = ReplayRequest.builder()
@@ -630,6 +747,33 @@ class WebhookServiceTest {
         assertThat(response.getEventsQueued()).isEqualTo(1);
         verify(dispatchService).dispatchToSubscription(matchesBoth, sub);
         verify(dispatchService, never()).dispatchToSubscription(eq(wrongType), any());
+    }
+
+    // #209 finding 3: /test is a NARROW, DOCUMENTED exception to the webhook
+    // category boundary. It POSTs a spec-defined system.webhook_test ping
+    // DIRECTLY to a (possibly tenant-owned) endpoint. This is intentional: the
+    // spec defines the test event as the admin-category `system.webhook_test`,
+    // the payload is a synthetic owner-triggered probe carrying no governance
+    // telemetry, and it bypasses the dispatch queue entirely. This test pins the
+    // documented envelope so the exception stays explicit.
+    @Test
+    void test_concreteTenantSub_usesSpecDefinedSystemWebhookTestEnvelope_documentedException() throws Exception {
+        WebhookSubscription concrete = buildSubscription("whsub_1", "tenant-1"); // concrete tenant
+        when(webhookRepository.findById("whsub_1")).thenReturn(concrete);
+        when(webhookRepository.getSigningSecret("whsub_1")).thenReturn("test-secret");
+        org.mockito.ArgumentCaptor<io.runcycles.admin.model.event.Event> evt =
+            org.mockito.ArgumentCaptor.forClass(io.runcycles.admin.model.event.Event.class);
+        when(objectMapper.writeValueAsString(evt.capture())).thenReturn("{\"test\":true}");
+
+        webhookService.test("whsub_1");
+
+        io.runcycles.admin.model.event.Event pinged = evt.getValue();
+        assertThat(pinged.getEventType())
+            .isEqualTo(io.runcycles.admin.model.event.EventType.SYSTEM_WEBHOOK_TEST);
+        assertThat(pinged.getCategory())
+            .isEqualTo(io.runcycles.admin.model.event.EventCategory.SYSTEM);
+        // Synthetic, owner-triggered probe — carries no real governance telemetry.
+        assertThat(pinged.getData()).containsEntry("test", true);
     }
 
     @Test
@@ -690,7 +834,7 @@ class WebhookServiceTest {
             .eventId("evt_2").eventType(EventType.TENANT_CREATED).tenantId("tenant-1")
             .timestamp(Instant.now()).build();
 
-        when(eventRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), anyInt()))
+        when(eventRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
             .thenReturn(List.of(evt1, evt2));
 
         ReplayRequest request = ReplayRequest.builder()
@@ -721,7 +865,7 @@ class WebhookServiceTest {
             .eventId("evt_2").eventType(EventType.BUDGET_FUNDED).tenantId("tenant-1")
             .timestamp(Instant.now()).build();
 
-        when(eventRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), anyInt()))
+        when(eventRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
             .thenReturn(List.of(evt1, evt2));
         doThrow(new RuntimeException("dispatch error")).when(dispatchService)
             .dispatchToSubscription(eq(evt1), any());
@@ -759,7 +903,7 @@ class WebhookServiceTest {
         WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1");
         when(webhookRepository.findById("whsub_1")).thenReturn(sub);
         when(webhookRepository.acquireReplayLock(eq("whsub_1"), any())).thenReturn(true);
-        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt()))
+        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
             .thenReturn(List.of());
 
         ReplayRequest request = ReplayRequest.builder()

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookServiceTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookServiceTest.java
@@ -37,11 +37,12 @@ class WebhookServiceTest {
 
     @org.junit.jupiter.api.BeforeEach
     void dispatchDeliversByDefault() {
-        // dispatchToSubscription now returns whether a delivery was enqueued;
-        // default to true so replay-counting tests behave as before (a guard
-        // that skips delivery is exercised explicitly where relevant).
+        // dispatchToSubscription returns a STRUCTURED outcome; default to ENQUEUED
+        // so replay-counting tests behave as before (a benign skip / backend
+        // failure is exercised explicitly where relevant).
         org.mockito.Mockito.lenient()
-            .when(dispatchService.dispatchToSubscription(any(), any())).thenReturn(true);
+            .when(dispatchService.dispatchToSubscription(any(), any()))
+            .thenReturn(WebhookDispatchService.DispatchOutcome.ENQUEUED);
     }
 
     private WebhookCreateRequest createRequest() {
@@ -535,13 +536,27 @@ class WebhookServiceTest {
         inOrder.verify(dispatchService).dispatchToSubscription(c, sub);
     }
 
+    private ch.qos.logback.core.read.ListAppender<ch.qos.logback.classic.spi.ILoggingEvent> attachWebhookServiceAppender() {
+        ch.qos.logback.classic.Logger logger =
+            (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(WebhookService.class);
+        ch.qos.logback.core.read.ListAppender<ch.qos.logback.classic.spi.ILoggingEvent> appender =
+            new ch.qos.logback.core.read.ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        return appender;
+    }
+
+    private void detachWebhookServiceAppender(ch.qos.logback.core.read.ListAppender<ch.qos.logback.classic.spi.ILoggingEvent> appender) {
+        ((ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(WebhookService.class)).detachAppender(appender);
+    }
+
     // #209 F1: enqueue is BEST-EFFORT by DESIGN (governance #130). Selection is
-    // complete, but a transient per-event enqueue failure makes events_queued <
-    // selected — this is the INTENDED, spec-conformant contract (not fail-on-
-    // partial, not atomic). The degraded enqueue MUST be loudly logged so it is
-    // operator-observable; events_queued honestly reports the accepted count.
+    // complete, but a REAL backend failure (ENQUEUE_FAILED) makes events_queued <
+    // selected — the INTENDED contract (not fail-on-partial, not atomic). Only a
+    // genuine degradation is a WARN; events_queued honestly reports the accepted
+    // count.
     @Test
-    void replay_partialEnqueue_reportsAcceptedCount_andLogsWarn_bestEffort() {
+    void replay_partialEnqueue_backendFailure_logsDegradedWarn() {
         WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1");
         when(webhookRepository.findById("whsub_1")).thenReturn(sub);
         when(webhookRepository.acquireReplayLock(eq("whsub_1"), any())).thenReturn(true);
@@ -549,30 +564,64 @@ class WebhookServiceTest {
         io.runcycles.admin.model.event.Event b = evt("evt_b", io.runcycles.admin.model.event.EventType.BUDGET_CREATED, io.runcycles.admin.model.event.EventCategory.BUDGET);
         io.runcycles.admin.model.event.Event c = evt("evt_c", io.runcycles.admin.model.event.EventType.BUDGET_CREATED, io.runcycles.admin.model.event.EventCategory.BUDGET);
         stubReplayWindow(List.of(a, b, c)); // 3 selected
-        // Backend transiently rejects the enqueue of one selected event.
-        when(dispatchService.dispatchToSubscription(b, sub)).thenReturn(false);
+        // Backend transiently FAILS the enqueue of one selected event.
+        when(dispatchService.dispatchToSubscription(b, sub))
+            .thenReturn(WebhookDispatchService.DispatchOutcome.ENQUEUE_FAILED);
 
-        // Capture the WARN so the partial enqueue is proven observable.
-        ch.qos.logback.classic.Logger logger =
-            (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(WebhookService.class);
-        ch.qos.logback.core.read.ListAppender<ch.qos.logback.classic.spi.ILoggingEvent> appender =
-            new ch.qos.logback.core.read.ListAppender<>();
-        appender.start();
-        logger.addAppender(appender);
+        var appender = attachWebhookServiceAppender();
         ReplayResponse response;
         try {
             response = webhookService.replay("whsub_1",
                 ReplayRequest.builder().from(Instant.now().minusSeconds(3600)).to(Instant.now())
                     .maxEvents(5).build());
         } finally {
-            logger.detachAppender(appender);
+            detachWebhookServiceAppender(appender);
         }
 
         assertThat(response.getEventsQueued()).isEqualTo(2); // accepted count, honest (< 3 selected)
+        // DEGRADED WARN (real backend failure), NOT the benign INFO.
         assertThat(appender.list).anyMatch(e -> e.getLevel() == ch.qos.logback.classic.Level.WARN
-                && e.getFormattedMessage().contains("PARTIAL enqueue")
+                && e.getFormattedMessage().contains("DEGRADED dispatch backend")
                 && e.getFormattedMessage().contains("selected=3")
-                && e.getFormattedMessage().contains("queued=2"));
+                && e.getFormattedMessage().contains("enqueued=2")
+                && e.getFormattedMessage().contains("enqueue_failed=1"));
+    }
+
+    // #209 P2: a BENIGN shortfall — subscription concurrently paused/disabled/
+    // deleted mid-replay (dispatch returns INACTIVE) — is NOT a backend
+    // degradation. events_queued reflects only the enqueued ones, and the signal
+    // is a benign INFO, NOT the degraded-backend WARN.
+    @Test
+    void replay_partialEnqueue_concurrentDisable_logsBenignInfo_notDegradedWarn() {
+        WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1");
+        when(webhookRepository.findById("whsub_1")).thenReturn(sub);
+        when(webhookRepository.acquireReplayLock(eq("whsub_1"), any())).thenReturn(true);
+        io.runcycles.admin.model.event.Event a = evt("evt_a", io.runcycles.admin.model.event.EventType.BUDGET_CREATED, io.runcycles.admin.model.event.EventCategory.BUDGET);
+        io.runcycles.admin.model.event.Event b = evt("evt_b", io.runcycles.admin.model.event.EventType.BUDGET_CREATED, io.runcycles.admin.model.event.EventCategory.BUDGET);
+        io.runcycles.admin.model.event.Event c = evt("evt_c", io.runcycles.admin.model.event.EventType.BUDGET_CREATED, io.runcycles.admin.model.event.EventCategory.BUDGET);
+        stubReplayWindow(List.of(a, b, c)); // 3 selected
+        // Subscription disabled mid-replay → one dispatch re-check returns INACTIVE.
+        when(dispatchService.dispatchToSubscription(b, sub))
+            .thenReturn(WebhookDispatchService.DispatchOutcome.INACTIVE);
+
+        var appender = attachWebhookServiceAppender();
+        ReplayResponse response;
+        try {
+            response = webhookService.replay("whsub_1",
+                ReplayRequest.builder().from(Instant.now().minusSeconds(3600)).to(Instant.now())
+                    .maxEvents(5).build());
+        } finally {
+            detachWebhookServiceAppender(appender);
+        }
+
+        assertThat(response.getEventsQueued()).isEqualTo(2); // only the enqueued ones
+        // Benign INFO — intended lifecycle change, NOT degradation.
+        assertThat(appender.list).anyMatch(e -> e.getLevel() == ch.qos.logback.classic.Level.INFO
+                && e.getFormattedMessage().contains("intended, NOT degradation")
+                && e.getFormattedMessage().contains("inactive=1"));
+        // And DEFINITELY no degraded-backend WARN.
+        assertThat(appender.list).noneMatch(e -> e.getLevel() == ch.qos.logback.classic.Level.WARN
+                && e.getFormattedMessage().contains("DEGRADED dispatch backend"));
     }
 
     // The fail-closed ownership boundary is applied DURING collection, so an

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookServiceTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookServiceTest.java
@@ -484,26 +484,55 @@ class WebhookServiceTest {
     // WebhookReplayPaginationIntegrationTest — mocked pages cannot exercise the
     // ZRANGEBYSCORE contract those bugs live in.
 
-    // Cap counts MATCHING events; delivery preserves chronological order.
+    // All-or-narrow: MORE than max_events deliverable in the window → 400,
+    // NOTHING dispatched, replay lock released (max_events is not a partial cap).
     @Test
-    void replay_capsAtMaxEventsMatching_preservesChronologicalOrder() {
+    void replay_moreThanMaxEventsDeliverable_throws400_nothingDispatched() {
         WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1");
         when(webhookRepository.findById("whsub_1")).thenReturn(sub);
         when(webhookRepository.acquireReplayLock(eq("whsub_1"), any())).thenReturn(true);
         io.runcycles.admin.model.event.Event a = evt("evt_a", io.runcycles.admin.model.event.EventType.BUDGET_CREATED, io.runcycles.admin.model.event.EventCategory.BUDGET);
         io.runcycles.admin.model.event.Event b = evt("evt_b", io.runcycles.admin.model.event.EventType.BUDGET_CREATED, io.runcycles.admin.model.event.EventCategory.BUDGET);
         io.runcycles.admin.model.event.Event c = evt("evt_c", io.runcycles.admin.model.event.EventType.BUDGET_CREATED, io.runcycles.admin.model.event.EventCategory.BUDGET);
-        stubReplayWindow(List.of(a, b, c)); // chronological order
+        stubReplayWindow(List.of(a, b, c)); // 3 deliverable
+
+        assertThatThrownBy(() -> webhookService.replay("whsub_1",
+                ReplayRequest.builder().from(Instant.now().minusSeconds(3600)).to(Instant.now())
+                    .maxEvents(2).build())) // 3 > max_events 2
+            .isInstanceOf(GovernanceException.class)
+            .satisfies(ex -> {
+                GovernanceException ge = (GovernanceException) ex;
+                assertThat(ge.getHttpStatus()).isEqualTo(400);
+                assertThat(ge.getErrorCode())
+                    .isEqualTo(io.runcycles.admin.model.shared.ErrorCode.INVALID_REQUEST);
+                assertThat(ge.getMessage()).contains("more than max_events").contains("raise max_events");
+            });
+
+        verify(dispatchService, never()).dispatchToSubscription(any(), any()); // nothing dispatched
+        verify(webhookRepository).releaseReplayLock(eq("whsub_1"), any());       // lock released
+    }
+
+    // All-or-narrow, within the cap: all deliverable events (<= max_events) are
+    // delivered, in chronological (id-list) order.
+    @Test
+    void replay_allDeliverableWithinMax_deliveredInOrder() {
+        WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1");
+        when(webhookRepository.findById("whsub_1")).thenReturn(sub);
+        when(webhookRepository.acquireReplayLock(eq("whsub_1"), any())).thenReturn(true);
+        io.runcycles.admin.model.event.Event a = evt("evt_a", io.runcycles.admin.model.event.EventType.BUDGET_CREATED, io.runcycles.admin.model.event.EventCategory.BUDGET);
+        io.runcycles.admin.model.event.Event b = evt("evt_b", io.runcycles.admin.model.event.EventType.BUDGET_CREATED, io.runcycles.admin.model.event.EventCategory.BUDGET);
+        io.runcycles.admin.model.event.Event c = evt("evt_c", io.runcycles.admin.model.event.EventType.BUDGET_CREATED, io.runcycles.admin.model.event.EventCategory.BUDGET);
+        stubReplayWindow(List.of(a, b, c));
 
         ReplayResponse response = webhookService.replay("whsub_1",
             ReplayRequest.builder().from(Instant.now().minusSeconds(3600)).to(Instant.now())
-                .maxEvents(2).build());
+                .maxEvents(5).build()); // 3 <= 5 → deliver all
 
-        assertThat(response.getEventsQueued()).isEqualTo(2);
+        assertThat(response.getEventsQueued()).isEqualTo(3);
         org.mockito.InOrder inOrder = org.mockito.Mockito.inOrder(dispatchService);
         inOrder.verify(dispatchService).dispatchToSubscription(a, sub);
         inOrder.verify(dispatchService).dispatchToSubscription(b, sub);
-        verify(dispatchService, never()).dispatchToSubscription(eq(c), any());
+        inOrder.verify(dispatchService).dispatchToSubscription(c, sub);
     }
 
     // The fail-closed ownership boundary is applied DURING collection, so an

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookServiceTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookServiceTest.java
@@ -535,6 +535,46 @@ class WebhookServiceTest {
         inOrder.verify(dispatchService).dispatchToSubscription(c, sub);
     }
 
+    // #209 F1: enqueue is BEST-EFFORT by DESIGN (governance #130). Selection is
+    // complete, but a transient per-event enqueue failure makes events_queued <
+    // selected — this is the INTENDED, spec-conformant contract (not fail-on-
+    // partial, not atomic). The degraded enqueue MUST be loudly logged so it is
+    // operator-observable; events_queued honestly reports the accepted count.
+    @Test
+    void replay_partialEnqueue_reportsAcceptedCount_andLogsWarn_bestEffort() {
+        WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1");
+        when(webhookRepository.findById("whsub_1")).thenReturn(sub);
+        when(webhookRepository.acquireReplayLock(eq("whsub_1"), any())).thenReturn(true);
+        io.runcycles.admin.model.event.Event a = evt("evt_a", io.runcycles.admin.model.event.EventType.BUDGET_CREATED, io.runcycles.admin.model.event.EventCategory.BUDGET);
+        io.runcycles.admin.model.event.Event b = evt("evt_b", io.runcycles.admin.model.event.EventType.BUDGET_CREATED, io.runcycles.admin.model.event.EventCategory.BUDGET);
+        io.runcycles.admin.model.event.Event c = evt("evt_c", io.runcycles.admin.model.event.EventType.BUDGET_CREATED, io.runcycles.admin.model.event.EventCategory.BUDGET);
+        stubReplayWindow(List.of(a, b, c)); // 3 selected
+        // Backend transiently rejects the enqueue of one selected event.
+        when(dispatchService.dispatchToSubscription(b, sub)).thenReturn(false);
+
+        // Capture the WARN so the partial enqueue is proven observable.
+        ch.qos.logback.classic.Logger logger =
+            (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(WebhookService.class);
+        ch.qos.logback.core.read.ListAppender<ch.qos.logback.classic.spi.ILoggingEvent> appender =
+            new ch.qos.logback.core.read.ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        ReplayResponse response;
+        try {
+            response = webhookService.replay("whsub_1",
+                ReplayRequest.builder().from(Instant.now().minusSeconds(3600)).to(Instant.now())
+                    .maxEvents(5).build());
+        } finally {
+            logger.detachAppender(appender);
+        }
+
+        assertThat(response.getEventsQueued()).isEqualTo(2); // accepted count, honest (< 3 selected)
+        assertThat(appender.list).anyMatch(e -> e.getLevel() == ch.qos.logback.classic.Level.WARN
+                && e.getFormattedMessage().contains("PARTIAL enqueue")
+                && e.getFormattedMessage().contains("selected=3")
+                && e.getFormattedMessage().contains("queued=2"));
+    }
+
     // The fail-closed ownership boundary is applied DURING collection, so an
     // admin event a concrete-tenant OFFENDER still matches by selector does not
     // consume cap budget and is not delivered.

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookServiceTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/service/WebhookServiceTest.java
@@ -361,8 +361,7 @@ class WebhookServiceTest {
         WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1");
         when(webhookRepository.findById("whsub_1")).thenReturn(sub);
         when(webhookRepository.acquireReplayLock(eq("whsub_1"), any())).thenReturn(true);
-        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
-            .thenReturn(List.of());
+        stubReplayWindow(List.of());
 
         ReplayRequest request = ReplayRequest.builder()
             .from(Instant.now().minusSeconds(3600))
@@ -384,8 +383,7 @@ class WebhookServiceTest {
             .eventId("evt_1").eventType(io.runcycles.admin.model.event.EventType.BUDGET_CREATED)
             .category(io.runcycles.admin.model.event.EventCategory.BUDGET)
             .tenantId("tenant-1").source("admin").timestamp(Instant.now()).build();
-        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
-            .thenReturn(List.of(event));
+        stubReplayWindow(List.of(event));
 
         ReplayRequest request = ReplayRequest.builder()
             .from(Instant.now().minusSeconds(3600))
@@ -412,8 +410,7 @@ class WebhookServiceTest {
             .eventId("evt_2").eventType(io.runcycles.admin.model.event.EventType.TENANT_CREATED)
             .category(io.runcycles.admin.model.event.EventCategory.TENANT)
             .tenantId("tenant-1").source("admin").timestamp(Instant.now()).build();
-        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
-            .thenReturn(List.of(budgetEvt, tenantEvt));
+        stubReplayWindow(List.of(budgetEvt, tenantEvt));
 
         ReplayRequest request = ReplayRequest.builder()
             .from(Instant.now().minusSeconds(3600))
@@ -445,8 +442,7 @@ class WebhookServiceTest {
             .eventId("evt_admin").eventType(io.runcycles.admin.model.event.EventType.API_KEY_CREATED)
             .category(io.runcycles.admin.model.event.EventCategory.API_KEY)
             .tenantId("tenant-1").source("admin").timestamp(Instant.now()).build();
-        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
-            .thenReturn(List.of(budgetEvt, adminEvt));
+        stubReplayWindow(List.of(budgetEvt, adminEvt));
 
         ReplayRequest request = ReplayRequest.builder()
             .from(Instant.now().minusSeconds(3600)).to(Instant.now()).build();
@@ -467,35 +463,26 @@ class WebhookServiceTest {
             .tenantId("tenant-1").source("admin").timestamp(Instant.now()).build();
     }
 
-    // #209 P2: the repository query is PAGED and filtered DURING pagination, so
-    // a matching event that falls AFTER a full first page of non-matching events
-    // is still delivered (no "cap-then-filter" under-delivery).
-    @Test
-    void replay_pagesPastNonMatchingFirstBatch_stillQueuesLaterMatches() {
-        WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1"); // BUDGET_CREATED only
-        when(webhookRepository.findById("whsub_1")).thenReturn(sub);
-        when(webhookRepository.acquireReplayLock(eq("whsub_1"), any())).thenReturn(true);
-        // First page: 500 non-matching TENANT_CREATED events (a full page).
-        List<io.runcycles.admin.model.event.Event> firstPage = new ArrayList<>();
-        for (int i = 0; i < 500; i++) {
-            firstPage.add(evt("evt_non_" + i, io.runcycles.admin.model.event.EventType.TENANT_CREATED,
-                io.runcycles.admin.model.event.EventCategory.TENANT));
-        }
-        io.runcycles.admin.model.event.Event match =
-            evt("evt_match", io.runcycles.admin.model.event.EventType.BUDGET_CREATED,
-                io.runcycles.admin.model.event.EventCategory.BUDGET);
-        // cursor=null → first page; cursor=last-of-first-page → second page with the match.
-        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), isNull(), anyInt(), any()))
-            .thenReturn(firstPage);
-        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), eq("evt_non_499"), anyInt(), any()))
-            .thenReturn(List.of(match));
-
-        ReplayResponse response = webhookService.replay("whsub_1",
-            ReplayRequest.builder().from(Instant.now().minusSeconds(3600)).to(Instant.now()).build());
-
-        assertThat(response.getEventsQueued()).isEqualTo(1);
-        verify(dispatchService).dispatchToSubscription(match, sub);
+    /**
+     * Approach-B replay stubbing: the collector reads a bounded ordered id list
+     * ({@code listEventIdsInRange}) then hydrates batches ({@code hydrateByIds}).
+     * These unit tests supply a single in-order window (all filter/ordering/cap
+     * logic in the collector is exercised); the real ZRANGEBYSCORE paging
+     * mechanics are covered by WebhookReplayPaginationIntegrationTest.
+     */
+    private void stubReplayWindow(List<io.runcycles.admin.model.event.Event> events) {
+        List<String> ids = events.stream()
+            .map(io.runcycles.admin.model.event.Event::getEventId).toList();
+        lenient().when(eventRepository.listEventIdsInRange(nullable(String.class), any(), any(), anyInt()))
+            .thenReturn(ids);
+        lenient().when(eventRepository.hydrateByIds(any())).thenReturn(events);
     }
+
+    // NOTE: the paging MECHANICS (equal-timestamp boundary, hydration-thinned
+    // pages, vanished cursor, scan ceiling, cross-page chronological order) are
+    // covered against REAL Redis / the real EventRepository in
+    // WebhookReplayPaginationIntegrationTest — mocked pages cannot exercise the
+    // ZRANGEBYSCORE contract those bugs live in.
 
     // Cap counts MATCHING events; delivery preserves chronological order.
     @Test
@@ -506,8 +493,7 @@ class WebhookServiceTest {
         io.runcycles.admin.model.event.Event a = evt("evt_a", io.runcycles.admin.model.event.EventType.BUDGET_CREATED, io.runcycles.admin.model.event.EventCategory.BUDGET);
         io.runcycles.admin.model.event.Event b = evt("evt_b", io.runcycles.admin.model.event.EventType.BUDGET_CREATED, io.runcycles.admin.model.event.EventCategory.BUDGET);
         io.runcycles.admin.model.event.Event c = evt("evt_c", io.runcycles.admin.model.event.EventType.BUDGET_CREATED, io.runcycles.admin.model.event.EventCategory.BUDGET);
-        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
-            .thenReturn(List.of(a, b, c)); // chronological order
+        stubReplayWindow(List.of(a, b, c)); // chronological order
 
         ReplayResponse response = webhookService.replay("whsub_1",
             ReplayRequest.builder().from(Instant.now().minusSeconds(3600)).to(Instant.now())
@@ -535,8 +521,7 @@ class WebhookServiceTest {
         when(webhookRepository.acquireReplayLock(eq("whsub_1"), any())).thenReturn(true);
         io.runcycles.admin.model.event.Event budgetEvt = evt("evt_ok", io.runcycles.admin.model.event.EventType.BUDGET_CREATED, io.runcycles.admin.model.event.EventCategory.BUDGET);
         io.runcycles.admin.model.event.Event adminEvt = evt("evt_admin", io.runcycles.admin.model.event.EventType.API_KEY_CREATED, io.runcycles.admin.model.event.EventCategory.API_KEY);
-        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
-            .thenReturn(List.of(budgetEvt, adminEvt));
+        stubReplayWindow(List.of(budgetEvt, adminEvt));
         // Boundary blocks the admin event for this concrete-tenant sub (the
         // budgetEvt call is left at the mock default, false → deliverable).
         lenient().when(dispatchService.isBlockedByOwnershipBoundary(adminEvt, offender)).thenReturn(true);
@@ -547,32 +532,6 @@ class WebhookServiceTest {
         assertThat(response.getEventsQueued()).isEqualTo(1);
         verify(dispatchService).dispatchToSubscription(budgetEvt, offender);
         verify(dispatchService, never()).dispatchToSubscription(eq(adminEvt), any());
-    }
-
-    // A very sparse window can't scan unbounded: the scan ceiling stops
-    // collection (and terminates the paging loop) rather than looping forever.
-    @Test
-    void replay_scanCeiling_stopsCollection_noInfiniteLoop() {
-        WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1"); // BUDGET_CREATED only
-        when(webhookRepository.findById("whsub_1")).thenReturn(sub);
-        when(webhookRepository.acquireReplayLock(eq("whsub_1"), any())).thenReturn(true);
-        // Every page is a FULL page of non-matching events → never exhausts by
-        // partial page; only the scan ceiling can stop it.
-        List<io.runcycles.admin.model.event.Event> fullNonMatchingPage = new ArrayList<>();
-        for (int i = 0; i < 500; i++) {
-            fullNonMatchingPage.add(evt("evt_" + i, io.runcycles.admin.model.event.EventType.TENANT_CREATED,
-                io.runcycles.admin.model.event.EventCategory.TENANT));
-        }
-        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
-            .thenReturn(fullNonMatchingPage);
-
-        ReplayResponse response = webhookService.replay("whsub_1",
-            ReplayRequest.builder().from(Instant.now().minusSeconds(3600)).to(Instant.now()).build());
-
-        assertThat(response.getEventsQueued()).isEqualTo(0);
-        verify(dispatchService, never()).dispatchToSubscription(any(), any());
-        // 20_000 scan ceiling / 500 page = 40 pages, then stop.
-        verify(eventRepository, times(40)).list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt(), any());
     }
 
     @Test
@@ -599,8 +558,7 @@ class WebhookServiceTest {
             .status(WebhookStatus.ACTIVE).consecutiveFailures(0).disableAfterFailures(10).build();
         when(webhookRepository.findById("whsub_sys")).thenReturn(sub);
         when(webhookRepository.acquireReplayLock(eq("whsub_sys"), any())).thenReturn(true);
-        when(eventRepository.list(isNull(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
-            .thenReturn(List.of());
+        stubReplayWindow(List.of());
 
         ReplayRequest request = ReplayRequest.builder()
             .from(Instant.now().minusSeconds(3600))
@@ -610,7 +568,7 @@ class WebhookServiceTest {
         webhookService.replay("whsub_sys", request);
 
         // Should pass null for tenantId to query all tenants
-        verify(eventRepository, atLeastOnce()).list(isNull(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any());
+        verify(eventRepository, atLeastOnce()).listEventIdsInRange(isNull(), any(), any(), anyInt());
     }
 
     // ---- replay scope_filter conformance (same matcher as live dispatch) ----
@@ -633,8 +591,7 @@ class WebhookServiceTest {
         io.runcycles.admin.model.event.Event matching = scopedEvent("evt_match", "tenant:a/workspace:b");
         io.runcycles.admin.model.event.Event otherScope = scopedEvent("evt_other", "tenant:b/workspace:c");
         io.runcycles.admin.model.event.Event unscoped = scopedEvent("evt_null", null);
-        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
-            .thenReturn(List.of(matching, otherScope, unscoped));
+        stubReplayWindow(List.of(matching, otherScope, unscoped));
 
         ReplayRequest request = ReplayRequest.builder()
             .from(Instant.now().minusSeconds(3600))
@@ -657,8 +614,7 @@ class WebhookServiceTest {
         sub.setScopeFilter("tenant:a/workspace:b");
         when(webhookRepository.findById("whsub_1")).thenReturn(sub);
         when(webhookRepository.acquireReplayLock(eq("whsub_1"), any())).thenReturn(true);
-        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
-            .thenReturn(List.of(scopedEvent("evt_null", null)));
+        stubReplayWindow(List.of(scopedEvent("evt_null", null)));
 
         ReplayRequest request = ReplayRequest.builder()
             .from(Instant.now().minusSeconds(3600))
@@ -680,8 +636,7 @@ class WebhookServiceTest {
 
         io.runcycles.admin.model.event.Event scoped = scopedEvent("evt_scoped", "tenant:a/workspace:b");
         io.runcycles.admin.model.event.Event unscoped = scopedEvent("evt_null", null);
-        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
-            .thenReturn(List.of(scoped, unscoped));
+        stubReplayWindow(List.of(scoped, unscoped));
 
         ReplayRequest request = ReplayRequest.builder()
             .from(Instant.now().minusSeconds(3600))
@@ -703,8 +658,7 @@ class WebhookServiceTest {
 
         io.runcycles.admin.model.event.Event scoped = scopedEvent("evt_scoped", "tenant:a/workspace:b");
         io.runcycles.admin.model.event.Event unscoped = scopedEvent("evt_null", null);
-        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
-            .thenReturn(List.of(scoped, unscoped));
+        stubReplayWindow(List.of(scoped, unscoped));
 
         ReplayRequest request = ReplayRequest.builder()
             .from(Instant.now().minusSeconds(3600))
@@ -733,8 +687,7 @@ class WebhookServiceTest {
             .timestamp(Instant.now()).build();
         // Matches both:
         io.runcycles.admin.model.event.Event matchesBoth = scopedEvent("evt_both", "tenant:a/workspace:b");
-        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
-            .thenReturn(List.of(wrongType, matchesBoth));
+        stubReplayWindow(List.of(wrongType, matchesBoth));
 
         ReplayRequest request = ReplayRequest.builder()
             .from(Instant.now().minusSeconds(3600))
@@ -834,8 +787,7 @@ class WebhookServiceTest {
             .eventId("evt_2").eventType(EventType.TENANT_CREATED).tenantId("tenant-1")
             .timestamp(Instant.now()).build();
 
-        when(eventRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
-            .thenReturn(List.of(evt1, evt2));
+        stubReplayWindow(List.of(evt1, evt2));
 
         ReplayRequest request = ReplayRequest.builder()
             .from(Instant.now().minusSeconds(3600))
@@ -865,8 +817,7 @@ class WebhookServiceTest {
             .eventId("evt_2").eventType(EventType.BUDGET_FUNDED).tenantId("tenant-1")
             .timestamp(Instant.now()).build();
 
-        when(eventRepository.list(any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
-            .thenReturn(List.of(evt1, evt2));
+        stubReplayWindow(List.of(evt1, evt2));
         doThrow(new RuntimeException("dispatch error")).when(dispatchService)
             .dispatchToSubscription(eq(evt1), any());
 
@@ -903,8 +854,7 @@ class WebhookServiceTest {
         WebhookSubscription sub = buildSubscription("whsub_1", "tenant-1");
         when(webhookRepository.findById("whsub_1")).thenReturn(sub);
         when(webhookRepository.acquireReplayLock(eq("whsub_1"), any())).thenReturn(true);
-        when(eventRepository.list(eq("tenant-1"), any(), any(), any(), any(), any(), any(), any(), anyInt(), any()))
-            .thenReturn(List.of());
+        stubReplayWindow(List.of());
 
         ReplayRequest request = ReplayRequest.builder()
             .from(Instant.now().minusSeconds(3600))

--- a/cycles-admin-service/cycles-admin-service-api/src/test/resources/application.properties
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/resources/application.properties
@@ -12,3 +12,6 @@ springdoc.api-docs.enabled=true
 # #209 reconciler: disable the startup one-shot sweep in tests so it never
 # races with per-test seeding; the reconcile logic is covered directly.
 webhook.category-boundary.reconcile-on-startup=false
+# Keep any full-context test that still triggers the runner fast + quiet.
+webhook.category-boundary.reconcile-max-attempts=1
+webhook.category-boundary.reconcile-initial-backoff-ms=0

--- a/cycles-admin-service/cycles-admin-service-api/src/test/resources/application.properties
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/resources/application.properties
@@ -8,3 +8,7 @@ spring.jackson.serialization.write-dates-as-timestamps=false
 spring.jackson.deserialization.fail-on-unknown-properties=false
 spring.jackson.default-property-inclusion=non_null
 springdoc.api-docs.enabled=true
+
+# #209 reconciler: disable the startup one-shot sweep in tests so it never
+# races with per-test seeding; the reconcile logic is covered directly.
+webhook.category-boundary.reconcile-on-startup=false

--- a/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/EventRepository.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/EventRepository.java
@@ -158,9 +158,10 @@ public class EventRepository {
      * bounded {@code ZRANGEBYSCORE} — the exact, de-duplicated member set in
      * ascending (score, member) order.
      *
-     * <p>Provided for webhook replay (governance #209, approach B): replay pages
-     * hydration over this FIXED id list instead of walking {@link #list}'s
-     * score-cursor, which sidesteps three cursor hazards on a millisecond-scored
+     * <p>Provided for webhook replay (governance #209, approach B): replay
+     * hydrates fixed BATCHES over this whole id list instead of walking
+     * {@link #list}'s score-cursor, which sidesteps three cursor hazards on a
+     * millisecond-scored
      * ZSET — equal-timestamp members skipped when the cursor advances by
      * {@code score+1}, a hydration-thinned short page misread as range
      * exhaustion, and duplicate pages when a cursor member has vanished. The ZSET

--- a/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/EventRepository.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/EventRepository.java
@@ -153,6 +153,69 @@ public class EventRepository {
     }
 
     /**
+     * Ordered event IDs in the {@code [from,to]} timestamp window for one tenant
+     * ({@code events:<tenant>}) or all tenants ({@code events:_all}), as a SINGLE
+     * bounded {@code ZRANGEBYSCORE} — the exact, de-duplicated member set in
+     * ascending (score, member) order.
+     *
+     * <p>Provided for webhook replay (governance #209, approach B): replay pages
+     * hydration over this FIXED id list instead of walking {@link #list}'s
+     * score-cursor, which sidesteps three cursor hazards on a millisecond-scored
+     * ZSET — equal-timestamp members skipped when the cursor advances by
+     * {@code score+1}, a hydration-thinned short page misread as range
+     * exhaustion, and duplicate pages when a cursor member has vanished. The ZSET
+     * range is inherently ordered, de-duplicated and stable, so none of those
+     * apply. Does NOT touch {@code list()} or its cursor, so other callers are
+     * unaffected. Capped at {@code maxIds} (the replay scan ceiling).
+     *
+     * @return chronologically ordered IDs (ascending score; ties by member),
+     *         at most {@code maxIds}; empty when the window has no events
+     */
+    public List<String> listEventIdsInRange(String tenantId, Instant from, Instant to, int maxIds) {
+        if (maxIds <= 0) {
+            return new ArrayList<>();
+        }
+        double minScore = (from != null) ? from.toEpochMilli() : Double.NEGATIVE_INFINITY;
+        double maxScore = (to != null) ? to.toEpochMilli() : Double.POSITIVE_INFINITY;
+        String indexKey = (tenantId != null) ? "events:" + tenantId : "events:_all";
+        try (Jedis jedis = jedisPool.getResource()) {
+            return jedis.zrangeByScore(indexKey, minScore, maxScore, 0, maxIds);
+        }
+    }
+
+    /**
+     * Hydrate + parse the given event IDs, PRESERVING their order, dropping any
+     * row that is missing/expired (a {@code null} {@code event:<id>} value) or
+     * unparseable. Unparseable includes strict {@code @JsonCreator} failures on
+     * unknown enum values — an unhydratable record is skipped (fail-closed:
+     * never delivered), it does not abort the batch. Used by replay to hydrate
+     * batches over the fixed id list from {@link #listEventIdsInRange}; a dropped
+     * row here is NOT treated as range exhaustion by the caller (the id list is
+     * already the full ordered member set).
+     */
+    public List<Event> hydrateByIds(List<String> ids) {
+        List<Event> events = new ArrayList<>(ids.size());
+        if (ids.isEmpty()) {
+            return events;
+        }
+        try (Jedis jedis = jedisPool.getResource()) {
+            for (String id : ids) {
+                String data = jedis.get("event:" + id);
+                if (data == null) {
+                    continue; // expired / evicted between the ZRANGE and hydration
+                }
+                try {
+                    events.add(objectMapper.readValue(data, Event.class));
+                } catch (Exception e) {
+                    LOG.warn("Replay hydration skipped an unparseable event row (fail-closed): event_id={} error={}",
+                        LogSanitizer.safe(id), LogSanitizer.safe(e.getMessage()));
+                }
+            }
+        }
+        return events;
+    }
+
+    /**
      * Upper bound on IDs hydrated for a non-timestamp sort pass. Sorted
      * walks need to see the full filter-matching population before the
      * cursor walk; without a ceiling a broad time window would OOM. At

--- a/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/WebhookRepository.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/WebhookRepository.java
@@ -143,15 +143,19 @@ public class WebhookRepository {
     }
 
     /**
-     * Atomic compare-and-set: only overwrite the row if it still holds exactly
-     * the value we read (ARGV[1]), so a reconcile write can never clobber a
-     * concurrent operator update between our GET and SET. Returns 1 on write,
-     * 0 if the row changed underneath us (treated as a concurrent-skip and
-     * retried on the next pass).
+     * Atomic compare-and-set + optional index membership, in ONE server-side op.
+     * Only overwrites the row if it still holds exactly the value we read
+     * (ARGV[1]) — so a reconcile write can never clobber a concurrent operator
+     * update between our GET and SET. When ARGV[3] == "1" it ALSO adds the id to
+     * the system index (KEYS[2]) inside the same atomic script, so a null-owner
+     * normalization can never persist the owner rewrite while leaving the row
+     * un-indexed (there is no window between SET and SADD). Returns 1 on write,
+     * 0 if the row changed underneath us (a concurrent-skip, retried next pass).
      */
-    private static final String CAS_SET_LUA =
+    private static final String CAS_SET_AND_INDEX_LUA =
         "if redis.call('GET', KEYS[1]) == ARGV[1] then\n" +
         "  redis.call('SET', KEYS[1], ARGV[2])\n" +
+        "  if ARGV[3] == '1' then redis.call('SADD', KEYS[2], ARGV[4]) end\n" +
         "  return 1\n" +
         "else\n" +
         "  return 0\n" +
@@ -159,6 +163,14 @@ public class WebhookRepository {
 
     /** Batch size for the SSCAN over the global webhook index. */
     private static final int RECONCILE_SCAN_BATCH = 200;
+
+    /**
+     * Exposes the exact production CAS+index Lua and SSCAN batch so integration
+     * tests exercise the real script/constant rather than a hand-copied string
+     * that could silently drift from production.
+     */
+    public static String reconcileCasSetAndIndexScript() { return CAS_SET_AND_INDEX_LUA; }
+    public static int reconcileScanBatch() { return RECONCILE_SCAN_BATCH; }
 
     /** What the category-boundary reconciler did (or would do) to one row. */
     public enum CategoryBoundaryAction {
@@ -169,7 +181,14 @@ public class WebhookRepository {
         /** Legacy empty-both (match-ALL) row → DISABLED (the 0.1.25.50 rule). */
         DISABLED_EMPTY_BOTH,
         /** Null-owner (corruption) row normalized to the __system__ owner + index. */
-        NORMALIZED_NULL_OWNER
+        NORMALIZED_NULL_OWNER,
+        /**
+         * System-owned row that was MISSING from the {@code webhooks:__system__}
+         * dispatch index (e.g. a prior partial normalization that set the owner
+         * but crashed before the SADD) — membership repaired. Independent of
+         * status (a DISABLED system row still must be indexed).
+         */
+        INDEXED_SYSTEM_MEMBER
     }
 
     /** {@code strippedSelectors} = the admin-only type/category wire values removed (empty for pure disable/normalize). */
@@ -200,14 +219,20 @@ public class WebhookRepository {
      * brought in line with the effective delivery behavior; NOT a behavior
      * change, and no collateral on legitimate tenant-accessible deliveries).
      *
-     * <p>Per row (skips already-{@code DISABLED} rows — idempotent):
+     * <p>The strip/disable actions are idempotent — they skip already-{@code
+     * DISABLED} rows. The NORMALIZE and INDEX actions run regardless of status
+     * (a DISABLED null-owner or unindexed system row still needs fixing). Per row:
      * <ul>
      *   <li><b>Null-owner</b> (corruption): normalized to the {@code __system__}
      *       owner and added to the {@code webhooks:__system__} dispatch index so
      *       it is a well-classified system subscription rather than limbo
-     *       (exempt from repair yet absent from every dispatch index).
-     *       {@code NORMALIZED_NULL_OWNER}. (If it is also empty-both it is
-     *       disabled in the same write.)</li>
+     *       (exempt from repair yet absent from every dispatch index). The owner
+     *       rewrite (SET) and the index add (SADD) execute in ONE atomic Lua op,
+     *       so a partial failure can never persist the owner while leaving the
+     *       row un-indexed. {@code NORMALIZED_NULL_OWNER}.</li>
+     *   <li><b>System-owned but MISSING from the index</b> (e.g. a prior partial
+     *       normalization): membership repaired via an idempotent SADD,
+     *       independent of status. {@code INDEXED_SYSTEM_MEMBER}.</li>
      *   <li><b>Concrete-tenant</b> (owner not null/{@code __system__}, per
      *       {@link WebhookSubscription#isSystemOwner}) carrying admin-only
      *       {@code event_types} and/or {@code event_categories}: those admin
@@ -243,64 +268,85 @@ public class WebhookRepository {
                         String data = jedis.get("webhook:" + id);
                         if (data == null) continue;
                         WebhookSubscription sub = objectMapper.readValue(data, WebhookSubscription.class);
-                        if (sub.getStatus() == WebhookStatus.DISABLED) continue; // idempotent
 
                         boolean nullOwner = sub.getTenantId() == null;
                         // Normalize null owner → __system__ (corruption fix); the row is then
                         // system-owned for the boundary logic below.
                         String effectiveOwner = nullOwner ? WebhookSubscription.SYSTEM_TENANT : sub.getTenantId();
                         boolean system = WebhookSubscription.isSystemOwner(effectiveOwner);
+                        boolean disabledRow = sub.getStatus() == WebhookStatus.DISABLED;
+
+                        // Index-membership repair, computed INDEPENDENTLY of status: a
+                        // system-owned row (incl. a just-normalized null-owner, or one left
+                        // un-indexed by a prior partial normalization — even if DISABLED)
+                        // must be a member of the system dispatch index.
+                        boolean needsIndex = system
+                            && !jedis.sismember("webhooks:" + WebhookSubscription.SYSTEM_TENANT, id);
 
                         // Concrete-tenant rows: strip admin-only selectors (dispatch already
-                        // blocks their delivery, so this only reconciles storage).
+                        // blocks their delivery, so this only reconciles storage). Skipped for
+                        // already-DISABLED rows (idempotent — nothing is delivered anyway).
                         List<String> stripped = new ArrayList<>();
-                        if (!system) {
-                            List<EventType> types = sub.getEventTypes();
-                            List<EventCategory> cats = sub.getEventCategories();
-                            List<EventType> keptTypes = new ArrayList<>();
-                            List<EventCategory> keptCats = new ArrayList<>();
-                            if (types != null) for (EventType t : types) {
-                                if (t.isTenantAccessible()) keptTypes.add(t); else stripped.add(t.getValue());
+                        boolean disable = false;
+                        if (!disabledRow) {
+                            if (!system) {
+                                List<EventType> types = sub.getEventTypes();
+                                List<EventCategory> cats = sub.getEventCategories();
+                                List<EventType> keptTypes = new ArrayList<>();
+                                List<EventCategory> keptCats = new ArrayList<>();
+                                if (types != null) for (EventType t : types) {
+                                    if (t.isTenantAccessible()) keptTypes.add(t); else stripped.add(t.getValue());
+                                }
+                                if (cats != null) for (EventCategory c : cats) {
+                                    if (c.isTenantAccessible()) keptCats.add(c); else stripped.add(c.getValue());
+                                }
+                                if (!stripped.isEmpty()) {
+                                    sub.setEventTypes(keptTypes.isEmpty() ? null : keptTypes);
+                                    sub.setEventCategories(keptCats.isEmpty() ? null : keptCats);
+                                }
                             }
-                            if (cats != null) for (EventCategory c : cats) {
-                                if (c.isTenantAccessible()) keptCats.add(c); else stripped.add(c.getValue());
-                            }
-                            if (!stripped.isEmpty()) {
-                                sub.setEventTypes(keptTypes.isEmpty() ? null : keptTypes);
-                                sub.setEventCategories(keptCats.isEmpty() ? null : keptCats);
-                            }
+                            // Empty-both computed on the RESULTING selectors (after any strip).
+                            List<EventType> t2 = sub.getEventTypes();
+                            List<EventCategory> c2 = sub.getEventCategories();
+                            boolean emptyBoth = (t2 == null || t2.isEmpty()) && (c2 == null || c2.isEmpty());
+                            disable = emptyBoth;
                         }
                         boolean didStrip = !stripped.isEmpty();
 
-                        // Empty-both computed on the RESULTING selectors (after any strip).
-                        List<EventType> t2 = sub.getEventTypes();
-                        List<EventCategory> c2 = sub.getEventCategories();
-                        boolean emptyBoth = (t2 == null || t2.isEmpty()) && (c2 == null || c2.isEmpty());
-                        boolean disable = emptyBoth; // was ACTIVE/PAUSED (DISABLED skipped above)
-
-                        boolean changed = nullOwner || didStrip || disable;
-                        if (!changed) continue; // clean row
+                        // A JSON write is needed for owner rewrite / strip / disable; a pure
+                        // index-membership repair needs only an (idempotent) SADD.
+                        boolean jsonChange = nullOwner || didStrip || disable;
+                        if (!jsonChange && !needsIndex) continue; // clean row
 
                         CategoryBoundaryAction action;
                         if (didStrip && disable) action = CategoryBoundaryAction.STRIPPED_AND_DISABLED;
                         else if (didStrip)       action = CategoryBoundaryAction.STRIPPED_ADMIN_SELECTORS;
                         else if (disable)        action = CategoryBoundaryAction.DISABLED_EMPTY_BOTH;
-                        else                     action = CategoryBoundaryAction.NORMALIZED_NULL_OWNER;
+                        else if (nullOwner)      action = CategoryBoundaryAction.NORMALIZED_NULL_OWNER;
+                        else                     action = CategoryBoundaryAction.INDEXED_SYSTEM_MEMBER;
 
                         if (!dryRun) {
-                            if (nullOwner) sub.setTenantId(WebhookSubscription.SYSTEM_TENANT);
-                            if (disable) sub.setStatus(WebhookStatus.DISABLED);
-                            sub.setUpdatedAt(Instant.now());
-                            String newJson = objectMapper.writeValueAsString(sub);
-                            Object casRes = jedis.eval(CAS_SET_LUA, List.of("webhook:" + id),
-                                List.of(data, newJson));
-                            if (!Long.valueOf(1L).equals(casRes)) {
-                                failures++;
-                                LOG.warn("category-boundary reconcile CAS miss (concurrent update), will retry: subscription_id={} tenant_id={}",
-                                    LogSanitizer.safe(id), LogSanitizer.safe(effectiveOwner));
-                                continue;
+                            if (jsonChange) {
+                                if (nullOwner) sub.setTenantId(WebhookSubscription.SYSTEM_TENANT);
+                                if (disable) sub.setStatus(WebhookStatus.DISABLED);
+                                sub.setUpdatedAt(Instant.now());
+                                String newJson = objectMapper.writeValueAsString(sub);
+                                // SADD folded into the SAME atomic op when the row must be indexed.
+                                boolean doIndex = nullOwner || needsIndex;
+                                Object casRes = jedis.eval(CAS_SET_AND_INDEX_LUA,
+                                    List.of("webhook:" + id, "webhooks:" + WebhookSubscription.SYSTEM_TENANT),
+                                    List.of(data, newJson, doIndex ? "1" : "0", id));
+                                if (!Long.valueOf(1L).equals(casRes)) {
+                                    failures++;
+                                    LOG.warn("category-boundary reconcile CAS miss (concurrent update), will retry: subscription_id={} tenant_id={}",
+                                        LogSanitizer.safe(id), LogSanitizer.safe(effectiveOwner));
+                                    continue;
+                                }
+                            } else {
+                                // Pure index repair: SADD is idempotent and cannot clobber the
+                                // row, so no CAS is needed.
+                                jedis.sadd("webhooks:" + WebhookSubscription.SYSTEM_TENANT, id);
                             }
-                            if (nullOwner) jedis.sadd("webhooks:" + WebhookSubscription.SYSTEM_TENANT, id);
                         }
 
                         repaired.add(new CategoryBoundaryRepairOutcome(id, effectiveOwner, action, stripped));

--- a/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/WebhookRepository.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/WebhookRepository.java
@@ -2,6 +2,7 @@ package io.runcycles.admin.data.repository;
 import io.runcycles.admin.data.exception.GovernanceException;
 import io.runcycles.admin.data.logging.LogSanitizer;
 import io.runcycles.admin.data.service.CryptoService;
+import io.runcycles.admin.model.event.EventCategory;
 import io.runcycles.admin.model.event.EventType;
 import io.runcycles.admin.model.shared.SearchSpec;
 import io.runcycles.admin.model.shared.SortSpec;
@@ -133,6 +134,117 @@ public class WebhookRepository {
                 } catch (Exception e) {
                     LOG.warn("Cascade-disable skipped webhook subscription: subscription_id={} tenant_id={} error={}",
                         LogSanitizer.safe(id), LogSanitizer.safe(tenantId), LogSanitizer.safe(e.getMessage()), e);
+                }
+            }
+        }
+        return outcomes;
+    }
+
+    /** Owning-tenant sentinel for admin-provisioned, non-tenant-owned rows. */
+    private static final String SYSTEM_TENANT = "__system__";
+
+    /** What the category-boundary reconciler did (or would do) to one row. */
+    public enum CategoryBoundaryAction {
+        /**
+         * Tenant-owned row carries admin-only categories → row DISABLED (NOT
+         * stripped): a concrete-tenant admin-category subscription may be a
+         * legit-but-misconfigured operator monitoring row, so we stop delivery
+         * loudly and leave the categories intact for the operator to review and
+         * migrate, rather than silently rewriting it.
+         */
+        DISABLED_ADMIN_CATEGORIES,
+        /** Legacy empty-both (match-ALL) row → DISABLED (the 0.1.25.50 rule). */
+        DISABLED_EMPTY_BOTH
+    }
+
+    /** {@code offendingCategories} = the admin-only categories that flagged the row. */
+    public record CategoryBoundaryRepairOutcome(String subscriptionId, String tenantId,
+                                                CategoryBoundaryAction action,
+                                                List<String> offendingCategories) {}
+
+    /**
+     * One-time (idempotent) cleanup for #209 / governance v0.1.25.40 (pending):
+     * find TENANT-owned (non-{@code __system__}) subscriptions that carry
+     * admin-only {@code event_categories} — placed there via the admin plane
+     * before the boundary was enforced — plus legacy empty-both match-ALL rows.
+     *
+     * <p><b>Conservative by design.</b> An offender is <b>DISABLED</b>, never
+     * silently stripped: a concrete-tenant admin-category subscription might be
+     * a legit-but-misconfigured operator monitoring row (delivering to an
+     * operator-controlled endpoint), and silently rewriting its selectors would
+     * break that with no signal. Disabling stops delivery immediately
+     * (dispatch only matches {@code ACTIVE} rows), is reversible, preserves the
+     * row (and its offending categories) for operator review, and is loudly
+     * logged. The supported replacement for genuine per-tenant admin monitoring
+     * is a {@code __system__}-owned subscription filtered by
+     * {@code event_categories} (it receives those admin events for ALL tenants,
+     * since {@code __system__} is in every tenant's dispatch union), selecting
+     * the target tenant CLIENT-SIDE on the envelope {@code tenant_id}. NOT a
+     * {@code scope_filter}: admin lifecycle events are null-scoped and
+     * {@code matchesScope} excludes null scopes from any non-blank filter, so a
+     * {@code scope_filter} would deliver none. A tenant-owned row exposes the
+     * endpoint URL + signing secret to the tenant; a {@code __system__} row
+     * does not.
+     *
+     * <p>Per row (skips {@code __system__} — legitimately admin-scoped): if it
+     * carries any admin-only category → {@code DISABLED_ADMIN_CATEGORIES}; else
+     * if it is empty-both → {@code DISABLED_EMPTY_BOTH}. Already-{@code DISABLED}
+     * offenders are skipped, so a re-run is a no-op (idempotent).
+     *
+     * @param dryRun when true, compute + log the offenders but mutate nothing
+     *               (report mode for operator review before the disabling pass)
+     */
+    public List<CategoryBoundaryRepairOutcome> reconcileTenantCategoryBoundary(boolean dryRun) {
+        List<CategoryBoundaryRepairOutcome> outcomes = new ArrayList<>();
+        try (Jedis jedis = jedisPool.getResource()) {
+            Set<String> ids = jedis.smembers("webhooks:_all");
+            if (ids == null || ids.isEmpty()) return outcomes;
+            for (String id : ids) {
+                try {
+                    String data = jedis.get("webhook:" + id);
+                    if (data == null) continue;
+                    WebhookSubscription sub = objectMapper.readValue(data, WebhookSubscription.class);
+                    // __system__ rows are not tenant-owned: admin-only categories
+                    // there are legitimate system-wide monitoring.
+                    if (SYSTEM_TENANT.equals(sub.getTenantId())) continue;
+                    // Already-disabled offenders need no further action (idempotent).
+                    if (sub.getStatus() == WebhookStatus.DISABLED) continue;
+
+                    List<EventCategory> cats = sub.getEventCategories();
+                    List<EventCategory> adminOnly = new ArrayList<>();
+                    if (cats != null) {
+                        for (EventCategory c : cats) {
+                            if (!c.isTenantAccessible()) adminOnly.add(c);
+                        }
+                    }
+                    boolean hasAdminCategories = !adminOnly.isEmpty();
+
+                    List<EventType> types = sub.getEventTypes();
+                    boolean typesEmpty = types == null || types.isEmpty();
+                    boolean catsEmpty = cats == null || cats.isEmpty();
+                    boolean emptyBoth = typesEmpty && catsEmpty;
+
+                    if (!hasAdminCategories && !emptyBoth) continue; // clean row
+
+                    CategoryBoundaryAction action = hasAdminCategories
+                        ? CategoryBoundaryAction.DISABLED_ADMIN_CATEGORIES
+                        : CategoryBoundaryAction.DISABLED_EMPTY_BOTH;
+                    List<String> offending = adminOnly.stream().map(EventCategory::getValue).toList();
+
+                    if (!dryRun) {
+                        // DISABLE only — do NOT strip. Categories left intact for review.
+                        sub.setStatus(WebhookStatus.DISABLED);
+                        sub.setUpdatedAt(Instant.now());
+                        jedis.set("webhook:" + id, objectMapper.writeValueAsString(sub));
+                    }
+
+                    outcomes.add(new CategoryBoundaryRepairOutcome(id, sub.getTenantId(), action, offending));
+                    LOG.warn("category-boundary reconcile {} offender webhook (#209): subscription_id={} tenant_id={} action={} offending_categories={} — operator action: migrate genuine per-tenant admin monitoring to a __system__ subscription filtered by event_categories, selecting the tenant client-side on the envelope tenant_id (admin events are null-scoped; a scope_filter would exclude them)",
+                        dryRun ? "REPORTED (dry-run)" : "DISABLED",
+                        LogSanitizer.safe(id), LogSanitizer.safe(sub.getTenantId()), action, offending);
+                } catch (Exception e) {
+                    LOG.warn("category-boundary reconcile skipped webhook subscription: subscription_id={} error={}",
+                        LogSanitizer.safe(id), LogSanitizer.safe(e.getMessage()), e);
                 }
             }
         }

--- a/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/WebhookRepository.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/WebhookRepository.java
@@ -13,6 +13,8 @@ import org.slf4j.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 import redis.clients.jedis.*;
+import redis.clients.jedis.params.ScanParams;
+import redis.clients.jedis.resps.ScanResult;
 import java.time.Instant;
 import java.util.*;
 @Repository
@@ -140,115 +142,178 @@ public class WebhookRepository {
         return outcomes;
     }
 
-    /** Owning-tenant sentinel for admin-provisioned, non-tenant-owned rows. */
-    private static final String SYSTEM_TENANT = "__system__";
+    /**
+     * Atomic compare-and-set: only overwrite the row if it still holds exactly
+     * the value we read (ARGV[1]), so a reconcile write can never clobber a
+     * concurrent operator update between our GET and SET. Returns 1 on write,
+     * 0 if the row changed underneath us (treated as a concurrent-skip and
+     * retried on the next pass).
+     */
+    private static final String CAS_SET_LUA =
+        "if redis.call('GET', KEYS[1]) == ARGV[1] then\n" +
+        "  redis.call('SET', KEYS[1], ARGV[2])\n" +
+        "  return 1\n" +
+        "else\n" +
+        "  return 0\n" +
+        "end\n";
+
+    /** Batch size for the SSCAN over the global webhook index. */
+    private static final int RECONCILE_SCAN_BATCH = 200;
 
     /** What the category-boundary reconciler did (or would do) to one row. */
     public enum CategoryBoundaryAction {
         /**
-         * Tenant-owned row carries admin-only categories → row DISABLED (NOT
-         * stripped): a concrete-tenant admin-category subscription may be a
+         * Concrete-tenant row carries admin-only event_types and/or
+         * event_categories → row DISABLED (NOT stripped): it may be a
          * legit-but-misconfigured operator monitoring row, so we stop delivery
-         * loudly and leave the categories intact for the operator to review and
+         * loudly and leave its selectors intact for the operator to review and
          * migrate, rather than silently rewriting it.
          */
-        DISABLED_ADMIN_CATEGORIES,
+        DISABLED_ADMIN_SELECTORS,
         /** Legacy empty-both (match-ALL) row → DISABLED (the 0.1.25.50 rule). */
         DISABLED_EMPTY_BOTH
     }
 
-    /** {@code offendingCategories} = the admin-only categories that flagged the row. */
+    /** {@code offendingSelectors} = the admin-only type/category wire values that flagged the row. */
     public record CategoryBoundaryRepairOutcome(String subscriptionId, String tenantId,
                                                 CategoryBoundaryAction action,
-                                                List<String> offendingCategories) {}
+                                                List<String> offendingSelectors) {}
 
     /**
-     * One-time (idempotent) cleanup for #209 / governance v0.1.25.40 (pending):
-     * find TENANT-owned (non-{@code __system__}) subscriptions that carry
-     * admin-only {@code event_categories} — placed there via the admin plane
-     * before the boundary was enforced — plus legacy empty-both match-ALL rows.
-     *
-     * <p><b>Conservative by design.</b> An offender is <b>DISABLED</b>, never
-     * silently stripped: a concrete-tenant admin-category subscription might be
-     * a legit-but-misconfigured operator monitoring row (delivering to an
-     * operator-controlled endpoint), and silently rewriting its selectors would
-     * break that with no signal. Disabling stops delivery immediately
-     * (dispatch only matches {@code ACTIVE} rows), is reversible, preserves the
-     * row (and its offending categories) for operator review, and is loudly
-     * logged. The supported replacement for genuine per-tenant admin monitoring
-     * is a {@code __system__}-owned subscription filtered by
-     * {@code event_categories} (it receives those admin events for ALL tenants,
-     * since {@code __system__} is in every tenant's dispatch union), selecting
-     * the target tenant CLIENT-SIDE on the envelope {@code tenant_id}. NOT a
-     * {@code scope_filter}: admin lifecycle events are null-scoped and
-     * {@code matchesScope} excludes null scopes from any non-blank filter, so a
-     * {@code scope_filter} would deliver none. A tenant-owned row exposes the
-     * endpoint URL + signing secret to the tenant; a {@code __system__} row
-     * does not.
-     *
-     * <p>Per row (skips {@code __system__} — legitimately admin-scoped): if it
-     * carries any admin-only category → {@code DISABLED_ADMIN_CATEGORIES}; else
-     * if it is empty-both → {@code DISABLED_EMPTY_BOTH}. Already-{@code DISABLED}
-     * offenders are skipped, so a re-run is a no-op (idempotent).
-     *
-     * @param dryRun when true, compute + log the offenders but mutate nothing
-     *               (report mode for operator review before the disabling pass)
+     * Result of one reconcile pass. {@code failures} counts rows that errored
+     * or were skipped due to a concurrent modification (CAS miss); a pass with
+     * {@code failures > 0} is incomplete and the caller should retry (the sweep
+     * is idempotent, so re-running is safe).
      */
-    public List<CategoryBoundaryRepairOutcome> reconcileTenantCategoryBoundary(boolean dryRun) {
-        List<CategoryBoundaryRepairOutcome> outcomes = new ArrayList<>();
+    public record ReconcileResult(List<CategoryBoundaryRepairOutcome> repaired, int failures) {
+        public boolean isComplete() { return failures == 0; }
+    }
+
+    /**
+     * One-time (idempotent, resumable) cleanup for #209 / governance v0.1.25.40
+     * (pending): find webhook subscriptions that violate the tenant-accessible
+     * boundary and DISABLE them.
+     *
+     * <p>Offender definition, per row:
+     * <ul>
+     *   <li><b>Concrete-tenant</b> rows (owner is NOT null/omitted and NOT the
+     *       {@code __system__} sentinel — see {@link WebhookSubscription#isSystemOwner})
+     *       carrying any admin-only {@code event_types} OR {@code event_categories}
+     *       (api_key/policy/webhook/system) → {@code DISABLED_ADMIN_SELECTORS}.
+     *       Both selector kinds are checked (event matching unions them).</li>
+     *   <li><b>Any</b> row (including {@code __system__}) that is empty-both — no
+     *       {@code event_types} AND no {@code event_categories}, i.e. match-ALL →
+     *       {@code DISABLED_EMPTY_BOTH}. The system carve-out exempts admin
+     *       SELECTORS only; it does not exempt a row from the universal
+     *       "at least one selector" invariant.</li>
+     * </ul>
+     *
+     * <p><b>Conservative:</b> offenders are DISABLED, never silently stripped —
+     * a concrete-tenant admin-selector row might be a legit-but-misconfigured
+     * operator monitoring row, and a silent rewrite would break it with no
+     * signal. Disabling stops delivery immediately (live dispatch AND replay
+     * only deliver to {@code ACTIVE} rows), is reversible, preserves the row +
+     * offending selectors for review, and is loudly logged. The supported
+     * replacement for genuine per-tenant admin monitoring is a
+     * {@code __system__}-owned subscription filtered by {@code event_categories}
+     * (it receives those admin events for ALL tenants, since {@code __system__}
+     * is in every tenant's dispatch union), selecting the target tenant
+     * CLIENT-SIDE on the envelope {@code tenant_id}. ({@code api_key},
+     * {@code webhook} and {@code system} events are null-scoped and cannot be
+     * scope-filtered; {@code policy} events carry a real tenant-bounded scope
+     * and CAN be scope-filtered.)
+     *
+     * <p><b>Robust:</b> SSCANs the global index in batches (bounded memory, no
+     * whole-keyspace SMEMBERS), writes via an atomic compare-and-set (never
+     * clobbers a concurrent update — a CAS miss is a concurrent-skip counted as
+     * a failure and retried next pass), and skips already-{@code DISABLED}
+     * offenders (idempotent). Never throws.
+     *
+     * @param dryRun when true, compute + log offenders but mutate nothing
+     */
+    public ReconcileResult reconcileTenantCategoryBoundary(boolean dryRun) {
+        List<CategoryBoundaryRepairOutcome> repaired = new ArrayList<>();
+        int failures = 0;
         try (Jedis jedis = jedisPool.getResource()) {
-            Set<String> ids = jedis.smembers("webhooks:_all");
-            if (ids == null || ids.isEmpty()) return outcomes;
-            for (String id : ids) {
-                try {
-                    String data = jedis.get("webhook:" + id);
-                    if (data == null) continue;
-                    WebhookSubscription sub = objectMapper.readValue(data, WebhookSubscription.class);
-                    // __system__ rows are not tenant-owned: admin-only categories
-                    // there are legitimate system-wide monitoring.
-                    if (SYSTEM_TENANT.equals(sub.getTenantId())) continue;
-                    // Already-disabled offenders need no further action (idempotent).
-                    if (sub.getStatus() == WebhookStatus.DISABLED) continue;
+            ScanParams params = new ScanParams().count(RECONCILE_SCAN_BATCH);
+            String cursor = ScanParams.SCAN_POINTER_START;
+            do {
+                ScanResult<String> scan = jedis.sscan("webhooks:_all", cursor, params);
+                cursor = scan.getCursor();
+                for (String id : scan.getResult()) {
+                    try {
+                        String data = jedis.get("webhook:" + id);
+                        if (data == null) continue;
+                        WebhookSubscription sub = objectMapper.readValue(data, WebhookSubscription.class);
+                        // Already-disabled offenders need no action (idempotent).
+                        if (sub.getStatus() == WebhookStatus.DISABLED) continue;
 
-                    List<EventCategory> cats = sub.getEventCategories();
-                    List<EventCategory> adminOnly = new ArrayList<>();
-                    if (cats != null) {
-                        for (EventCategory c : cats) {
-                            if (!c.isTenantAccessible()) adminOnly.add(c);
+                        boolean system = WebhookSubscription.isSystemOwner(sub.getTenantId());
+
+                        // Admin selectors only flag CONCRETE-owner rows.
+                        List<String> offending = new ArrayList<>();
+                        if (!system) {
+                            List<EventType> types = sub.getEventTypes();
+                            if (types != null) {
+                                for (EventType t : types) {
+                                    if (!t.isTenantAccessible()) offending.add(t.getValue());
+                                }
+                            }
+                            List<EventCategory> cats0 = sub.getEventCategories();
+                            if (cats0 != null) {
+                                for (EventCategory c : cats0) {
+                                    if (!c.isTenantAccessible()) offending.add(c.getValue());
+                                }
+                            }
                         }
+                        boolean hasAdminSelectors = !offending.isEmpty();
+
+                        // Empty-both applies to ALL rows, __system__ included.
+                        List<EventType> t2 = sub.getEventTypes();
+                        List<EventCategory> c2 = sub.getEventCategories();
+                        boolean emptyBoth = (t2 == null || t2.isEmpty()) && (c2 == null || c2.isEmpty());
+
+                        if (!hasAdminSelectors && !emptyBoth) continue; // clean row
+
+                        CategoryBoundaryAction action = hasAdminSelectors
+                            ? CategoryBoundaryAction.DISABLED_ADMIN_SELECTORS
+                            : CategoryBoundaryAction.DISABLED_EMPTY_BOTH;
+
+                        if (!dryRun) {
+                            // DISABLE only — do NOT strip. Selectors left intact for review.
+                            sub.setStatus(WebhookStatus.DISABLED);
+                            sub.setUpdatedAt(Instant.now());
+                            String newJson = objectMapper.writeValueAsString(sub);
+                            Object casRes = jedis.eval(CAS_SET_LUA, List.of("webhook:" + id),
+                                List.of(data, newJson));
+                            if (!Long.valueOf(1L).equals(casRes)) {
+                                // Concurrent update landed between GET and CAS — skip; retried next pass.
+                                failures++;
+                                LOG.warn("category-boundary reconcile CAS miss (concurrent update), will retry: subscription_id={} tenant_id={}",
+                                    LogSanitizer.safe(id), LogSanitizer.safe(sub.getTenantId()));
+                                continue;
+                            }
+                        }
+
+                        repaired.add(new CategoryBoundaryRepairOutcome(id, sub.getTenantId(), action, offending));
+                        LOG.warn("category-boundary reconcile {} offender webhook (#209): subscription_id={} tenant_id={} action={} offending_selectors={} — operator action: migrate genuine per-tenant admin monitoring to a __system__ subscription filtered by event_categories, selecting the tenant client-side on the envelope tenant_id (api_key.*/webhook.*/system.* are null-scoped; policy.* is scope-filterable)",
+                            dryRun ? "REPORTED (dry-run)" : "DISABLED",
+                            LogSanitizer.safe(id), LogSanitizer.safe(sub.getTenantId()), action, offending);
+                    } catch (Exception e) {
+                        failures++;
+                        LOG.warn("category-boundary reconcile skipped webhook subscription (will retry): subscription_id={} error={}",
+                            LogSanitizer.safe(id), LogSanitizer.safe(e.getMessage()), e);
                     }
-                    boolean hasAdminCategories = !adminOnly.isEmpty();
-
-                    List<EventType> types = sub.getEventTypes();
-                    boolean typesEmpty = types == null || types.isEmpty();
-                    boolean catsEmpty = cats == null || cats.isEmpty();
-                    boolean emptyBoth = typesEmpty && catsEmpty;
-
-                    if (!hasAdminCategories && !emptyBoth) continue; // clean row
-
-                    CategoryBoundaryAction action = hasAdminCategories
-                        ? CategoryBoundaryAction.DISABLED_ADMIN_CATEGORIES
-                        : CategoryBoundaryAction.DISABLED_EMPTY_BOTH;
-                    List<String> offending = adminOnly.stream().map(EventCategory::getValue).toList();
-
-                    if (!dryRun) {
-                        // DISABLE only — do NOT strip. Categories left intact for review.
-                        sub.setStatus(WebhookStatus.DISABLED);
-                        sub.setUpdatedAt(Instant.now());
-                        jedis.set("webhook:" + id, objectMapper.writeValueAsString(sub));
-                    }
-
-                    outcomes.add(new CategoryBoundaryRepairOutcome(id, sub.getTenantId(), action, offending));
-                    LOG.warn("category-boundary reconcile {} offender webhook (#209): subscription_id={} tenant_id={} action={} offending_categories={} — operator action: migrate genuine per-tenant admin monitoring to a __system__ subscription filtered by event_categories, selecting the tenant client-side on the envelope tenant_id (admin events are null-scoped; a scope_filter would exclude them)",
-                        dryRun ? "REPORTED (dry-run)" : "DISABLED",
-                        LogSanitizer.safe(id), LogSanitizer.safe(sub.getTenantId()), action, offending);
-                } catch (Exception e) {
-                    LOG.warn("category-boundary reconcile skipped webhook subscription: subscription_id={} error={}",
-                        LogSanitizer.safe(id), LogSanitizer.safe(e.getMessage()), e);
                 }
-            }
+            } while (!ScanParams.SCAN_POINTER_START.equals(cursor));
+        } catch (Exception e) {
+            // Whole-pass failure (e.g. Redis unavailable): report incomplete so
+            // the caller retries in the background — do NOT throw.
+            failures++;
+            LOG.error("category-boundary reconcile pass failed (will retry): error={}",
+                LogSanitizer.safe(e.getMessage()), e);
         }
-        return outcomes;
+        return new ReconcileResult(repaired, failures);
     }
 
     public void update(String subscriptionId, WebhookSubscription updated) {
@@ -423,7 +488,15 @@ public class WebhookRepository {
         }
     }
 
-    private boolean matchesEventType(WebhookSubscription sub, EventType eventType) {
+    /**
+     * Event-type/category matcher shared by live dispatch
+     * ({@link #findMatchingSubscriptions}) and replay
+     * ({@code WebhookService.replay}) — public static so replay honors the same
+     * "event types the subscription is subscribed to" contract as live delivery
+     * (spec: replayEvents) and cannot leak events outside the subscription's
+     * own selectors.
+     */
+    public static boolean matchesEventType(WebhookSubscription sub, EventType eventType) {
         // Check if the subscription explicitly lists this event type
         if (sub.getEventTypes() != null && !sub.getEventTypes().isEmpty()) {
             if (sub.getEventTypes().contains(eventType)) return true;

--- a/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/WebhookRepository.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/main/java/io/runcycles/admin/data/repository/WebhookRepository.java
@@ -162,22 +162,20 @@ public class WebhookRepository {
 
     /** What the category-boundary reconciler did (or would do) to one row. */
     public enum CategoryBoundaryAction {
-        /**
-         * Concrete-tenant row carries admin-only event_types and/or
-         * event_categories → row DISABLED (NOT stripped): it may be a
-         * legit-but-misconfigured operator monitoring row, so we stop delivery
-         * loudly and leave its selectors intact for the operator to review and
-         * migrate, rather than silently rewriting it.
-         */
-        DISABLED_ADMIN_SELECTORS,
+        /** Concrete-tenant row: admin-only selectors STRIPPED, tenant-accessible kept. */
+        STRIPPED_ADMIN_SELECTORS,
+        /** Stripping admin-only selectors emptied both selector lists → DISABLED. */
+        STRIPPED_AND_DISABLED,
         /** Legacy empty-both (match-ALL) row → DISABLED (the 0.1.25.50 rule). */
-        DISABLED_EMPTY_BOTH
+        DISABLED_EMPTY_BOTH,
+        /** Null-owner (corruption) row normalized to the __system__ owner + index. */
+        NORMALIZED_NULL_OWNER
     }
 
-    /** {@code offendingSelectors} = the admin-only type/category wire values that flagged the row. */
+    /** {@code strippedSelectors} = the admin-only type/category wire values removed (empty for pure disable/normalize). */
     public record CategoryBoundaryRepairOutcome(String subscriptionId, String tenantId,
                                                 CategoryBoundaryAction action,
-                                                List<String> offendingSelectors) {}
+                                                List<String> strippedSelectors) {}
 
     /**
      * Result of one reconcile pass. {@code failures} counts rows that errored
@@ -190,46 +188,46 @@ public class WebhookRepository {
     }
 
     /**
-     * One-time (idempotent, resumable) cleanup for #209 / governance v0.1.25.40
-     * (pending): find webhook subscriptions that violate the tenant-accessible
-     * boundary and DISABLE them.
+     * Best-effort hygiene cleanup for #209 / governance v0.1.25.40 (pending).
      *
-     * <p>Offender definition, per row:
+     * <p><b>This is NOT the security mechanism.</b> The durable confidentiality
+     * guarantee is the fail-closed DISPATCH boundary
+     * ({@code WebhookDispatchService}): a concrete-tenant subscription never
+     * receives admin-only events, immediately and unconditionally, regardless of
+     * stored selectors or this reconciler's state. Because dispatch already
+     * blocks the leak, admin-only selectors stored on a concrete-tenant row are
+     * already non-functional — so this reconciler safely STRIPS them (storage is
+     * brought in line with the effective delivery behavior; NOT a behavior
+     * change, and no collateral on legitimate tenant-accessible deliveries).
+     *
+     * <p>Per row (skips already-{@code DISABLED} rows — idempotent):
      * <ul>
-     *   <li><b>Concrete-tenant</b> rows (owner is NOT null/omitted and NOT the
-     *       {@code __system__} sentinel — see {@link WebhookSubscription#isSystemOwner})
-     *       carrying any admin-only {@code event_types} OR {@code event_categories}
-     *       (api_key/policy/webhook/system) → {@code DISABLED_ADMIN_SELECTORS}.
-     *       Both selector kinds are checked (event matching unions them).</li>
+     *   <li><b>Null-owner</b> (corruption): normalized to the {@code __system__}
+     *       owner and added to the {@code webhooks:__system__} dispatch index so
+     *       it is a well-classified system subscription rather than limbo
+     *       (exempt from repair yet absent from every dispatch index).
+     *       {@code NORMALIZED_NULL_OWNER}. (If it is also empty-both it is
+     *       disabled in the same write.)</li>
+     *   <li><b>Concrete-tenant</b> (owner not null/{@code __system__}, per
+     *       {@link WebhookSubscription#isSystemOwner}) carrying admin-only
+     *       {@code event_types} and/or {@code event_categories}: those admin
+     *       selectors are STRIPPED, tenant-accessible ones kept →
+     *       {@code STRIPPED_ADMIN_SELECTORS}. If stripping empties BOTH lists the
+     *       row would match every event, so it is DISABLED →
+     *       {@code STRIPPED_AND_DISABLED}.</li>
      *   <li><b>Any</b> row (including {@code __system__}) that is empty-both — no
      *       {@code event_types} AND no {@code event_categories}, i.e. match-ALL →
      *       {@code DISABLED_EMPTY_BOTH}. The system carve-out exempts admin
-     *       SELECTORS only; it does not exempt a row from the universal
-     *       "at least one selector" invariant.</li>
+     *       SELECTORS only, not the universal "at least one selector" invariant.</li>
      * </ul>
-     *
-     * <p><b>Conservative:</b> offenders are DISABLED, never silently stripped —
-     * a concrete-tenant admin-selector row might be a legit-but-misconfigured
-     * operator monitoring row, and a silent rewrite would break it with no
-     * signal. Disabling stops delivery immediately (live dispatch AND replay
-     * only deliver to {@code ACTIVE} rows), is reversible, preserves the row +
-     * offending selectors for review, and is loudly logged. The supported
-     * replacement for genuine per-tenant admin monitoring is a
-     * {@code __system__}-owned subscription filtered by {@code event_categories}
-     * (it receives those admin events for ALL tenants, since {@code __system__}
-     * is in every tenant's dispatch union), selecting the target tenant
-     * CLIENT-SIDE on the envelope {@code tenant_id}. ({@code api_key},
-     * {@code webhook} and {@code system} events are null-scoped and cannot be
-     * scope-filtered; {@code policy} events carry a real tenant-bounded scope
-     * and CAN be scope-filtered.)
+     * Every action is loudly logged for operator visibility.
      *
      * <p><b>Robust:</b> SSCANs the global index in batches (bounded memory, no
      * whole-keyspace SMEMBERS), writes via an atomic compare-and-set (never
-     * clobbers a concurrent update — a CAS miss is a concurrent-skip counted as
-     * a failure and retried next pass), and skips already-{@code DISABLED}
-     * offenders (idempotent). Never throws.
+     * clobbers a concurrent update — a CAS miss is counted as a failure and
+     * retried next pass). Never throws.
      *
-     * @param dryRun when true, compute + log offenders but mutate nothing
+     * @param dryRun when true, compute + log the actions but mutate nothing
      */
     public ReconcileResult reconcileTenantCategoryBoundary(boolean dryRun) {
         List<CategoryBoundaryRepairOutcome> repaired = new ArrayList<>();
@@ -245,60 +243,70 @@ public class WebhookRepository {
                         String data = jedis.get("webhook:" + id);
                         if (data == null) continue;
                         WebhookSubscription sub = objectMapper.readValue(data, WebhookSubscription.class);
-                        // Already-disabled offenders need no action (idempotent).
-                        if (sub.getStatus() == WebhookStatus.DISABLED) continue;
+                        if (sub.getStatus() == WebhookStatus.DISABLED) continue; // idempotent
 
-                        boolean system = WebhookSubscription.isSystemOwner(sub.getTenantId());
+                        boolean nullOwner = sub.getTenantId() == null;
+                        // Normalize null owner → __system__ (corruption fix); the row is then
+                        // system-owned for the boundary logic below.
+                        String effectiveOwner = nullOwner ? WebhookSubscription.SYSTEM_TENANT : sub.getTenantId();
+                        boolean system = WebhookSubscription.isSystemOwner(effectiveOwner);
 
-                        // Admin selectors only flag CONCRETE-owner rows.
-                        List<String> offending = new ArrayList<>();
+                        // Concrete-tenant rows: strip admin-only selectors (dispatch already
+                        // blocks their delivery, so this only reconciles storage).
+                        List<String> stripped = new ArrayList<>();
                         if (!system) {
                             List<EventType> types = sub.getEventTypes();
-                            if (types != null) {
-                                for (EventType t : types) {
-                                    if (!t.isTenantAccessible()) offending.add(t.getValue());
-                                }
+                            List<EventCategory> cats = sub.getEventCategories();
+                            List<EventType> keptTypes = new ArrayList<>();
+                            List<EventCategory> keptCats = new ArrayList<>();
+                            if (types != null) for (EventType t : types) {
+                                if (t.isTenantAccessible()) keptTypes.add(t); else stripped.add(t.getValue());
                             }
-                            List<EventCategory> cats0 = sub.getEventCategories();
-                            if (cats0 != null) {
-                                for (EventCategory c : cats0) {
-                                    if (!c.isTenantAccessible()) offending.add(c.getValue());
-                                }
+                            if (cats != null) for (EventCategory c : cats) {
+                                if (c.isTenantAccessible()) keptCats.add(c); else stripped.add(c.getValue());
+                            }
+                            if (!stripped.isEmpty()) {
+                                sub.setEventTypes(keptTypes.isEmpty() ? null : keptTypes);
+                                sub.setEventCategories(keptCats.isEmpty() ? null : keptCats);
                             }
                         }
-                        boolean hasAdminSelectors = !offending.isEmpty();
+                        boolean didStrip = !stripped.isEmpty();
 
-                        // Empty-both applies to ALL rows, __system__ included.
+                        // Empty-both computed on the RESULTING selectors (after any strip).
                         List<EventType> t2 = sub.getEventTypes();
                         List<EventCategory> c2 = sub.getEventCategories();
                         boolean emptyBoth = (t2 == null || t2.isEmpty()) && (c2 == null || c2.isEmpty());
+                        boolean disable = emptyBoth; // was ACTIVE/PAUSED (DISABLED skipped above)
 
-                        if (!hasAdminSelectors && !emptyBoth) continue; // clean row
+                        boolean changed = nullOwner || didStrip || disable;
+                        if (!changed) continue; // clean row
 
-                        CategoryBoundaryAction action = hasAdminSelectors
-                            ? CategoryBoundaryAction.DISABLED_ADMIN_SELECTORS
-                            : CategoryBoundaryAction.DISABLED_EMPTY_BOTH;
+                        CategoryBoundaryAction action;
+                        if (didStrip && disable) action = CategoryBoundaryAction.STRIPPED_AND_DISABLED;
+                        else if (didStrip)       action = CategoryBoundaryAction.STRIPPED_ADMIN_SELECTORS;
+                        else if (disable)        action = CategoryBoundaryAction.DISABLED_EMPTY_BOTH;
+                        else                     action = CategoryBoundaryAction.NORMALIZED_NULL_OWNER;
 
                         if (!dryRun) {
-                            // DISABLE only — do NOT strip. Selectors left intact for review.
-                            sub.setStatus(WebhookStatus.DISABLED);
+                            if (nullOwner) sub.setTenantId(WebhookSubscription.SYSTEM_TENANT);
+                            if (disable) sub.setStatus(WebhookStatus.DISABLED);
                             sub.setUpdatedAt(Instant.now());
                             String newJson = objectMapper.writeValueAsString(sub);
                             Object casRes = jedis.eval(CAS_SET_LUA, List.of("webhook:" + id),
                                 List.of(data, newJson));
                             if (!Long.valueOf(1L).equals(casRes)) {
-                                // Concurrent update landed between GET and CAS — skip; retried next pass.
                                 failures++;
                                 LOG.warn("category-boundary reconcile CAS miss (concurrent update), will retry: subscription_id={} tenant_id={}",
-                                    LogSanitizer.safe(id), LogSanitizer.safe(sub.getTenantId()));
+                                    LogSanitizer.safe(id), LogSanitizer.safe(effectiveOwner));
                                 continue;
                             }
+                            if (nullOwner) jedis.sadd("webhooks:" + WebhookSubscription.SYSTEM_TENANT, id);
                         }
 
-                        repaired.add(new CategoryBoundaryRepairOutcome(id, sub.getTenantId(), action, offending));
-                        LOG.warn("category-boundary reconcile {} offender webhook (#209): subscription_id={} tenant_id={} action={} offending_selectors={} — operator action: migrate genuine per-tenant admin monitoring to a __system__ subscription filtered by event_categories, selecting the tenant client-side on the envelope tenant_id (api_key.*/webhook.*/system.* are null-scoped; policy.* is scope-filterable)",
-                            dryRun ? "REPORTED (dry-run)" : "DISABLED",
-                            LogSanitizer.safe(id), LogSanitizer.safe(sub.getTenantId()), action, offending);
+                        repaired.add(new CategoryBoundaryRepairOutcome(id, effectiveOwner, action, stripped));
+                        LOG.warn("category-boundary reconcile {} webhook (#209): subscription_id={} tenant_id={} action={} stripped_selectors={} — dispatch already blocks admin-only delivery to concrete-tenant subs; this reconciles storage.",
+                            dryRun ? "REPORTED (dry-run)" : "repaired",
+                            LogSanitizer.safe(id), LogSanitizer.safe(effectiveOwner), action, stripped);
                     } catch (Exception e) {
                         failures++;
                         LOG.warn("category-boundary reconcile skipped webhook subscription (will retry): subscription_id={} error={}",
@@ -307,8 +315,6 @@ public class WebhookRepository {
                 }
             } while (!ScanParams.SCAN_POINTER_START.equals(cursor));
         } catch (Exception e) {
-            // Whole-pass failure (e.g. Redis unavailable): report incomplete so
-            // the caller retries in the background — do NOT throw.
             failures++;
             LOG.error("category-boundary reconcile pass failed (will retry): error={}",
                 LogSanitizer.safe(e.getMessage()), e);

--- a/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/integration/WebhookCategoryBoundaryReconcileIntegrationTest.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/integration/WebhookCategoryBoundaryReconcileIntegrationTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.runcycles.admin.data.repository.WebhookRepository;
 import io.runcycles.admin.data.repository.WebhookRepository.CategoryBoundaryAction;
 import io.runcycles.admin.data.repository.WebhookRepository.CategoryBoundaryRepairOutcome;
+import io.runcycles.admin.data.repository.WebhookRepository.ReconcileResult;
 import io.runcycles.admin.data.service.CryptoService;
 import io.runcycles.admin.model.event.EventCategory;
 import io.runcycles.admin.model.event.EventType;
@@ -110,58 +111,69 @@ class WebhookCategoryBoundaryReconcileIntegrationTest {
 
     @Test
     void reconcile_seededMix_disablesOffenders_conservatively_andIsIdempotent() {
-        // 1) offender: admin category alongside a legit type → DISABLE (NOT
-        //    stripped: it may be legit-but-misconfigured operator monitoring).
+        // 1) offender: admin CATEGORY alongside a legit type -> DISABLE (not stripped)
         seed("wh_admin_cat", "tenant-1", List.of(EventType.BUDGET_CREATED),
                 List.of(EventCategory.BUDGET, EventCategory.API_KEY), WebhookStatus.ACTIVE);
-        // 2) offender: admin-category-only, no types → DISABLE (admin categories).
-        seed("wh_admin_only", "tenant-2", List.of(),
-                List.of(EventCategory.API_KEY), WebhookStatus.ACTIVE);
-        // 3) legit tenant-accessible categories → untouched
+        // 2) offender: admin-only TYPE (finding 3) -> DISABLE
+        seed("wh_admin_type", "tenant-2", List.of(EventType.API_KEY_CREATED),
+                null, WebhookStatus.ACTIVE);
+        // 3) legit tenant-accessible categories -> untouched
         seed("wh_legit", "tenant-3", List.of(EventType.BUDGET_CREATED),
                 List.of(EventCategory.RESERVATION), WebhookStatus.ACTIVE);
-        // 4) __system__ row with admin categories → NOT tenant-owned, untouched
+        // 4) __system__ row with admin categories -> NOT tenant-owned, untouched
         seed("wh_system", "__system__", List.of(EventType.API_KEY_CREATED),
                 List.of(EventCategory.API_KEY), WebhookStatus.ACTIVE);
-        // 5) pre-existing empty-both (match-ALL) row → DISABLE
+        // 5) tenant empty-both (match-ALL) -> DISABLE
         seed("wh_empty_both", "tenant-4", List.of(), null, WebhookStatus.ACTIVE);
-        // 6) legit types-only → untouched
+        // 6) __system__ empty-both (finding 4) -> DISABLE (carve-out is admin-selectors only)
+        seed("wh_system_empty_both", "__system__", List.of(), null, WebhookStatus.ACTIVE);
+        // 7) null-owner (system per isSystemOwner) with admin category -> untouched for
+        //    admin selectors, but... it is NOT empty-both here, so untouched (finding 6)
+        seed("wh_null_owner", null, List.of(EventType.API_KEY_CREATED),
+                List.of(EventCategory.API_KEY), WebhookStatus.ACTIVE);
+        // 8) legit types-only -> untouched
         seed("wh_types_only", "tenant-5", List.of(EventType.BUDGET_CREATED),
                 null, WebhookStatus.ACTIVE);
-        // 7) already-DISABLED offender → skipped (idempotent)
+        // 9) already-DISABLED offender -> skipped (idempotent)
         seed("wh_already_disabled", "tenant-6", List.of(EventType.BUDGET_CREATED),
                 List.of(EventCategory.POLICY), WebhookStatus.DISABLED);
 
-        List<CategoryBoundaryRepairOutcome> outcomes = webhookRepository.reconcileTenantCategoryBoundary(false);
+        ReconcileResult result = webhookRepository.reconcileTenantCategoryBoundary(false);
+        assertThat(result.isComplete()).isTrue();
+        List<CategoryBoundaryRepairOutcome> outcomes = result.repaired();
 
-        // Exactly the three ACTIVE offenders were disabled.
+        // Offenders disabled: admin-cat, admin-type, tenant empty-both, __system__ empty-both.
         assertThat(outcomes).extracting(CategoryBoundaryRepairOutcome::subscriptionId)
-                .containsExactlyInAnyOrder("wh_admin_cat", "wh_admin_only", "wh_empty_both");
+                .containsExactlyInAnyOrder("wh_admin_cat", "wh_admin_type", "wh_empty_both", "wh_system_empty_both");
 
-        assertThat(outcomeFor(outcomes, "wh_admin_cat").action()).isEqualTo(CategoryBoundaryAction.DISABLED_ADMIN_CATEGORIES);
-        assertThat(outcomeFor(outcomes, "wh_admin_cat").offendingCategories()).containsExactly("api_key");
-        assertThat(outcomeFor(outcomes, "wh_admin_only").action()).isEqualTo(CategoryBoundaryAction.DISABLED_ADMIN_CATEGORIES);
+        assertThat(outcomeFor(outcomes, "wh_admin_cat").action()).isEqualTo(CategoryBoundaryAction.DISABLED_ADMIN_SELECTORS);
+        assertThat(outcomeFor(outcomes, "wh_admin_cat").offendingSelectors()).containsExactly("api_key");
+        assertThat(outcomeFor(outcomes, "wh_admin_type").action()).isEqualTo(CategoryBoundaryAction.DISABLED_ADMIN_SELECTORS);
+        assertThat(outcomeFor(outcomes, "wh_admin_type").offendingSelectors()).containsExactly("api_key.created");
         assertThat(outcomeFor(outcomes, "wh_empty_both").action()).isEqualTo(CategoryBoundaryAction.DISABLED_EMPTY_BOTH);
+        assertThat(outcomeFor(outcomes, "wh_system_empty_both").action()).isEqualTo(CategoryBoundaryAction.DISABLED_EMPTY_BOTH);
 
-        // Offenders DISABLED, categories left INTACT for operator review.
+        // Offenders DISABLED, selectors left INTACT for operator review.
         WebhookSubscription adminCat = read("wh_admin_cat");
         assertThat(adminCat.getStatus()).isEqualTo(WebhookStatus.DISABLED);
-        assertThat(adminCat.getEventCategories()).containsExactly(EventCategory.BUDGET, EventCategory.API_KEY); // NOT stripped
+        assertThat(adminCat.getEventCategories()).containsExactly(EventCategory.BUDGET, EventCategory.API_KEY);
         assertThat(adminCat.getEventTypes()).containsExactly(EventType.BUDGET_CREATED);
-
-        assertThat(read("wh_admin_only").getStatus()).isEqualTo(WebhookStatus.DISABLED);
-        assertThat(read("wh_admin_only").getEventCategories()).containsExactly(EventCategory.API_KEY); // intact
+        assertThat(read("wh_admin_type").getStatus()).isEqualTo(WebhookStatus.DISABLED);
+        assertThat(read("wh_admin_type").getEventTypes()).containsExactly(EventType.API_KEY_CREATED); // intact
         assertThat(read("wh_empty_both").getStatus()).isEqualTo(WebhookStatus.DISABLED);
+        assertThat(read("wh_system_empty_both").getStatus()).isEqualTo(WebhookStatus.DISABLED);
 
         // Untouched rows.
         assertThat(read("wh_legit").getStatus()).isEqualTo(WebhookStatus.ACTIVE);
         assertThat(read("wh_system").getStatus()).isEqualTo(WebhookStatus.ACTIVE);
-        assertThat(read("wh_system").getEventCategories()).containsExactly(EventCategory.API_KEY);
+        assertThat(read("wh_null_owner").getStatus()).isEqualTo(WebhookStatus.ACTIVE); // system-exempt for admin selectors
         assertThat(read("wh_types_only").getStatus()).isEqualTo(WebhookStatus.ACTIVE);
         assertThat(read("wh_already_disabled").getStatus()).isEqualTo(WebhookStatus.DISABLED);
 
-        // Idempotent: a second run finds nothing to disable.
-        assertThat(webhookRepository.reconcileTenantCategoryBoundary(false)).isEmpty();
+        // Idempotent: a second run finds nothing to disable and is complete.
+        ReconcileResult rerun = webhookRepository.reconcileTenantCategoryBoundary(false);
+        assertThat(rerun.repaired()).isEmpty();
+        assertThat(rerun.isComplete()).isTrue();
     }
 
     @Test
@@ -170,10 +182,9 @@ class WebhookCategoryBoundaryReconcileIntegrationTest {
                 List.of(EventCategory.API_KEY), WebhookStatus.ACTIVE);
         seed("wh_empty_both", "tenant-2", List.of(), null, WebhookStatus.ACTIVE);
 
-        List<CategoryBoundaryRepairOutcome> outcomes = webhookRepository.reconcileTenantCategoryBoundary(true);
+        ReconcileResult result = webhookRepository.reconcileTenantCategoryBoundary(true);
 
-        // Reports both offenders...
-        assertThat(outcomes).extracting(CategoryBoundaryRepairOutcome::subscriptionId)
+        assertThat(result.repaired()).extracting(CategoryBoundaryRepairOutcome::subscriptionId)
                 .containsExactlyInAnyOrder("wh_admin_cat", "wh_empty_both");
         // ...but mutates nothing (both still ACTIVE).
         assertThat(read("wh_admin_cat").getStatus()).isEqualTo(WebhookStatus.ACTIVE);
@@ -181,7 +192,26 @@ class WebhookCategoryBoundaryReconcileIntegrationTest {
     }
 
     @Test
+    void reconcile_manyRows_scanBatchingCoversAll() {
+        // Larger set than one SSCAN batch worth to exercise cursor paging.
+        for (int i = 0; i < 250; i++) {
+            seed("wh_ok_" + i, "tenant-x", List.of(EventType.BUDGET_CREATED), null, WebhookStatus.ACTIVE);
+        }
+        seed("wh_off", "tenant-y", List.of(EventType.BUDGET_CREATED),
+                List.of(EventCategory.API_KEY), WebhookStatus.ACTIVE);
+
+        ReconcileResult result = webhookRepository.reconcileTenantCategoryBoundary(false);
+
+        assertThat(result.isComplete()).isTrue();
+        assertThat(result.repaired()).extracting(CategoryBoundaryRepairOutcome::subscriptionId)
+                .containsExactly("wh_off");
+        assertThat(read("wh_off").getStatus()).isEqualTo(WebhookStatus.DISABLED);
+    }
+
+    @Test
     void reconcile_emptyStore_isNoOp() {
-        assertThat(webhookRepository.reconcileTenantCategoryBoundary(false)).isEmpty();
+        ReconcileResult result = webhookRepository.reconcileTenantCategoryBoundary(false);
+        assertThat(result.repaired()).isEmpty();
+        assertThat(result.isComplete()).isTrue();
     }
 }

--- a/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/integration/WebhookCategoryBoundaryReconcileIntegrationTest.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/integration/WebhookCategoryBoundaryReconcileIntegrationTest.java
@@ -1,0 +1,187 @@
+package io.runcycles.admin.data.integration;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.runcycles.admin.data.repository.WebhookRepository;
+import io.runcycles.admin.data.repository.WebhookRepository.CategoryBoundaryAction;
+import io.runcycles.admin.data.repository.WebhookRepository.CategoryBoundaryRepairOutcome;
+import io.runcycles.admin.data.service.CryptoService;
+import io.runcycles.admin.model.event.EventCategory;
+import io.runcycles.admin.model.event.EventType;
+import io.runcycles.admin.model.webhook.WebhookStatus;
+import io.runcycles.admin.model.webhook.WebhookSubscription;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
+
+import java.lang.reflect.Field;
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * #209 (d2) one-time cleanup: {@link WebhookRepository#reconcileTenantCategoryBoundary()}
+ * over a real Redis with a seeded mix of offender / legit / empty-both /
+ * __system__ rows, asserting terminal states and idempotency on re-run.
+ */
+@Testcontainers
+class WebhookCategoryBoundaryReconcileIntegrationTest {
+
+    @Container
+    static GenericContainer<?> redis = new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
+            .withExposedPorts(6379);
+
+    private static JedisPool jedisPool;
+    private static ObjectMapper objectMapper;
+    private static WebhookRepository webhookRepository;
+
+    @BeforeAll
+    static void setupAll() throws Exception {
+        JedisPoolConfig config = new JedisPoolConfig();
+        config.setMaxTotal(10);
+        jedisPool = new JedisPool(config, redis.getHost(), redis.getMappedPort(6379));
+
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+        webhookRepository = new WebhookRepository();
+        inject(webhookRepository, "jedisPool", jedisPool);
+        inject(webhookRepository, "objectMapper", objectMapper);
+        inject(webhookRepository, "cryptoService", new CryptoService(""));
+    }
+
+    @AfterAll
+    static void tearDownAll() {
+        if (jedisPool != null) jedisPool.close();
+    }
+
+    @BeforeEach
+    void flush() {
+        try (Jedis jedis = jedisPool.getResource()) {
+            jedis.flushAll();
+        }
+    }
+
+    private static void inject(Object target, String field, Object value) throws Exception {
+        Field f = target.getClass().getDeclaredField(field);
+        f.setAccessible(true);
+        f.set(target, value);
+    }
+
+    /** Seed a raw subscription row + index membership (mirrors save()'s keys). */
+    private void seed(String id, String tenantId, List<EventType> types,
+                      List<EventCategory> categories, WebhookStatus status) {
+        WebhookSubscription sub = WebhookSubscription.builder()
+                .subscriptionId(id).tenantId(tenantId).url("https://example.com/" + id)
+                .eventTypes(types).eventCategories(categories).status(status)
+                .createdAt(Instant.now()).build();
+        try (Jedis jedis = jedisPool.getResource()) {
+            jedis.set("webhook:" + id, objectMapper.writeValueAsString(sub));
+            jedis.sadd("webhooks:_all", id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private WebhookSubscription read(String id) {
+        try (Jedis jedis = jedisPool.getResource()) {
+            return objectMapper.readValue(jedis.get("webhook:" + id), WebhookSubscription.class);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private CategoryBoundaryRepairOutcome outcomeFor(List<CategoryBoundaryRepairOutcome> outcomes, String id) {
+        return outcomes.stream().filter(o -> o.subscriptionId().equals(id)).findFirst().orElse(null);
+    }
+
+    @Test
+    void reconcile_seededMix_disablesOffenders_conservatively_andIsIdempotent() {
+        // 1) offender: admin category alongside a legit type → DISABLE (NOT
+        //    stripped: it may be legit-but-misconfigured operator monitoring).
+        seed("wh_admin_cat", "tenant-1", List.of(EventType.BUDGET_CREATED),
+                List.of(EventCategory.BUDGET, EventCategory.API_KEY), WebhookStatus.ACTIVE);
+        // 2) offender: admin-category-only, no types → DISABLE (admin categories).
+        seed("wh_admin_only", "tenant-2", List.of(),
+                List.of(EventCategory.API_KEY), WebhookStatus.ACTIVE);
+        // 3) legit tenant-accessible categories → untouched
+        seed("wh_legit", "tenant-3", List.of(EventType.BUDGET_CREATED),
+                List.of(EventCategory.RESERVATION), WebhookStatus.ACTIVE);
+        // 4) __system__ row with admin categories → NOT tenant-owned, untouched
+        seed("wh_system", "__system__", List.of(EventType.API_KEY_CREATED),
+                List.of(EventCategory.API_KEY), WebhookStatus.ACTIVE);
+        // 5) pre-existing empty-both (match-ALL) row → DISABLE
+        seed("wh_empty_both", "tenant-4", List.of(), null, WebhookStatus.ACTIVE);
+        // 6) legit types-only → untouched
+        seed("wh_types_only", "tenant-5", List.of(EventType.BUDGET_CREATED),
+                null, WebhookStatus.ACTIVE);
+        // 7) already-DISABLED offender → skipped (idempotent)
+        seed("wh_already_disabled", "tenant-6", List.of(EventType.BUDGET_CREATED),
+                List.of(EventCategory.POLICY), WebhookStatus.DISABLED);
+
+        List<CategoryBoundaryRepairOutcome> outcomes = webhookRepository.reconcileTenantCategoryBoundary(false);
+
+        // Exactly the three ACTIVE offenders were disabled.
+        assertThat(outcomes).extracting(CategoryBoundaryRepairOutcome::subscriptionId)
+                .containsExactlyInAnyOrder("wh_admin_cat", "wh_admin_only", "wh_empty_both");
+
+        assertThat(outcomeFor(outcomes, "wh_admin_cat").action()).isEqualTo(CategoryBoundaryAction.DISABLED_ADMIN_CATEGORIES);
+        assertThat(outcomeFor(outcomes, "wh_admin_cat").offendingCategories()).containsExactly("api_key");
+        assertThat(outcomeFor(outcomes, "wh_admin_only").action()).isEqualTo(CategoryBoundaryAction.DISABLED_ADMIN_CATEGORIES);
+        assertThat(outcomeFor(outcomes, "wh_empty_both").action()).isEqualTo(CategoryBoundaryAction.DISABLED_EMPTY_BOTH);
+
+        // Offenders DISABLED, categories left INTACT for operator review.
+        WebhookSubscription adminCat = read("wh_admin_cat");
+        assertThat(adminCat.getStatus()).isEqualTo(WebhookStatus.DISABLED);
+        assertThat(adminCat.getEventCategories()).containsExactly(EventCategory.BUDGET, EventCategory.API_KEY); // NOT stripped
+        assertThat(adminCat.getEventTypes()).containsExactly(EventType.BUDGET_CREATED);
+
+        assertThat(read("wh_admin_only").getStatus()).isEqualTo(WebhookStatus.DISABLED);
+        assertThat(read("wh_admin_only").getEventCategories()).containsExactly(EventCategory.API_KEY); // intact
+        assertThat(read("wh_empty_both").getStatus()).isEqualTo(WebhookStatus.DISABLED);
+
+        // Untouched rows.
+        assertThat(read("wh_legit").getStatus()).isEqualTo(WebhookStatus.ACTIVE);
+        assertThat(read("wh_system").getStatus()).isEqualTo(WebhookStatus.ACTIVE);
+        assertThat(read("wh_system").getEventCategories()).containsExactly(EventCategory.API_KEY);
+        assertThat(read("wh_types_only").getStatus()).isEqualTo(WebhookStatus.ACTIVE);
+        assertThat(read("wh_already_disabled").getStatus()).isEqualTo(WebhookStatus.DISABLED);
+
+        // Idempotent: a second run finds nothing to disable.
+        assertThat(webhookRepository.reconcileTenantCategoryBoundary(false)).isEmpty();
+    }
+
+    @Test
+    void reconcile_dryRun_reportsOffenders_withoutMutating() {
+        seed("wh_admin_cat", "tenant-1", List.of(EventType.BUDGET_CREATED),
+                List.of(EventCategory.API_KEY), WebhookStatus.ACTIVE);
+        seed("wh_empty_both", "tenant-2", List.of(), null, WebhookStatus.ACTIVE);
+
+        List<CategoryBoundaryRepairOutcome> outcomes = webhookRepository.reconcileTenantCategoryBoundary(true);
+
+        // Reports both offenders...
+        assertThat(outcomes).extracting(CategoryBoundaryRepairOutcome::subscriptionId)
+                .containsExactlyInAnyOrder("wh_admin_cat", "wh_empty_both");
+        // ...but mutates nothing (both still ACTIVE).
+        assertThat(read("wh_admin_cat").getStatus()).isEqualTo(WebhookStatus.ACTIVE);
+        assertThat(read("wh_empty_both").getStatus()).isEqualTo(WebhookStatus.ACTIVE);
+    }
+
+    @Test
+    void reconcile_emptyStore_isNoOp() {
+        assertThat(webhookRepository.reconcileTenantCategoryBoundary(false)).isEmpty();
+    }
+}

--- a/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/integration/WebhookCategoryBoundaryReconcileIntegrationTest.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/integration/WebhookCategoryBoundaryReconcileIntegrationTest.java
@@ -110,25 +110,24 @@ class WebhookCategoryBoundaryReconcileIntegrationTest {
     }
 
     @Test
-    void reconcile_seededMix_disablesOffenders_conservatively_andIsIdempotent() {
-        // 1) offender: admin CATEGORY alongside a legit type -> DISABLE (not stripped)
+    void reconcile_seededMix_stripsAndDisables_conservatively_andIsIdempotent() {
+        // 1) concrete admin CATEGORY alongside a legit type -> STRIP admin cat, stay ACTIVE
         seed("wh_admin_cat", "tenant-1", List.of(EventType.BUDGET_CREATED),
                 List.of(EventCategory.BUDGET, EventCategory.API_KEY), WebhookStatus.ACTIVE);
-        // 2) offender: admin-only TYPE (finding 3) -> DISABLE
+        // 2) concrete admin-only TYPE, no other selector -> strip empties both -> DISABLE
         seed("wh_admin_type", "tenant-2", List.of(EventType.API_KEY_CREATED),
                 null, WebhookStatus.ACTIVE);
         // 3) legit tenant-accessible categories -> untouched
         seed("wh_legit", "tenant-3", List.of(EventType.BUDGET_CREATED),
                 List.of(EventCategory.RESERVATION), WebhookStatus.ACTIVE);
-        // 4) __system__ row with admin categories -> NOT tenant-owned, untouched
+        // 4) __system__ row with admin categories -> untouched (not tenant-owned)
         seed("wh_system", "__system__", List.of(EventType.API_KEY_CREATED),
                 List.of(EventCategory.API_KEY), WebhookStatus.ACTIVE);
         // 5) tenant empty-both (match-ALL) -> DISABLE
         seed("wh_empty_both", "tenant-4", List.of(), null, WebhookStatus.ACTIVE);
-        // 6) __system__ empty-both (finding 4) -> DISABLE (carve-out is admin-selectors only)
+        // 6) __system__ empty-both -> DISABLE (carve-out is admin-selectors only)
         seed("wh_system_empty_both", "__system__", List.of(), null, WebhookStatus.ACTIVE);
-        // 7) null-owner (system per isSystemOwner) with admin category -> untouched for
-        //    admin selectors, but... it is NOT empty-both here, so untouched (finding 6)
+        // 7) null-owner -> normalized to __system__ (+ index), selectors intact
         seed("wh_null_owner", null, List.of(EventType.API_KEY_CREATED),
                 List.of(EventCategory.API_KEY), WebhookStatus.ACTIVE);
         // 8) legit types-only -> untouched
@@ -142,70 +141,126 @@ class WebhookCategoryBoundaryReconcileIntegrationTest {
         assertThat(result.isComplete()).isTrue();
         List<CategoryBoundaryRepairOutcome> outcomes = result.repaired();
 
-        // Offenders disabled: admin-cat, admin-type, tenant empty-both, __system__ empty-both.
         assertThat(outcomes).extracting(CategoryBoundaryRepairOutcome::subscriptionId)
-                .containsExactlyInAnyOrder("wh_admin_cat", "wh_admin_type", "wh_empty_both", "wh_system_empty_both");
+                .containsExactlyInAnyOrder("wh_admin_cat", "wh_admin_type", "wh_empty_both",
+                        "wh_system_empty_both", "wh_null_owner");
 
-        assertThat(outcomeFor(outcomes, "wh_admin_cat").action()).isEqualTo(CategoryBoundaryAction.DISABLED_ADMIN_SELECTORS);
-        assertThat(outcomeFor(outcomes, "wh_admin_cat").offendingSelectors()).containsExactly("api_key");
-        assertThat(outcomeFor(outcomes, "wh_admin_type").action()).isEqualTo(CategoryBoundaryAction.DISABLED_ADMIN_SELECTORS);
-        assertThat(outcomeFor(outcomes, "wh_admin_type").offendingSelectors()).containsExactly("api_key.created");
+        assertThat(outcomeFor(outcomes, "wh_admin_cat").action()).isEqualTo(CategoryBoundaryAction.STRIPPED_ADMIN_SELECTORS);
+        assertThat(outcomeFor(outcomes, "wh_admin_cat").strippedSelectors()).containsExactly("api_key");
+        assertThat(outcomeFor(outcomes, "wh_admin_type").action()).isEqualTo(CategoryBoundaryAction.STRIPPED_AND_DISABLED);
         assertThat(outcomeFor(outcomes, "wh_empty_both").action()).isEqualTo(CategoryBoundaryAction.DISABLED_EMPTY_BOTH);
         assertThat(outcomeFor(outcomes, "wh_system_empty_both").action()).isEqualTo(CategoryBoundaryAction.DISABLED_EMPTY_BOTH);
+        assertThat(outcomeFor(outcomes, "wh_null_owner").action()).isEqualTo(CategoryBoundaryAction.NORMALIZED_NULL_OWNER);
 
-        // Offenders DISABLED, selectors left INTACT for operator review.
+        // Persisted states.
         WebhookSubscription adminCat = read("wh_admin_cat");
-        assertThat(adminCat.getStatus()).isEqualTo(WebhookStatus.DISABLED);
-        assertThat(adminCat.getEventCategories()).containsExactly(EventCategory.BUDGET, EventCategory.API_KEY);
-        assertThat(adminCat.getEventTypes()).containsExactly(EventType.BUDGET_CREATED);
+        assertThat(adminCat.getStatus()).isEqualTo(WebhookStatus.ACTIVE);
+        assertThat(adminCat.getEventCategories()).containsExactly(EventCategory.BUDGET); // admin stripped
+        assertThat(adminCat.getEventTypes()).containsExactly(EventType.BUDGET_CREATED);  // kept
         assertThat(read("wh_admin_type").getStatus()).isEqualTo(WebhookStatus.DISABLED);
-        assertThat(read("wh_admin_type").getEventTypes()).containsExactly(EventType.API_KEY_CREATED); // intact
         assertThat(read("wh_empty_both").getStatus()).isEqualTo(WebhookStatus.DISABLED);
         assertThat(read("wh_system_empty_both").getStatus()).isEqualTo(WebhookStatus.DISABLED);
 
-        // Untouched rows.
+        WebhookSubscription normalized = read("wh_null_owner");
+        assertThat(normalized.getTenantId()).isEqualTo("__system__");
+        assertThat(normalized.getStatus()).isEqualTo(WebhookStatus.ACTIVE);
+        assertThat(normalized.getEventCategories()).containsExactly(EventCategory.API_KEY); // intact (now system)
+        try (Jedis jedis = jedisPool.getResource()) {
+            assertThat(jedis.sismember("webhooks:__system__", "wh_null_owner")).isTrue();
+        }
+
+        // Untouched.
         assertThat(read("wh_legit").getStatus()).isEqualTo(WebhookStatus.ACTIVE);
         assertThat(read("wh_system").getStatus()).isEqualTo(WebhookStatus.ACTIVE);
-        assertThat(read("wh_null_owner").getStatus()).isEqualTo(WebhookStatus.ACTIVE); // system-exempt for admin selectors
         assertThat(read("wh_types_only").getStatus()).isEqualTo(WebhookStatus.ACTIVE);
         assertThat(read("wh_already_disabled").getStatus()).isEqualTo(WebhookStatus.DISABLED);
 
-        // Idempotent: a second run finds nothing to disable and is complete.
+        // Idempotent: a second run reconciles nothing (all offenders repaired).
         ReconcileResult rerun = webhookRepository.reconcileTenantCategoryBoundary(false);
         assertThat(rerun.repaired()).isEmpty();
         assertThat(rerun.isComplete()).isTrue();
     }
 
     @Test
-    void reconcile_dryRun_reportsOffenders_withoutMutating() {
+    void reconcile_dryRun_reportsWithoutMutating() {
         seed("wh_admin_cat", "tenant-1", List.of(EventType.BUDGET_CREATED),
-                List.of(EventCategory.API_KEY), WebhookStatus.ACTIVE);
-        seed("wh_empty_both", "tenant-2", List.of(), null, WebhookStatus.ACTIVE);
+                List.of(EventCategory.BUDGET, EventCategory.API_KEY), WebhookStatus.ACTIVE);
 
         ReconcileResult result = webhookRepository.reconcileTenantCategoryBoundary(true);
 
         assertThat(result.repaired()).extracting(CategoryBoundaryRepairOutcome::subscriptionId)
-                .containsExactlyInAnyOrder("wh_admin_cat", "wh_empty_both");
-        // ...but mutates nothing (both still ACTIVE).
+                .containsExactly("wh_admin_cat");
+        // Unchanged: admin category still present, still ACTIVE.
+        assertThat(read("wh_admin_cat").getEventCategories())
+                .containsExactly(EventCategory.BUDGET, EventCategory.API_KEY);
         assertThat(read("wh_admin_cat").getStatus()).isEqualTo(WebhookStatus.ACTIVE);
-        assertThat(read("wh_empty_both").getStatus()).isEqualTo(WebhookStatus.ACTIVE);
     }
 
     @Test
-    void reconcile_manyRows_scanBatchingCoversAll() {
-        // Larger set than one SSCAN batch worth to exercise cursor paging.
-        for (int i = 0; i < 250; i++) {
+    void reconcile_manyRows_spansMultipleSscanCursors() {
+        // Force a small SSCAN batch so the sweep must page across cursors.
+        // (RECONCILE_SCAN_BATCH is a COUNT hint; 600 members over a batch of 200
+        // means several SSCAN round-trips — a single-batch bug would miss rows.)
+        for (int i = 0; i < 600; i++) {
             seed("wh_ok_" + i, "tenant-x", List.of(EventType.BUDGET_CREATED), null, WebhookStatus.ACTIVE);
         }
-        seed("wh_off", "tenant-y", List.of(EventType.BUDGET_CREATED),
-                List.of(EventCategory.API_KEY), WebhookStatus.ACTIVE);
+        seed("wh_off_a", "tenant-y", List.of(EventType.API_KEY_CREATED), null, WebhookStatus.ACTIVE);
+        seed("wh_off_b", "tenant-z", List.of(), null, WebhookStatus.ACTIVE);
 
         ReconcileResult result = webhookRepository.reconcileTenantCategoryBoundary(false);
 
         assertThat(result.isComplete()).isTrue();
         assertThat(result.repaired()).extracting(CategoryBoundaryRepairOutcome::subscriptionId)
-                .containsExactly("wh_off");
-        assertThat(read("wh_off").getStatus()).isEqualTo(WebhookStatus.DISABLED);
+                .containsExactlyInAnyOrder("wh_off_a", "wh_off_b");
+        assertThat(read("wh_off_a").getStatus()).isEqualTo(WebhookStatus.DISABLED); // admin type → strip empties → disable
+        assertThat(read("wh_off_b").getStatus()).isEqualTo(WebhookStatus.DISABLED); // empty-both
+    }
+
+    @Test
+    void reconcile_concurrentUpdate_casMiss_noClobber_notComplete() throws Exception {
+        // Real-Redis CAS test: mutate the row AFTER the reconciler read it. We
+        // stage the concurrent write by overriding get() through a wrapper is
+        // hard here, so instead we prove the Lua CAS semantics directly: a row
+        // whose stored value differs from the value the reconciler serialized-from
+        // must NOT be overwritten. We simulate by seeding, capturing the raw JSON,
+        // then changing the row, then invoking a CAS with the STALE old-value.
+        seed("wh_cas", "tenant-1", List.of(EventType.BUDGET_CREATED),
+                List.of(EventCategory.API_KEY), WebhookStatus.ACTIVE);
+        String stale;
+        try (Jedis jedis = jedisPool.getResource()) {
+            stale = jedis.get("webhook:wh_cas");
+            // Concurrent operator update lands (changes the row).
+            jedis.set("webhook:wh_cas", stale.replace("https://example.com/", "https://changed.example.com/"));
+        }
+        // A reconcile pass now reads the CHANGED value, so its CAS old-value
+        // matches current → it WOULD write. To exercise the miss path we prove
+        // the Lua directly: CAS with the stale value must return 0 and not write.
+        try (Jedis jedis = jedisPool.getResource()) {
+            Object res = jedis.eval(
+                "if redis.call('GET', KEYS[1]) == ARGV[1] then redis.call('SET', KEYS[1], ARGV[2]) return 1 else return 0 end",
+                List.of("webhook:wh_cas"), List.of(stale, "{}"));
+            assertThat(res).isEqualTo(0L);
+            assertThat(jedis.get("webhook:wh_cas")).contains("https://changed.example.com/"); // not clobbered
+        }
+        // And a normal reconcile pass (reading the current value) succeeds.
+        ReconcileResult result = webhookRepository.reconcileTenantCategoryBoundary(false);
+        assertThat(result.isComplete()).isTrue();
+        assertThat(read("wh_cas").getEventCategories()).isNullOrEmpty(); // admin category stripped
+    }
+
+    @Test
+    void reconcile_blankOwner_isConcrete_stripped() {
+        // Finding 5 at the data layer: a blank (whitespace-only) owner is NOT
+        // system — it is concrete, so admin selectors are stripped.
+        seed("wh_blank", "   ", List.of(EventType.BUDGET_CREATED),
+                List.of(EventCategory.API_KEY), WebhookStatus.ACTIVE);
+
+        ReconcileResult result = webhookRepository.reconcileTenantCategoryBoundary(false);
+
+        assertThat(outcomeFor(result.repaired(), "wh_blank").action())
+                .isEqualTo(CategoryBoundaryAction.STRIPPED_ADMIN_SELECTORS);
+        assertThat(read("wh_blank").getEventCategories()).isNullOrEmpty();
+        assertThat(read("wh_blank").getEventTypes()).containsExactly(EventType.BUDGET_CREATED);
     }
 
     @Test

--- a/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/integration/WebhookCategoryBoundaryReconcileIntegrationTest.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/integration/WebhookCategoryBoundaryReconcileIntegrationTest.java
@@ -24,6 +24,8 @@ import org.testcontainers.utility.DockerImageName;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
+import redis.clients.jedis.params.ScanParams;
+import redis.clients.jedis.resps.ScanResult;
 
 import java.lang.reflect.Field;
 import java.time.Instant;
@@ -92,6 +94,9 @@ class WebhookCategoryBoundaryReconcileIntegrationTest {
         try (Jedis jedis = jedisPool.getResource()) {
             jedis.set("webhook:" + id, objectMapper.writeValueAsString(sub));
             jedis.sadd("webhooks:_all", id);
+            // Mirror production save(): also index by owning tenant (incl.
+            // __system__). Null owner is the corruption case — left unindexed.
+            if (tenantId != null) jedis.sadd("webhooks:" + tenantId, id);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -207,6 +212,20 @@ class WebhookCategoryBoundaryReconcileIntegrationTest {
         seed("wh_off_a", "tenant-y", List.of(EventType.API_KEY_CREATED), null, WebhookStatus.ACTIVE);
         seed("wh_off_b", "tenant-z", List.of(), null, WebhookStatus.ACTIVE);
 
+        // Assert the index genuinely spans MULTIPLE SSCAN cursors at the
+        // production COUNT — otherwise a single-batch bug wouldn't be caught.
+        int roundTrips = 0;
+        String cur = ScanParams.SCAN_POINTER_START;
+        try (Jedis jedis = jedisPool.getResource()) {
+            ScanParams p = new ScanParams().count(WebhookRepository.reconcileScanBatch());
+            do {
+                ScanResult<String> s = jedis.sscan("webhooks:_all", cur, p);
+                cur = s.getCursor();
+                roundTrips++;
+            } while (!cur.equals(ScanParams.SCAN_POINTER_START));
+        }
+        assertThat(roundTrips).isGreaterThan(1);
+
         ReconcileResult result = webhookRepository.reconcileTenantCategoryBoundary(false);
 
         assertThat(result.isComplete()).isTrue();
@@ -233,12 +252,14 @@ class WebhookCategoryBoundaryReconcileIntegrationTest {
             jedis.set("webhook:wh_cas", stale.replace("https://example.com/", "https://changed.example.com/"));
         }
         // A reconcile pass now reads the CHANGED value, so its CAS old-value
-        // matches current → it WOULD write. To exercise the miss path we prove
-        // the Lua directly: CAS with the stale value must return 0 and not write.
+        // matches current → it WOULD write. To exercise the miss path we invoke
+        // the ACTUAL production script (not a hand-copied string, so drift is
+        // caught): CAS with the stale value must return 0 and not write.
         try (Jedis jedis = jedisPool.getResource()) {
             Object res = jedis.eval(
-                "if redis.call('GET', KEYS[1]) == ARGV[1] then redis.call('SET', KEYS[1], ARGV[2]) return 1 else return 0 end",
-                List.of("webhook:wh_cas"), List.of(stale, "{}"));
+                WebhookRepository.reconcileCasSetAndIndexScript(),
+                List.of("webhook:wh_cas", "webhooks:__system__"),
+                List.of(stale, "{}", "0", "wh_cas"));
             assertThat(res).isEqualTo(0L);
             assertThat(jedis.get("webhook:wh_cas")).contains("https://changed.example.com/"); // not clobbered
         }
@@ -261,6 +282,56 @@ class WebhookCategoryBoundaryReconcileIntegrationTest {
                 .isEqualTo(CategoryBoundaryAction.STRIPPED_ADMIN_SELECTORS);
         assertThat(read("wh_blank").getEventCategories()).isNullOrEmpty();
         assertThat(read("wh_blank").getEventTypes()).containsExactly(EventType.BUDGET_CREATED);
+    }
+
+    // #209 finding 2 (real Redis): a DISABLED null-owner row is still normalized
+    // to __system__ and indexed atomically, and stays DISABLED.
+    @Test
+    void reconcile_disabledNullOwner_normalizedAndIndexed_staysDisabled() {
+        seed("wh_dnull", null, List.of(EventType.API_KEY_CREATED),
+                List.of(EventCategory.API_KEY), WebhookStatus.DISABLED);
+
+        ReconcileResult result = webhookRepository.reconcileTenantCategoryBoundary(false);
+
+        assertThat(outcomeFor(result.repaired(), "wh_dnull").action())
+                .isEqualTo(CategoryBoundaryAction.NORMALIZED_NULL_OWNER);
+        WebhookSubscription w = read("wh_dnull");
+        assertThat(w.getTenantId()).isEqualTo("__system__");
+        assertThat(w.getStatus()).isEqualTo(WebhookStatus.DISABLED);
+        try (Jedis jedis = jedisPool.getResource()) {
+            assertThat(jedis.sismember("webhooks:__system__", "wh_dnull")).isTrue();
+        }
+    }
+
+    // #209 finding 2 (real Redis): a system-owned row present in webhooks:_all
+    // but MISSING from webhooks:__system__ (a prior partial normalization) has
+    // its index membership repaired, independent of status.
+    @Test
+    void reconcile_systemRowMissingFromIndex_membershipRepaired() {
+        // Seed directly into _all WITHOUT the __system__ index (simulate the
+        // partial-failure state the old non-atomic code could leave behind).
+        WebhookSubscription sub = WebhookSubscription.builder()
+                .subscriptionId("wh_orphan").tenantId("__system__")
+                .url("https://example.com/wh_orphan")
+                .eventCategories(List.of(EventCategory.API_KEY))
+                .status(WebhookStatus.ACTIVE).createdAt(Instant.now()).build();
+        try (Jedis jedis = jedisPool.getResource()) {
+            jedis.set("webhook:wh_orphan", objectMapper.writeValueAsString(sub));
+            jedis.sadd("webhooks:_all", "wh_orphan");
+            assertThat(jedis.sismember("webhooks:__system__", "wh_orphan")).isFalse();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        ReconcileResult result = webhookRepository.reconcileTenantCategoryBoundary(false);
+
+        assertThat(outcomeFor(result.repaired(), "wh_orphan").action())
+                .isEqualTo(CategoryBoundaryAction.INDEXED_SYSTEM_MEMBER);
+        try (Jedis jedis = jedisPool.getResource()) {
+            assertThat(jedis.sismember("webhooks:__system__", "wh_orphan")).isTrue();
+        }
+        // Idempotent: a second pass sees it indexed and does nothing.
+        assertThat(webhookRepository.reconcileTenantCategoryBoundary(false).repaired()).isEmpty();
     }
 
     @Test

--- a/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/EventRepositoryTest.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/EventRepositoryTest.java
@@ -163,6 +163,60 @@ class EventRepositoryTest {
                 });
     }
 
+    // ---- listEventIdsInRange() / hydrateByIds() (replay approach B) ----
+
+    @Test
+    void listEventIdsInRange_tenant_usesZrangeByScoreAscending() {
+        when(jedis.zrangeByScore(eq("events:tenant-1"), anyDouble(), anyDouble(), eq(0), eq(500)))
+                .thenReturn(List.of("evt_a", "evt_b", "evt_c"));
+
+        List<String> ids = repository.listEventIdsInRange("tenant-1",
+                Instant.ofEpochMilli(1000), Instant.ofEpochMilli(2000), 500);
+
+        assertThat(ids).containsExactly("evt_a", "evt_b", "evt_c"); // order preserved
+        verify(jedis).zrangeByScore(eq("events:tenant-1"), eq(1000.0), eq(2000.0), eq(0), eq(500));
+    }
+
+    @Test
+    void listEventIdsInRange_nullTenant_usesGlobalIndex_andInfinities() {
+        when(jedis.zrangeByScore(eq("events:_all"), eq(Double.NEGATIVE_INFINITY),
+                eq(Double.POSITIVE_INFINITY), eq(0), eq(100))).thenReturn(List.of("evt_x"));
+
+        List<String> ids = repository.listEventIdsInRange(null, null, null, 100);
+
+        assertThat(ids).containsExactly("evt_x");
+    }
+
+    @Test
+    void listEventIdsInRange_nonPositiveMax_returnsEmpty_noRedis() {
+        assertThat(repository.listEventIdsInRange("tenant-1", null, null, 0)).isEmpty();
+        verify(jedis, never()).zrangeByScore(anyString(), anyDouble(), anyDouble(), anyInt(), anyInt());
+    }
+
+    @Test
+    void hydrateByIds_dropsMissingAndCorrupt_preservesOrderOfRest() throws Exception {
+        Event e1 = Event.builder().eventId("evt_1").tenantId("t").eventType(EventType.BUDGET_CREATED)
+                .category(EventCategory.BUDGET).source("s").timestamp(Instant.now()).build();
+        Event e3 = Event.builder().eventId("evt_3").tenantId("t").eventType(EventType.BUDGET_CREATED)
+                .category(EventCategory.BUDGET).source("s").timestamp(Instant.now()).build();
+        String e1Json = objectMapper.writeValueAsString(e1);
+        String e3Json = objectMapper.writeValueAsString(e3);
+        when(jedis.get("event:evt_1")).thenReturn(e1Json);
+        when(jedis.get("event:evt_2")).thenReturn(null);        // expired/missing → dropped
+        when(jedis.get("event:evt_3")).thenReturn(e3Json);
+        when(jedis.get("event:evt_4")).thenReturn("{not-json"); // corrupt → dropped, not thrown
+
+        List<Event> events = repository.hydrateByIds(List.of("evt_1", "evt_2", "evt_3", "evt_4"));
+
+        assertThat(events).extracting(Event::getEventId).containsExactly("evt_1", "evt_3");
+    }
+
+    @Test
+    void hydrateByIds_empty_returnsEmpty_noRedis() {
+        assertThat(repository.hydrateByIds(List.of())).isEmpty();
+        verify(jedis, never()).get(anyString());
+    }
+
     // ---- list() ----
 
     @Test

--- a/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/WebhookRepositoryTest.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/WebhookRepositoryTest.java
@@ -1314,4 +1314,212 @@ class WebhookRepositoryTest {
         assertThat(outcomes).hasSize(1);
         assertThat(outcomes.get(0).subscriptionId()).isEqualTo("whsub_1");
     }
+
+    // ---- reconcileTenantCategoryBoundary (#209 d2 cleanup) ----
+    // Mocked-Jedis coverage (the real-Redis behavior lives in
+    // WebhookCategoryBoundaryReconcileIntegrationTest, which CI's unit job
+    // excludes) so every branch runs in the default -Dtest=!*IntegrationTest job.
+    // The reconciler SSCANs webhooks:_all and writes via an atomic CAS eval.
+
+    /** Build the row JSON BEFORE when() (objectMapper is a @Spy — nested-stubbing guard). */
+    private String rowJson(String id, String tenantId, java.util.List<EventType> types,
+                           java.util.List<EventCategory> cats, WebhookStatus status) throws Exception {
+        return objectMapper.writeValueAsString(WebhookSubscription.builder()
+                .subscriptionId(id).tenantId(tenantId).url("https://x/" + id)
+                .eventTypes(types).eventCategories(cats).status(status)
+                .createdAt(Instant.now()).consecutiveFailures(0).build());
+    }
+
+    /** Stub the single-batch SSCAN over webhooks:_all returning the given ids. */
+    private void stubScan(String... ids) {
+        when(jedis.sscan(eq("webhooks:_all"), anyString(),
+                any(redis.clients.jedis.params.ScanParams.class)))
+                .thenReturn(new redis.clients.jedis.resps.ScanResult<>("0", List.of(ids)));
+    }
+
+    private void stubGet(String id, String json) {
+        when(jedis.get("webhook:" + id)).thenReturn(json);
+    }
+
+    @org.junit.jupiter.api.BeforeEach
+    void stubCasSuccessByDefault() {
+        // CAS eval returns 1 (write applied) unless a test overrides it.
+        lenient().when(jedis.eval(anyString(), anyList(), anyList())).thenReturn(1L);
+    }
+
+    @Test
+    void reconcile_emptyIndex_completeNoRepairs() {
+        stubScan();
+        WebhookRepository.ReconcileResult r = repository.reconcileTenantCategoryBoundary(false);
+        assertThat(r.repaired()).isEmpty();
+        assertThat(r.isComplete()).isTrue();
+        verify(jedis, never()).eval(anyString(), anyList(), anyList());
+    }
+
+    @Test
+    void reconcile_adminCategoryOffender_disabled_viaCas_selectorsIntact() throws Exception {
+        stubScan("wh_admin");
+        stubGet("wh_admin", rowJson("wh_admin", "tenant-1", List.of(EventType.BUDGET_CREATED),
+                List.of(EventCategory.BUDGET, EventCategory.API_KEY), WebhookStatus.ACTIVE));
+
+        WebhookRepository.ReconcileResult r = repository.reconcileTenantCategoryBoundary(false);
+
+        assertThat(r.isComplete()).isTrue();
+        assertThat(r.repaired()).hasSize(1);
+        assertThat(r.repaired().get(0).action()).isEqualTo(WebhookRepository.CategoryBoundaryAction.DISABLED_ADMIN_SELECTORS);
+        assertThat(r.repaired().get(0).offendingSelectors()).containsExactly("api_key");
+        // CAS write: old value == what we read; new value has DISABLED but keeps both categories.
+        org.mockito.ArgumentCaptor<java.util.List> args = org.mockito.ArgumentCaptor.forClass(java.util.List.class);
+        verify(jedis).eval(anyString(), anyList(), args.capture());
+        String newJson = (String) args.getValue().get(1);
+        WebhookSubscription written = objectMapper.readValue(newJson, WebhookSubscription.class);
+        assertThat(written.getStatus()).isEqualTo(WebhookStatus.DISABLED);
+        assertThat(written.getEventCategories()).containsExactly(EventCategory.BUDGET, EventCategory.API_KEY);
+    }
+
+    @Test
+    void reconcile_adminEventTypeOffender_disabled() throws Exception {
+        // Finding 3: admin-only event TYPE flags a concrete-tenant row.
+        stubScan("wh_type");
+        stubGet("wh_type", rowJson("wh_type", "tenant-1", List.of(EventType.API_KEY_CREATED),
+                null, WebhookStatus.ACTIVE));
+
+        WebhookRepository.ReconcileResult r = repository.reconcileTenantCategoryBoundary(false);
+
+        assertThat(r.repaired()).hasSize(1);
+        assertThat(r.repaired().get(0).action()).isEqualTo(WebhookRepository.CategoryBoundaryAction.DISABLED_ADMIN_SELECTORS);
+        assertThat(r.repaired().get(0).offendingSelectors()).containsExactly("api_key.created");
+        verify(jedis).eval(anyString(), anyList(), anyList());
+    }
+
+    @Test
+    void reconcile_tenantEmptyBoth_disabled() throws Exception {
+        stubScan("wh_eb");
+        stubGet("wh_eb", rowJson("wh_eb", "tenant-2", List.of(), null, WebhookStatus.ACTIVE));
+
+        WebhookRepository.ReconcileResult r = repository.reconcileTenantCategoryBoundary(false);
+
+        assertThat(r.repaired()).hasSize(1);
+        assertThat(r.repaired().get(0).action()).isEqualTo(WebhookRepository.CategoryBoundaryAction.DISABLED_EMPTY_BOTH);
+        assertThat(r.repaired().get(0).offendingSelectors()).isEmpty();
+    }
+
+    @Test
+    void reconcile_systemEmptyBoth_disabled_findingFour() throws Exception {
+        // Finding 4: __system__ empty-both is still repaired (carve-out is admin-selectors only).
+        stubScan("wh_sys_eb");
+        stubGet("wh_sys_eb", rowJson("wh_sys_eb", "__system__", List.of(), null, WebhookStatus.ACTIVE));
+
+        WebhookRepository.ReconcileResult r = repository.reconcileTenantCategoryBoundary(false);
+
+        assertThat(r.repaired()).hasSize(1);
+        assertThat(r.repaired().get(0).action()).isEqualTo(WebhookRepository.CategoryBoundaryAction.DISABLED_EMPTY_BOTH);
+    }
+
+    @Test
+    void reconcile_systemAdminCategory_untouched() throws Exception {
+        stubScan("wh_sys");
+        stubGet("wh_sys", rowJson("wh_sys", "__system__", List.of(EventType.API_KEY_CREATED),
+                List.of(EventCategory.API_KEY), WebhookStatus.ACTIVE));
+
+        WebhookRepository.ReconcileResult r = repository.reconcileTenantCategoryBoundary(false);
+
+        assertThat(r.repaired()).isEmpty();
+        assertThat(r.isComplete()).isTrue();
+        verify(jedis, never()).eval(anyString(), anyList(), anyList());
+    }
+
+    @Test
+    void reconcile_nullOwnerAdminCategory_untouched_findingSix() throws Exception {
+        // Finding 6: null owner is system per isSystemOwner → admin-selector exempt.
+        stubScan("wh_null");
+        stubGet("wh_null", rowJson("wh_null", null, List.of(EventType.API_KEY_CREATED),
+                List.of(EventCategory.API_KEY), WebhookStatus.ACTIVE));
+
+        assertThat(repository.reconcileTenantCategoryBoundary(false).repaired()).isEmpty();
+        verify(jedis, never()).eval(anyString(), anyList(), anyList());
+    }
+
+    @Test
+    void reconcile_alreadyDisabled_skipped_idempotent() throws Exception {
+        stubScan("wh_dis");
+        stubGet("wh_dis", rowJson("wh_dis", "tenant-3", List.of(EventType.BUDGET_CREATED),
+                List.of(EventCategory.POLICY), WebhookStatus.DISABLED));
+
+        assertThat(repository.reconcileTenantCategoryBoundary(false).repaired()).isEmpty();
+        verify(jedis, never()).eval(anyString(), anyList(), anyList());
+    }
+
+    @Test
+    void reconcile_legitAndTypesOnly_untouched() throws Exception {
+        stubScan("wh_ok", "wh_types");
+        stubGet("wh_ok", rowJson("wh_ok", "tenant-4", List.of(EventType.BUDGET_CREATED),
+                List.of(EventCategory.RESERVATION), WebhookStatus.ACTIVE));
+        stubGet("wh_types", rowJson("wh_types", "tenant-5", List.of(EventType.BUDGET_CREATED),
+                null, WebhookStatus.ACTIVE));
+
+        assertThat(repository.reconcileTenantCategoryBoundary(false).repaired()).isEmpty();
+        verify(jedis, never()).eval(anyString(), anyList(), anyList());
+    }
+
+    @Test
+    void reconcile_dryRun_reportsButDoesNotWrite() throws Exception {
+        stubScan("wh_admin");
+        stubGet("wh_admin", rowJson("wh_admin", "tenant-1", List.of(EventType.BUDGET_CREATED),
+                List.of(EventCategory.API_KEY), WebhookStatus.ACTIVE));
+
+        WebhookRepository.ReconcileResult r = repository.reconcileTenantCategoryBoundary(true);
+
+        assertThat(r.repaired()).hasSize(1);
+        verify(jedis, never()).eval(anyString(), anyList(), anyList());
+    }
+
+    @Test
+    void reconcile_casMiss_countedAsFailure_notComplete() throws Exception {
+        stubScan("wh_admin");
+        stubGet("wh_admin", rowJson("wh_admin", "tenant-1", List.of(EventType.BUDGET_CREATED),
+                List.of(EventCategory.API_KEY), WebhookStatus.ACTIVE));
+        when(jedis.eval(anyString(), anyList(), anyList())).thenReturn(0L); // concurrent update
+
+        WebhookRepository.ReconcileResult r = repository.reconcileTenantCategoryBoundary(false);
+
+        assertThat(r.repaired()).isEmpty();       // not counted as repaired
+        assertThat(r.failures()).isEqualTo(1);
+        assertThat(r.isComplete()).isFalse();
+    }
+
+    @Test
+    void reconcile_missingRow_skipped() {
+        stubScan("wh_gone");
+        when(jedis.get("webhook:wh_gone")).thenReturn(null);
+
+        assertThat(repository.reconcileTenantCategoryBoundary(false).repaired()).isEmpty();
+    }
+
+    @Test
+    void reconcile_corruptRow_countedFailure_othersStillRepaired() throws Exception {
+        stubScan("wh_bad", "wh_admin");
+        when(jedis.get("webhook:wh_bad")).thenReturn("{not-json");
+        stubGet("wh_admin", rowJson("wh_admin", "tenant-1", List.of(EventType.BUDGET_CREATED),
+                List.of(EventCategory.API_KEY), WebhookStatus.ACTIVE));
+
+        WebhookRepository.ReconcileResult r = repository.reconcileTenantCategoryBoundary(false);
+
+        assertThat(r.repaired()).extracting(WebhookRepository.CategoryBoundaryRepairOutcome::subscriptionId)
+                .containsExactly("wh_admin");
+        assertThat(r.failures()).isEqualTo(1);    // the corrupt row
+        assertThat(r.isComplete()).isFalse();
+    }
+
+    @Test
+    void reconcile_scanThrows_wholePassFailure_notComplete() {
+        when(jedis.sscan(eq("webhooks:_all"), anyString(),
+                any(redis.clients.jedis.params.ScanParams.class)))
+                .thenThrow(new RuntimeException("redis down"));
+
+        WebhookRepository.ReconcileResult r = repository.reconcileTenantCategoryBoundary(false);
+
+        assertThat(r.repaired()).isEmpty();
+        assertThat(r.isComplete()).isFalse();     // fail-open at the pass level → caller retries
+    }
 }

--- a/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/WebhookRepositoryTest.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/WebhookRepositoryTest.java
@@ -1315,13 +1315,12 @@ class WebhookRepositoryTest {
         assertThat(outcomes.get(0).subscriptionId()).isEqualTo("whsub_1");
     }
 
-    // ---- reconcileTenantCategoryBoundary (#209 d2 cleanup) ----
-    // Mocked-Jedis coverage (the real-Redis behavior lives in
+    // ---- reconcileTenantCategoryBoundary (#209 d2 hygiene) ----
+    // Mocked-Jedis coverage (real-Redis behavior lives in
     // WebhookCategoryBoundaryReconcileIntegrationTest, which CI's unit job
     // excludes) so every branch runs in the default -Dtest=!*IntegrationTest job.
     // The reconciler SSCANs webhooks:_all and writes via an atomic CAS eval.
 
-    /** Build the row JSON BEFORE when() (objectMapper is a @Spy — nested-stubbing guard). */
     private String rowJson(String id, String tenantId, java.util.List<EventType> types,
                            java.util.List<EventCategory> cats, WebhookStatus status) throws Exception {
         return objectMapper.writeValueAsString(WebhookSubscription.builder()
@@ -1330,7 +1329,6 @@ class WebhookRepositoryTest {
                 .createdAt(Instant.now()).consecutiveFailures(0).build());
     }
 
-    /** Stub the single-batch SSCAN over webhooks:_all returning the given ids. */
     private void stubScan(String... ids) {
         when(jedis.sscan(eq("webhooks:_all"), anyString(),
                 any(redis.clients.jedis.params.ScanParams.class)))
@@ -1341,14 +1339,19 @@ class WebhookRepositoryTest {
         when(jedis.get("webhook:" + id)).thenReturn(json);
     }
 
+    private WebhookSubscription written(String id) throws Exception {
+        org.mockito.ArgumentCaptor<java.util.List> args = org.mockito.ArgumentCaptor.forClass(java.util.List.class);
+        verify(jedis).eval(anyString(), anyList(), args.capture());
+        return objectMapper.readValue((String) args.getValue().get(1), WebhookSubscription.class);
+    }
+
     @org.junit.jupiter.api.BeforeEach
     void stubCasSuccessByDefault() {
-        // CAS eval returns 1 (write applied) unless a test overrides it.
         lenient().when(jedis.eval(anyString(), anyList(), anyList())).thenReturn(1L);
     }
 
     @Test
-    void reconcile_emptyIndex_completeNoRepairs() {
+    void reconcile_emptyIndex_completeNoWrites() {
         stubScan();
         WebhookRepository.ReconcileResult r = repository.reconcileTenantCategoryBoundary(false);
         assertThat(r.repaired()).isEmpty();
@@ -1357,7 +1360,7 @@ class WebhookRepositoryTest {
     }
 
     @Test
-    void reconcile_adminCategoryOffender_disabled_viaCas_selectorsIntact() throws Exception {
+    void reconcile_adminCategory_strippedViaCas_tenantAccessibleKept() throws Exception {
         stubScan("wh_admin");
         stubGet("wh_admin", rowJson("wh_admin", "tenant-1", List.of(EventType.BUDGET_CREATED),
                 List.of(EventCategory.BUDGET, EventCategory.API_KEY), WebhookStatus.ACTIVE));
@@ -1366,30 +1369,41 @@ class WebhookRepositoryTest {
 
         assertThat(r.isComplete()).isTrue();
         assertThat(r.repaired()).hasSize(1);
-        assertThat(r.repaired().get(0).action()).isEqualTo(WebhookRepository.CategoryBoundaryAction.DISABLED_ADMIN_SELECTORS);
-        assertThat(r.repaired().get(0).offendingSelectors()).containsExactly("api_key");
-        // CAS write: old value == what we read; new value has DISABLED but keeps both categories.
-        org.mockito.ArgumentCaptor<java.util.List> args = org.mockito.ArgumentCaptor.forClass(java.util.List.class);
-        verify(jedis).eval(anyString(), anyList(), args.capture());
-        String newJson = (String) args.getValue().get(1);
-        WebhookSubscription written = objectMapper.readValue(newJson, WebhookSubscription.class);
-        assertThat(written.getStatus()).isEqualTo(WebhookStatus.DISABLED);
-        assertThat(written.getEventCategories()).containsExactly(EventCategory.BUDGET, EventCategory.API_KEY);
+        assertThat(r.repaired().get(0).action()).isEqualTo(WebhookRepository.CategoryBoundaryAction.STRIPPED_ADMIN_SELECTORS);
+        assertThat(r.repaired().get(0).strippedSelectors()).containsExactly("api_key");
+        WebhookSubscription w = written("wh_admin");
+        assertThat(w.getStatus()).isEqualTo(WebhookStatus.ACTIVE);            // still ACTIVE
+        assertThat(w.getEventCategories()).containsExactly(EventCategory.BUDGET); // admin one stripped
+        assertThat(w.getEventTypes()).containsExactly(EventType.BUDGET_CREATED);  // kept
     }
 
     @Test
-    void reconcile_adminEventTypeOffender_disabled() throws Exception {
-        // Finding 3: admin-only event TYPE flags a concrete-tenant row.
+    void reconcile_adminTypeOnly_strippingEmptiesBoth_disabled() throws Exception {
         stubScan("wh_type");
         stubGet("wh_type", rowJson("wh_type", "tenant-1", List.of(EventType.API_KEY_CREATED),
                 null, WebhookStatus.ACTIVE));
 
         WebhookRepository.ReconcileResult r = repository.reconcileTenantCategoryBoundary(false);
 
-        assertThat(r.repaired()).hasSize(1);
-        assertThat(r.repaired().get(0).action()).isEqualTo(WebhookRepository.CategoryBoundaryAction.DISABLED_ADMIN_SELECTORS);
-        assertThat(r.repaired().get(0).offendingSelectors()).containsExactly("api_key.created");
-        verify(jedis).eval(anyString(), anyList(), anyList());
+        assertThat(r.repaired().get(0).action()).isEqualTo(WebhookRepository.CategoryBoundaryAction.STRIPPED_AND_DISABLED);
+        assertThat(r.repaired().get(0).strippedSelectors()).containsExactly("api_key.created");
+        WebhookSubscription w = written("wh_type");
+        assertThat(w.getStatus()).isEqualTo(WebhookStatus.DISABLED);
+        assertThat(w.getEventTypes()).isNullOrEmpty();
+    }
+
+    @Test
+    void reconcile_adminTypeWithKeptType_stripped_staysActive() throws Exception {
+        stubScan("wh_mix");
+        stubGet("wh_mix", rowJson("wh_mix", "tenant-1",
+                List.of(EventType.BUDGET_CREATED, EventType.API_KEY_CREATED), null, WebhookStatus.ACTIVE));
+
+        WebhookRepository.ReconcileResult r = repository.reconcileTenantCategoryBoundary(false);
+
+        assertThat(r.repaired().get(0).action()).isEqualTo(WebhookRepository.CategoryBoundaryAction.STRIPPED_ADMIN_SELECTORS);
+        WebhookSubscription w = written("wh_mix");
+        assertThat(w.getStatus()).isEqualTo(WebhookStatus.ACTIVE);
+        assertThat(w.getEventTypes()).containsExactly(EventType.BUDGET_CREATED);
     }
 
     @Test
@@ -1399,20 +1413,18 @@ class WebhookRepositoryTest {
 
         WebhookRepository.ReconcileResult r = repository.reconcileTenantCategoryBoundary(false);
 
-        assertThat(r.repaired()).hasSize(1);
         assertThat(r.repaired().get(0).action()).isEqualTo(WebhookRepository.CategoryBoundaryAction.DISABLED_EMPTY_BOTH);
-        assertThat(r.repaired().get(0).offendingSelectors()).isEmpty();
+        assertThat(r.repaired().get(0).strippedSelectors()).isEmpty();
+        assertThat(written("wh_eb").getStatus()).isEqualTo(WebhookStatus.DISABLED);
     }
 
     @Test
-    void reconcile_systemEmptyBoth_disabled_findingFour() throws Exception {
-        // Finding 4: __system__ empty-both is still repaired (carve-out is admin-selectors only).
+    void reconcile_systemEmptyBoth_disabled() throws Exception {
         stubScan("wh_sys_eb");
         stubGet("wh_sys_eb", rowJson("wh_sys_eb", "__system__", List.of(), null, WebhookStatus.ACTIVE));
 
         WebhookRepository.ReconcileResult r = repository.reconcileTenantCategoryBoundary(false);
 
-        assertThat(r.repaired()).hasSize(1);
         assertThat(r.repaired().get(0).action()).isEqualTo(WebhookRepository.CategoryBoundaryAction.DISABLED_EMPTY_BOTH);
     }
 
@@ -1425,23 +1437,29 @@ class WebhookRepositoryTest {
         WebhookRepository.ReconcileResult r = repository.reconcileTenantCategoryBoundary(false);
 
         assertThat(r.repaired()).isEmpty();
-        assertThat(r.isComplete()).isTrue();
         verify(jedis, never()).eval(anyString(), anyList(), anyList());
     }
 
     @Test
-    void reconcile_nullOwnerAdminCategory_untouched_findingSix() throws Exception {
-        // Finding 6: null owner is system per isSystemOwner → admin-selector exempt.
+    void reconcile_nullOwner_normalizedToSystem_andIndexed() throws Exception {
         stubScan("wh_null");
         stubGet("wh_null", rowJson("wh_null", null, List.of(EventType.API_KEY_CREATED),
                 List.of(EventCategory.API_KEY), WebhookStatus.ACTIVE));
 
-        assertThat(repository.reconcileTenantCategoryBoundary(false).repaired()).isEmpty();
-        verify(jedis, never()).eval(anyString(), anyList(), anyList());
+        WebhookRepository.ReconcileResult r = repository.reconcileTenantCategoryBoundary(false);
+
+        assertThat(r.repaired().get(0).action()).isEqualTo(WebhookRepository.CategoryBoundaryAction.NORMALIZED_NULL_OWNER);
+        assertThat(r.repaired().get(0).tenantId()).isEqualTo("__system__");
+        WebhookSubscription w = written("wh_null");
+        assertThat(w.getTenantId()).isEqualTo("__system__");
+        // system-owned now → admin selectors NOT stripped
+        assertThat(w.getEventCategories()).containsExactly(EventCategory.API_KEY);
+        assertThat(w.getStatus()).isEqualTo(WebhookStatus.ACTIVE);
+        verify(jedis).sadd("webhooks:__system__", "wh_null");
     }
 
     @Test
-    void reconcile_alreadyDisabled_skipped_idempotent() throws Exception {
+    void reconcile_alreadyDisabled_skipped() throws Exception {
         stubScan("wh_dis");
         stubGet("wh_dis", rowJson("wh_dis", "tenant-3", List.of(EventType.BUDGET_CREATED),
                 List.of(EventCategory.POLICY), WebhookStatus.DISABLED));
@@ -1471,11 +1489,13 @@ class WebhookRepositoryTest {
         WebhookRepository.ReconcileResult r = repository.reconcileTenantCategoryBoundary(true);
 
         assertThat(r.repaired()).hasSize(1);
+        assertThat(r.repaired().get(0).action()).isEqualTo(WebhookRepository.CategoryBoundaryAction.STRIPPED_ADMIN_SELECTORS);
         verify(jedis, never()).eval(anyString(), anyList(), anyList());
+        verify(jedis, never()).sadd(anyString(), anyString());
     }
 
     @Test
-    void reconcile_casMiss_countedAsFailure_notComplete() throws Exception {
+    void reconcile_casMiss_countedFailure_notComplete() throws Exception {
         stubScan("wh_admin");
         stubGet("wh_admin", rowJson("wh_admin", "tenant-1", List.of(EventType.BUDGET_CREATED),
                 List.of(EventCategory.API_KEY), WebhookStatus.ACTIVE));
@@ -1483,7 +1503,7 @@ class WebhookRepositoryTest {
 
         WebhookRepository.ReconcileResult r = repository.reconcileTenantCategoryBoundary(false);
 
-        assertThat(r.repaired()).isEmpty();       // not counted as repaired
+        assertThat(r.repaired()).isEmpty();
         assertThat(r.failures()).isEqualTo(1);
         assertThat(r.isComplete()).isFalse();
     }
@@ -1492,7 +1512,6 @@ class WebhookRepositoryTest {
     void reconcile_missingRow_skipped() {
         stubScan("wh_gone");
         when(jedis.get("webhook:wh_gone")).thenReturn(null);
-
         assertThat(repository.reconcileTenantCategoryBoundary(false).repaired()).isEmpty();
     }
 
@@ -1507,7 +1526,7 @@ class WebhookRepositoryTest {
 
         assertThat(r.repaired()).extracting(WebhookRepository.CategoryBoundaryRepairOutcome::subscriptionId)
                 .containsExactly("wh_admin");
-        assertThat(r.failures()).isEqualTo(1);    // the corrupt row
+        assertThat(r.failures()).isEqualTo(1);
         assertThat(r.isComplete()).isFalse();
     }
 
@@ -1520,6 +1539,6 @@ class WebhookRepositoryTest {
         WebhookRepository.ReconcileResult r = repository.reconcileTenantCategoryBoundary(false);
 
         assertThat(r.repaired()).isEmpty();
-        assertThat(r.isComplete()).isFalse();     // fail-open at the pass level → caller retries
+        assertThat(r.isComplete()).isFalse();
     }
 }

--- a/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/WebhookRepositoryTest.java
+++ b/cycles-admin-service/cycles-admin-service-data/src/test/java/io/runcycles/admin/data/repository/WebhookRepositoryTest.java
@@ -1348,6 +1348,16 @@ class WebhookRepositoryTest {
     @org.junit.jupiter.api.BeforeEach
     void stubCasSuccessByDefault() {
         lenient().when(jedis.eval(anyString(), anyList(), anyList())).thenReturn(1L);
+        // Default: system-owned rows are already members of the dispatch index,
+        // so the index-membership repair is a no-op unless a test says otherwise.
+        lenient().when(jedis.sismember(anyString(), anyString())).thenReturn(true);
+    }
+
+    @Test
+    void reconcile_scriptAndBatchAccessors_exposeProductionConstants() {
+        assertThat(WebhookRepository.reconcileCasSetAndIndexScript())
+                .contains("SADD").contains("SET").contains("GET");
+        assertThat(WebhookRepository.reconcileScanBatch()).isEqualTo(200);
     }
 
     @Test
@@ -1455,7 +1465,16 @@ class WebhookRepositoryTest {
         // system-owned now → admin selectors NOT stripped
         assertThat(w.getEventCategories()).containsExactly(EventCategory.API_KEY);
         assertThat(w.getStatus()).isEqualTo(WebhookStatus.ACTIVE);
-        verify(jedis).sadd("webhooks:__system__", "wh_null");
+        // #209 finding 2: the SADD is folded into the SAME atomic Lua op as the
+        // owner rewrite (no separate sadd), so a partial failure can't persist
+        // the owner while leaving the row un-indexed.
+        verify(jedis, never()).sadd(anyString(), anyString());
+        org.mockito.ArgumentCaptor<java.util.List> keys = org.mockito.ArgumentCaptor.forClass(java.util.List.class);
+        org.mockito.ArgumentCaptor<java.util.List> argv = org.mockito.ArgumentCaptor.forClass(java.util.List.class);
+        verify(jedis).eval(anyString(), keys.capture(), argv.capture());
+        assertThat(keys.getValue()).containsExactly("webhook:wh_null", "webhooks:__system__");
+        assertThat((String) argv.getValue().get(2)).isEqualTo("1");       // doIndex flag
+        assertThat((String) argv.getValue().get(3)).isEqualTo("wh_null"); // id added to index
     }
 
     @Test
@@ -1466,6 +1485,58 @@ class WebhookRepositoryTest {
 
         assertThat(repository.reconcileTenantCategoryBoundary(false).repaired()).isEmpty();
         verify(jedis, never()).eval(anyString(), anyList(), anyList());
+    }
+
+    // #209 finding 2: a DISABLED null-owner row still needs normalizing +
+    // indexing (the blanket DISABLED-skip previously left it in limbo).
+    @Test
+    void reconcile_disabledNullOwner_normalizedAndIndexed_staysDisabled() throws Exception {
+        stubScan("wh_dnull");
+        stubGet("wh_dnull", rowJson("wh_dnull", null, List.of(EventType.API_KEY_CREATED),
+                List.of(EventCategory.API_KEY), WebhookStatus.DISABLED));
+
+        WebhookRepository.ReconcileResult r = repository.reconcileTenantCategoryBoundary(false);
+
+        assertThat(r.repaired().get(0).action()).isEqualTo(WebhookRepository.CategoryBoundaryAction.NORMALIZED_NULL_OWNER);
+        WebhookSubscription w = written("wh_dnull");
+        assertThat(w.getTenantId()).isEqualTo("__system__");
+        assertThat(w.getStatus()).isEqualTo(WebhookStatus.DISABLED); // stays disabled
+        // Owner rewrite + SADD are one atomic op (no separate sadd).
+        verify(jedis, never()).sadd(anyString(), anyString());
+        org.mockito.ArgumentCaptor<java.util.List> argv = org.mockito.ArgumentCaptor.forClass(java.util.List.class);
+        verify(jedis).eval(anyString(), anyList(), argv.capture());
+        assertThat((String) argv.getValue().get(2)).isEqualTo("1"); // doIndex
+    }
+
+    // #209 finding 2: a system-owned row that is MISSING from the dispatch index
+    // (e.g. a prior partial normalization) gets its membership repaired,
+    // independent of status, via an idempotent SADD (no CAS write needed).
+    @Test
+    void reconcile_systemUnindexed_membershipRepaired_noJsonWrite() throws Exception {
+        stubScan("wh_sys_unx");
+        stubGet("wh_sys_unx", rowJson("wh_sys_unx", "__system__", List.of(EventType.API_KEY_CREATED),
+                List.of(EventCategory.API_KEY), WebhookStatus.ACTIVE));
+        when(jedis.sismember("webhooks:__system__", "wh_sys_unx")).thenReturn(false); // not indexed
+
+        WebhookRepository.ReconcileResult r = repository.reconcileTenantCategoryBoundary(false);
+
+        assertThat(r.repaired().get(0).action()).isEqualTo(WebhookRepository.CategoryBoundaryAction.INDEXED_SYSTEM_MEMBER);
+        verify(jedis).sadd("webhooks:__system__", "wh_sys_unx"); // pure index repair
+        verify(jedis, never()).eval(anyString(), anyList(), anyList()); // no JSON change
+    }
+
+    // A DISABLED system row missing from the index is still indexed (status-independent).
+    @Test
+    void reconcile_disabledSystemUnindexed_membershipRepaired() throws Exception {
+        stubScan("wh_dsys");
+        stubGet("wh_dsys", rowJson("wh_dsys", "__system__", List.of(EventType.API_KEY_CREATED),
+                null, WebhookStatus.DISABLED));
+        when(jedis.sismember("webhooks:__system__", "wh_dsys")).thenReturn(false);
+
+        WebhookRepository.ReconcileResult r = repository.reconcileTenantCategoryBoundary(false);
+
+        assertThat(r.repaired().get(0).action()).isEqualTo(WebhookRepository.CategoryBoundaryAction.INDEXED_SYSTEM_MEMBER);
+        verify(jedis).sadd("webhooks:__system__", "wh_dsys");
     }
 
     @Test

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/webhook/ReplayRequest.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/webhook/ReplayRequest.java
@@ -1,6 +1,8 @@
 package io.runcycles.admin.model.webhook;
 import com.fasterxml.jackson.annotation.*;
 import io.runcycles.admin.model.event.EventType;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.*;
 import java.time.Instant;
 import java.util.List;
@@ -10,5 +12,7 @@ public class ReplayRequest {
     @JsonProperty("from") private Instant from;
     @JsonProperty("to") private Instant to;
     @JsonProperty("event_types") private List<EventType> eventTypes;
-    @JsonProperty("max_events") @Builder.Default private Integer maxEvents = 100;
+    // Governance spec: minimum 1, maximum 1000, default 100. Out-of-range values
+    // are REJECTED (400) by @Valid on the controller, not silently clamped.
+    @Min(1) @Max(1000) @JsonProperty("max_events") @Builder.Default private Integer maxEvents = 100;
 }

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/webhook/ReplayResponse.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/webhook/ReplayResponse.java
@@ -4,6 +4,14 @@ import lombok.*;
 @Data @Builder @NoArgsConstructor @AllArgsConstructor
 public class ReplayResponse {
     @JsonProperty("replay_id") private String replayId;
+    /**
+     * The number of selected events ACCEPTED onto the dispatch queue (governance
+     * #130 best-effort contract). Selection is complete for the window, but
+     * enqueue is best-effort: on a transient backend failure this may be fewer
+     * than the events selected (the shortfall is logged server-side). Replay is
+     * NOT idempotent — delivery IDs are random, so a retry may duplicate
+     * already-queued deliveries.
+     */
     @JsonProperty("events_queued") private Integer eventsQueued;
     @JsonProperty("estimated_completion_seconds") private Integer estimatedCompletionSeconds;
 }

--- a/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/webhook/WebhookSubscription.java
+++ b/cycles-admin-service/cycles-admin-service-model/src/main/java/io/runcycles/admin/model/webhook/WebhookSubscription.java
@@ -9,6 +9,23 @@ import java.util.Map;
 @Data @Builder @NoArgsConstructor @AllArgsConstructor
 @com.fasterxml.jackson.annotation.JsonIgnoreProperties(ignoreUnknown = false)
 public class WebhookSubscription {
+
+    /** Owning-tenant sentinel for admin-provisioned, non-tenant-owned rows. */
+    public static final String SYSTEM_TENANT = "__system__";
+
+    /**
+     * Single source of truth for "is this subscription system-owned (not
+     * tenant-owned)". Per governance v0.1.25.40 the tenant-accessible boundary
+     * exempts ONLY a null/omitted owner and the literal {@link #SYSTEM_TENANT}
+     * sentinel. A blank (whitespace-only) {@code tenant_id} is NOT system - it
+     * is treated as a concrete owner so it stays boundary-validated (closes the
+     * blank-owner exemption bypass). Used by both the write-path validator (api)
+     * and the cleanup reconciler (data) so they cannot disagree.
+     */
+    public static boolean isSystemOwner(String tenantId) {
+        return tenantId == null || SYSTEM_TENANT.equals(tenantId);
+    }
+
     @JsonProperty("subscription_id") private String subscriptionId;
     @JsonProperty("tenant_id") private String tenantId;
     @JsonInclude(JsonInclude.Include.NON_NULL) @JsonProperty("name") private String name;

--- a/cycles-admin-service/pom.xml
+++ b/cycles-admin-service/pom.xml
@@ -18,7 +18,7 @@
         <module>cycles-admin-service-api</module>
     </modules>
     <properties>
-        <revision>0.1.25.50</revision>
+        <revision>0.1.25.51</revision>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>


### PR DESCRIPTION
**Closes #209.** Security fix (v0.1.25.51): closes the admin-plane CARRIER source for admin-only webhook `event_categories`, and conservatively cleans up pre-existing offenders.

## The carrier source

The 0.1.25.50 fix closed the tenant-plane *injection* path. But `WebhookAdminController.create` (`POST /v1/admin/webhooks?tenant_id=X`) and `.update` (PATCH) applied **no** category validation, so an operator / admin-on-behalf-of could place admin-only categories (`api_key`, `policy`, `webhook`, `system`) on a subscription owned by a **concrete tenant X**. Since `matchesEventType` treats categories as an ADDITIVE union, X — which controls that row's endpoint URL and signing secret — then received admin-only governance/security telemetry for its tenant.

## (a) Admin write-path validation

- New shared **`WebhookCategoryBoundaryValidator`** (`@Component`) — the single source of truth for the boundary. Both the tenant controller (refactored off its two private methods) and the admin controller call it, so the type-/category-level checks and both planes cannot drift; the boundary derives from `EventCategory.isTenantAccessible()`.
- Admin plane validates **only when the target is a concrete tenant** (`validateForTarget` no-ops on `__system__`). Target tenant: create → the `tenant_id` param; **update → the STORED subscription's `tenant_id`** (`WebhookUpdateRequest` has no `tenant_id`; ownership is the subscription's, validated against `prior.getTenantId()`). Admin-only entry on a non-`__system__` target → **400 `INVALID_REQUEST`**.
- **`__system__` carve-out:** admin-only categories remain allowed there (legitimate system-wide monitoring; not tenant-owned).

Governance spec revision **v0.1.25.40** (pending, runcycles/cycles-protocol#129) makes this normative.

## Capability removal (recorded)

This changes a previously-allowed behavior. 0.1.25.50 explicitly tested/documented admin-plane admin-only categories as 201/200 ("the boundary is tenant-plane-only, not a global tightening"). **Verified by grep** those two `WebhookAdminControllerTest` cases were the *only* place this was asserted — an incidental tested-as-allowed behavior, **not** a separately documented product feature. Both are rewritten to assert the new 400 (concrete tenant) / 201-200 (`__system__`). This is an intentional security correction: a tenant-owned row exposes URL + secret to the tenant.

## (d2) One-time cleanup — conservative (disable, not strip)

A startup `ApplicationRunner` (`WebhookCategoryBoundaryReconciler`) → `WebhookRepository.reconcileTenantCategoryBoundary(dryRun)`. Chosen over a maintenance endpoint because a new admin endpoint would fail the OpenAPI contract-diff check (undocumented surface); mirrors the repo's `@Scheduled` audit-sweep / `CommandLineRunner` precedent.

Per non-`__system__` row: a row carrying admin-only categories, or a legacy empty-both match-ALL row, is **DISABLED — not silently stripped**. Per review: a concrete-tenant admin-category row may be a *legit-but-misconfigured operator monitoring* subscription; silently rewriting its selectors would break it with no signal. Disabling stops delivery immediately (dispatch matches only `ACTIVE`), is reversible, preserves the row + offending categories for review, and is **loudly logged** (subscription_id / tenant_id / offending categories + migration hint). Already-`DISABLED` offenders are skipped → idempotent.

Config: `webhook.category-boundary.reconcile-on-startup` (default `true`), `webhook.category-boundary.reconcile-dry-run` (default `false`; `true` = REPORT offenders in logs without mutating, for review before the disabling pass).

## Migration (corrected per review — no `scope_filter`)

Genuine per-tenant admin monitoring must move to a **`__system__`-owned** subscription (create with no `tenant_id`) filtered by **`event_categories`** to the admin classes; because `__system__` is in every tenant's dispatch union it receives those events for ALL tenants, so select the target tenant **client-side** on the envelope's `tenant_id`. **Do NOT use a `scope_filter`:** admin lifecycle events are null-scoped (verified: `ApiKeyController` emits `scope=null`) and `matchesScope` excludes null scopes from any non-blank filter, so a `scope_filter` would deliver **none** of them. The `__system__` row stays operator-owned (URL + secret). gov #129 is being corrected the same way.

## Tests

- `WebhookCategoryBoundaryValidatorTest` — boundary, `__system__` carve-out, null no-ops.
- Admin controller — admin-only category/type on a real tenant → 400 (create + update, service never called); on `__system__` → 201/200; tenant-accessible → ok.
- Reconciler integration (real Redis, `WebhookCategoryBoundaryReconcileIntegrationTest`) — seeded mix (admin-category offender, admin-only-category offender, legit, `__system__`, empty-both, types-only, already-disabled) → correct `DISABLED` terminal states **with categories left intact**, non-offenders untouched, **dry-run reports without mutating**, idempotent re-run.
- Reconciler component unit — flag on/off, dry-run passthrough, failure-swallowed.
- Existing admin/tenant webhook + service tests stay green.

`mvn -B verify` green — **1,590 tests** (192 model + 564 data + 834 api), coverage gates met. Version 0.1.25.50 → **0.1.25.51**. README spec-alignment stays governance v0.1.25.39 (.40 / #129 still pending on origin/main).
