### PR TITLE
docs: close v0.1.25.52 release provenance

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -155,6 +155,16 @@ not this long-lived audit narrative. Merge requires a clean Maven verification,
 Docker-backed integration tests, independent 95% JaCoCo line and branch gates
 for every code module, Compose validation, image build, and `git diff --check`.
 
+### 2026-07-15 — v0.1.25.52 pre-release provenance closure (documentation only)
+
+The pre-tag drift checklist found that two already-merged, non-runtime changes
+since `v0.1.25.51` did not have an explicit home in the `0.1.25.52` consumer
+CHANGELOG entry: the declared governance-spec alignment update through
+v0.1.25.41 (PR #211) and the CodeQL SARIF upload action refresh to v4.37.0
+(PR #213). The `Changed` entry now records both. No application source, wire
+contract, production Compose pin, or release version changed in this
+bookkeeping correction.
+
 ### 2026-07-12 — declared spec alignment bump v0.1.25.39 → v0.1.25.41 (doc-only)
 
 Post-release doc bookkeeping (0.1.25.51 shipped; PR #210 merged to main).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,9 @@ new optional request fields) are **not** considered breaking.
   95% JaCoCo branch-coverage gate in addition to the line gate. Jqwik uses
   supported JUnit Platform configuration, and Mockito is inherited as a test
   dependency and attached explicitly as a test JVM agent, including on cold CI
-  runners. GitHub's Java setup action is pinned to v5.5.0.
+  runners. GitHub's Java setup action is pinned to v5.5.0, the CodeQL SARIF
+  uploader is pinned to v4.37.0, and the release documentation declares
+  governance-spec v0.1.25.41 alignment.
 - The task scheduler defaults to two threads so a tenant-close reconciliation
   cannot starve its own distributed-lease heartbeat.
 - `X-Cycles-Cascade-Status: in_progress` and `Retry-After: 1` remain additive


### PR DESCRIPTION
## Summary

- record the already-merged governance-spec v0.1.25.41 documentation alignment in the v0.1.25.52 CHANGELOG entry
- record the already-merged CodeQL SARIF uploader v4.37.0 refresh
- add the required AUDIT.md provenance note

## Why

The pre-tag checklist requires every commit since the previous release tag, including workflow and documentation changes, to have an explicit home in the target release entry. PRs #211 and #213 were present on `main` but not both named in the v0.1.25.52 CHANGELOG section.

This is documentation-only release bookkeeping. It does not change application source, the wire contract, production Compose pins, or the 0.1.25.52 artifact version.

## Validation

- `git diff --check`
- POM revision, CHANGELOG version/date, and AUDIT title agree on v0.1.25.52 / 2026-07-15
- pinned governance YAML is byte-identical to cycles-protocol `main` and reports info.version 0.1.25.41
- post-merge CI, CodeQL, Scorecard, and container scan for PR #214's merge commit are green
