### PR TITLE
chore(release): pin v0.1.25.52 and open v0.1.25.53

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,4 +1,4 @@
-# Complete Budget Governance v0.1.25.52 — Admin Server Audit
+# Complete Budget Governance v0.1.25.53 — Admin Server Audit
 
 **Spec:**
 [`cycles-governance-admin-v0.1.25.yaml`](https://github.com/runcycles/cycles-protocol/blob/469840bb2f41ce35650c89405ea12fc56e847c76/cycles-governance-admin-v0.1.25.yaml)
@@ -43,6 +43,19 @@ the `/test` synthetic-ping exception — .40 and .41 both implemented here in
 pin · tomcat-embed-core 10.1.55 pin
 (re-introduced 2026-05-25 for Apache Tomcat CVE-2026-43512 / -43513 / -43514 /
 -43515 / -42498 / -41284 / -41293)
+
+### 2026-07-15 — v0.1.25.52 published; production pins advanced; v0.1.25.53 opened
+
+GitHub release `v0.1.25.52` was published from merge commit `6ca8293`. The
+release workflow's vulnerability gate and published-image smoke test completed
+successfully, and the immutable `0.1.25.52` and moving `latest` GHCR tags both
+resolved to digest
+`sha256:04f0b91ab508bd6aafee898c0454f319d8a9c863aa0d687589de8c216e623589`.
+With the image available, both production Compose manifests now advance their
+admin self-pin from `0.1.25.51` to `0.1.25.52`. Sibling full-stack image pins
+are unchanged. The Maven development revision advances from `0.1.25.52` to
+`0.1.25.53` immediately after release as required by the pre-release drift
+runbook; no `0.1.25.53` application or wire behavior is claimed yet.
 
 ### 2026-07-15 — full admin-server remediation and self-review
 

--- a/cycles-admin-service/pom.xml
+++ b/cycles-admin-service/pom.xml
@@ -18,7 +18,7 @@
         <module>cycles-admin-service-api</module>
     </modules>
     <properties>
-        <revision>0.1.25.52</revision>
+        <revision>0.1.25.53</revision>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/docker-compose.full-stack.prod.yml
+++ b/docker-compose.full-stack.prod.yml
@@ -22,7 +22,7 @@ services:
 
   cycles-admin:
     logging: *default-logging
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.51
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.52
     restart: unless-stopped
     ports:
       - "7979:7979"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -22,7 +22,7 @@ services:
 
   cycles-admin:
     logging: *default-logging
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.51
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.52
     restart: unless-stopped
     ports:
       - "7979:7979"


### PR DESCRIPTION
## Summary

- advance both production Compose admin-image pins from 0.1.25.51 to the now-published 0.1.25.52 image
- advance the Maven development revision from 0.1.25.52 to 0.1.25.53
- record immutable release workflow and GHCR digest evidence in AUDIT.md

## Why

Release v0.1.25.52 is published and its authoritative build, Trivy gate, and published-image smoke test are green. Keeping Compose on 0.1.25.51 is therefore no longer necessary. The operations runbook also requires opening the next development revision immediately after a release so future untagged work cannot silently reuse the shipped version.

This PR does not change application or wire behavior. Full-stack sibling image pins remain unchanged.

## Validation

- release workflow `29444830267`: build/push, Trivy, and published-image smoke test passed
- `0.1.25.52` and `latest` both resolve to `sha256:04f0b91ab508bd6aafee898c0454f319d8a9c863aa0d687589de8c216e623589`
- both production Compose manifests render successfully
- `docker compose -f docker-compose.prod.yml pull cycles-admin` succeeds
- Maven reactor validation resolves all modules as 0.1.25.53
- `git diff --check`
