### PR TITLE
v0.1.25.53: return 405 for unsupported HTTP methods

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -44,6 +44,31 @@ pin · tomcat-embed-core 10.1.55 pin
 (re-introduced 2026-05-25 for Apache Tomcat CVE-2026-43512 / -43513 / -43514 /
 -43515 / -42498 / -41284 / -41293)
 
+### 2026-07-16 — v0.1.25.53: unsupported HTTP methods return 405
+
+Live dashboard-stack testing sent a wrong-method request to an admin endpoint
+and received `500 INTERNAL_ERROR`. The controller was never invoked: Spring
+raised `HttpRequestMethodNotSupportedException`, which had no dedicated advice
+method and therefore fell into `GlobalExceptionHandler`'s generic 500 branch.
+That misclassified a deterministic client/protocol error as an operator-paging
+server fault and omitted the HTTP `Allow` response header.
+
+`GlobalExceptionHandler` now maps this exception to `405 Method Not Allowed`,
+uses the existing `INVALID_REQUEST` error code (the pinned governance error
+enum has no method-specific value), includes Spring's supported methods in the
+wire message and `Allow` header, and records the same 405 classification via
+`AuditFailureService`. The generic 500 path remains unchanged for genuinely
+unexpected exceptions. A focused handler test covers status, envelope, header,
+and audit-write behavior. No governance-spec surface or success response
+changes. Full Maven verification against the authoritative local spec at the
+repository's pinned commit (`cycles-protocol@469840b`) passes 1,923 tests across
+79 report files with zero failures/errors. Focused coverage includes both
+direct advice assertions and the real `/v1/auth/introspect` WebMvc slice, which
+proves Spring dispatch returns the envelope and `Allow` header before controller
+invocation. The 95% JaCoCo gates pass in every
+module: API 97.53% line / 95.34% branch, data 97.60% / 95.65%, and model 97.85%
+/ 98.44%.
+
 ### 2026-07-15 — v0.1.25.52 published; production pins advanced; v0.1.25.53 opened
 
 GitHub release `v0.1.25.52` was published from merge commit `6ca8293`. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ changes to request/response bodies or Lua-script semantics would require a
 minor bump. Additive fields (new optional response fields, new enum values,
 new optional request fields) are **not** considered breaking.
 
+## [0.1.25.53] — 2026-07-16
+
+### Fixed
+
+- Requests using an unsupported HTTP method now return `405 Method Not
+  Allowed` with the standard JSON `ErrorResponse`, `error=INVALID_REQUEST`,
+  and an RFC-compliant `Allow` header. Previously Spring's
+  `HttpRequestMethodNotSupportedException` fell through the generic exception
+  handler and was misreported as `500 INTERNAL_ERROR`. The rejection is also
+  recorded in the failure audit with status 405.
+
 ## [0.1.25.52] — 2026-07-15
 
 ### Fixed

--- a/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/exception/GlobalExceptionHandler.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/main/java/io/runcycles/admin/api/exception/GlobalExceptionHandler.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.servlet.HandlerMapping;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -135,6 +136,29 @@ public class GlobalExceptionHandler {
         auditFailure.logFailure(request, HttpStatus.BAD_REQUEST.value(), ErrorCode.INVALID_REQUEST, "Malformed request body", null);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
             .body(errorBuilder(request).error(ErrorCode.INVALID_REQUEST).message("Malformed request body").build());
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleMethodNotSupported(
+            HttpRequestMethodNotSupportedException ex, HttpServletRequest request) {
+        Set<HttpMethod> supported = ex.getSupportedHttpMethods();
+        String allowed = supported == null || supported.isEmpty()
+                ? ""
+                : supported.stream().map(HttpMethod::name).sorted().collect(Collectors.joining(", "));
+        String message = "Request method '" + ex.getMethod() + "' is not supported"
+                + (allowed.isEmpty() ? " for this endpoint" : "; supported methods: " + allowed);
+        logRequestError(request, HttpStatus.METHOD_NOT_ALLOWED.value(), ErrorCode.INVALID_REQUEST, message);
+        auditFailure.logFailure(request, HttpStatus.METHOD_NOT_ALLOWED.value(),
+                ErrorCode.INVALID_REQUEST, message, null);
+
+        ResponseEntity.BodyBuilder response = ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED);
+        if (supported != null && !supported.isEmpty()) {
+            response.allow(supported.toArray(HttpMethod[]::new));
+        }
+        return response.body(errorBuilder(request)
+                .error(ErrorCode.INVALID_REQUEST)
+                .message(message)
+                .build());
     }
 
     @ExceptionHandler(Exception.class)

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/AuthControllerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/controller/AuthControllerTest.java
@@ -158,6 +158,17 @@ class AuthControllerTest {
     }
 
     @Test
+    void introspect_withWrongMethod_returns405ErrorEnvelopeAndAllowHeader() throws Exception {
+        mockMvc.perform(post("/v1/auth/introspect")
+                        .header("X-Admin-API-Key", ADMIN_KEY))
+                .andExpect(status().isMethodNotAllowed())
+                .andExpect(header().string("Allow", org.hamcrest.Matchers.containsString("GET")))
+                .andExpect(jsonPath("$.error").value("INVALID_REQUEST"))
+                .andExpect(jsonPath("$.message").value(
+                        org.hamcrest.Matchers.containsString("POST")));
+    }
+
+    @Test
     void introspect_withoutAnyKey_returns401() throws Exception {
         // v0.1.25.19: the endpoint is dual-auth but still rejects missing
         // credentials. Without either header, the interceptor routes through

--- a/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/exception/GlobalExceptionHandlerTest.java
+++ b/cycles-admin-service/cycles-admin-service-api/src/test/java/io/runcycles/admin/api/exception/GlobalExceptionHandlerTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -19,8 +20,13 @@ import org.springframework.validation.FieldError;
 import org.springframework.core.MethodParameter;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.servlet.HandlerMapping;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolation;
@@ -28,6 +34,7 @@ import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Path;
 
 import java.util.Map;
+import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,6 +48,11 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(OutputCaptureExtension.class)
 class GlobalExceptionHandlerTest {
@@ -175,6 +187,50 @@ class GlobalExceptionHandlerTest {
         assertThat(response.getBody().getError()).isEqualTo(ErrorCode.INVALID_REQUEST);
         assertThat(response.getBody().getMessage()).contains("limit");
         assertThat(response.getBody().getMessage()).contains("abc");
+    }
+
+    @Test
+    void handleMethodNotSupported_returns405WithAllowHeaderAndAuditEntry() {
+        when(mockRequest.getMethod()).thenReturn("POST");
+        when(mockRequest.getRequestURI()).thenReturn("/v1/auth/introspect");
+        HttpRequestMethodNotSupportedException ex =
+                new HttpRequestMethodNotSupportedException("POST", List.of("GET", "HEAD"));
+
+        ResponseEntity<ErrorResponse> response = handler.handleMethodNotSupported(ex, mockRequest);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.METHOD_NOT_ALLOWED);
+        assertThat(response.getHeaders().getAllow()).containsExactlyInAnyOrder(
+                org.springframework.http.HttpMethod.GET, org.springframework.http.HttpMethod.HEAD);
+        assertThat(response.getBody().getError()).isEqualTo(ErrorCode.INVALID_REQUEST);
+        assertThat(response.getBody().getMessage())
+                .contains("POST")
+                .contains("GET")
+                .contains("HEAD");
+        verify(auditFailure).logFailure(eq(mockRequest), eq(405),
+                eq(ErrorCode.INVALID_REQUEST), anyString(), isNull());
+    }
+
+    @Test
+    void springDispatch_routesWrongMethodToDedicated405Handler() throws Exception {
+        @RestController
+        class MethodFixtureController {
+            @GetMapping("/method-fixture")
+            Map<String, String> getOnly() {
+                return Map.of("status", "ok");
+            }
+        }
+        MockMvc mvc = MockMvcBuilders.standaloneSetup(new MethodFixtureController())
+                .setControllerAdvice(handler)
+                .build();
+
+        mvc.perform(post("/method-fixture"))
+                .andExpect(status().isMethodNotAllowed())
+                .andExpect(header().string(HttpHeaders.ALLOW, containsString("GET")))
+                .andExpect(jsonPath("$.error").value("INVALID_REQUEST"))
+                .andExpect(jsonPath("$.message").value(containsString("POST")));
+
+        verify(auditFailure).logFailure(any(HttpServletRequest.class), eq(405),
+                eq(ErrorCode.INVALID_REQUEST), anyString(), isNull());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes unsupported HTTP methods being misclassified as `500 INTERNAL_ERROR` in the admin plane.

## Root cause

Spring raises `HttpRequestMethodNotSupportedException` before invoking a controller. The global exception advice had no dedicated mapping, so the exception fell through the generic 500 handler.

## Changes

- map unsupported methods to `405 Method Not Allowed`
- return the standard JSON `ErrorResponse` with `error=INVALID_REQUEST`
- emit the RFC-compliant `Allow` header from Spring's supported-method set
- record the rejection in the failure audit with status 405
- cover direct advice behavior, Spring MVC dispatch, and the real `/v1/auth/introspect` WebMvc slice
- document the fix in CHANGELOG and AUDIT for the open `0.1.25.53` release

## Validation

- full Maven verification against authoritative `cycles-protocol@469840b`
- **1,923/1,923 tests** across 79 report files
- JaCoCo:
  - API: 97.53% line / 95.34% branch
  - data: 97.60% line / 95.65% branch
  - model: 97.85% line / 98.44% branch
- `git diff --check` clean

Companion dashboard patch: [cycles-dashboard PR #244](https://github.com/runcycles/cycles-dashboard/pull/244).