### PR TITLE
Configure encryption for release smoke test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,7 @@ jobs:
           -e REDIS_PORT=6379
           -e REDIS_PASSWORD=
           -e ADMIN_API_KEY=smoke-test-admin-key
+          -e WEBHOOK_SECRET_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
           ghcr.io/runcycles/cycles-server-admin:${VERSION}
 
       - name: Wait for /actuator/health/readiness

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -65,7 +65,9 @@ change the governance API or Redis value format.
 Local Compose manifests declare the plaintext opt-out alongside an empty key;
 production manifests continue to require the shared 32-byte key and explicitly
 keep the opt-out false. Unit and integration test configurations opt out only
-where plaintext fixtures are intentional.
+where plaintext fixtures are intentional. The published-image release smoke test
+supplies a fixed, non-production 32-byte key so it validates encrypted startup
+under the new fail-closed default.
 
 Verification used the protocol checkout's spec file after confirming its Git
 blob exactly matches the repository pin at `cycles-protocol@469840b`. Full


### PR DESCRIPTION
## What changed

- configure the published-image smoke container with a valid 32-byte webhook-secret encryption key
- record that the release smoke test validates encrypted startup under the fail-closed default

## Why

PR #219 made a missing webhook encryption key a startup failure. The release workflow still started its smoke container without a key, so publishing `v0.1.25.54` would push the image and then fail the smoke-test job even though the application default is working as intended.

## Impact

This only changes the transient release smoke container. Production deployments must continue to provide their own `WEBHOOK_SECRET_ENCRYPTION_KEY`; no runtime default or API behavior changes.

## Validation

- confirmed the smoke key decodes to exactly 32 bytes
- `git diff --check`
