### PR TITLE
Pin v0.1.25.54 and open v0.1.25.55

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,4 +1,4 @@
-# Complete Budget Governance v0.1.25.54 — Admin Server Audit
+# Complete Budget Governance v0.1.25.55 — Admin Server Audit
 
 **Spec:**
 [`cycles-governance-admin-v0.1.25.yaml`](https://github.com/runcycles/cycles-protocol/blob/469840bb2f41ce35650c89405ea12fc56e847c76/cycles-governance-admin-v0.1.25.yaml)
@@ -43,6 +43,20 @@ the `/test` synthetic-ping exception — .40 and .41 both implemented here in
 pin · tomcat-embed-core 10.1.55 pin
 (re-introduced 2026-05-25 for Apache Tomcat CVE-2026-43512 / -43513 / -43514 /
 -43515 / -42498 / -41284 / -41293)
+
+### 2026-07-18 — v0.1.25.54 published; production pins advanced; v0.1.25.55 opened
+
+GitHub release `v0.1.25.54` was published from merge commit `b88953b`. The
+release workflow's HIGH/CRITICAL vulnerability gate and published-image smoke
+test completed successfully, including encrypted startup, readiness, version,
+and authenticated error-envelope probes. The immutable `0.1.25.54` and moving
+`latest` GHCR tags both resolve to digest
+`sha256:36ae9d76a0b7c8a688d847d8b112d2726f696e3e4b9acd5e58f20100a1a0c2d5`.
+With the image available, both production Compose manifests now advance their
+admin self-pin from `0.1.25.53` to `0.1.25.54`; sibling full-stack image pins
+are unchanged. The Maven development revision advances from `0.1.25.54` to
+`0.1.25.55` immediately after release as required by the pre-release drift
+runbook; no `0.1.25.55` application or wire behavior is claimed yet.
 
 ### 2026-07-18 — v0.1.25.54: webhook secret encryption fails closed by default
 

--- a/cycles-admin-service/pom.xml
+++ b/cycles-admin-service/pom.xml
@@ -18,7 +18,7 @@
         <module>cycles-admin-service-api</module>
     </modules>
     <properties>
-        <revision>0.1.25.54</revision>
+        <revision>0.1.25.55</revision>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/docker-compose.full-stack.prod.yml
+++ b/docker-compose.full-stack.prod.yml
@@ -22,7 +22,7 @@ services:
 
   cycles-admin:
     logging: *default-logging
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.53
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.54
     restart: unless-stopped
     ports:
       - "7979:7979"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -22,7 +22,7 @@ services:
 
   cycles-admin:
     logging: *default-logging
-    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.53
+    image: ghcr.io/runcycles/cycles-server-admin:0.1.25.54
     restart: unless-stopped
     ports:
       - "7979:7979"


### PR DESCRIPTION
## What changed

- pin both production Compose manifests to the published `cycles-server-admin:0.1.25.54` image
- advance the Maven development revision to `0.1.25.55`
- record the successful release workflow, smoke probes, and immutable GHCR digest

## Why

This is the repository's standard post-release drift step after publishing `v0.1.25.54`. It keeps production manifests on an available immutable image while opening the next development patch version.

## Release verification

- GitHub release: `v0.1.25.54` from `b88953b`
- release workflow: passed build, HIGH/CRITICAL Trivy gate, GHCR push, and published-image smoke test
- image digest: `sha256:36ae9d76a0b7c8a688d847d8b112d2726f696e3e4b9acd5e58f20100a1a0c2d5`
- readiness, reported version `0.1.25.54`, and authenticated error-envelope probes passed

## Validation

- parsed the Maven POM and confirmed revision `0.1.25.55`
- `docker compose config --quiet` for both production manifests
- `git diff --check`

`mvn-proxy` is unavailable in this environment; no Maven build is needed for these version/pin-only changes, and the release commit's complete GitHub CI suite passed before publication.
