### PR TITLE
docs: close v0.1.25.55 release provenance

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -46,7 +46,7 @@ pin · tomcat-embed-core 10.1.55 pin
 (re-introduced 2026-05-25 for Apache Tomcat CVE-2026-43512 / -43513 / -43514 /
 -43515 / -42498 / -41284 / -41293)
 
-### 2026-07-20 — v0.1.25.55: enforce the policy priority contract
+### 2026-07-21 — v0.1.25.55: enforce the policy priority contract
 
 Governance spec revision 0.1.25.42 resolves a request/response contradiction:
 `Policy.priority` already had `minimum: 0`, while the create and update request
@@ -61,6 +61,10 @@ persist a policy that its own successful response schema could not represent.
   field on a legacy row.
 - Contract tests now pin cycles-protocol commit `402307a` so CI validates the
   exact 0.1.25.42 schema rather than a moving branch.
+- The pre-release provenance sweep records the two workflow-only commits since
+  v0.1.25.54: `actions/setup-java` 5.6.0 and
+  `github/codeql-action/upload-sarif` 4.37.1. Both remain SHA-pinned and neither
+  changes the application artifact or wire contract.
 
 Focused model and controller verification passes 43 tests. A clean full
 non-integration Maven verification passes 1,855 tests with zero failures or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ changes to request/response bodies or Lua-script semantics would require a
 minor bump. Additive fields (new optional response fields, new enum values,
 new optional request fields) are **not** considered breaking.
 
-## [0.1.25.55] — 2026-07-20
+## [0.1.25.55] — 2026-07-21
 
 ### Fixed
 
@@ -26,6 +26,12 @@ new optional request fields) are **not** considered breaking.
 
 - Contract validation advances to governance spec revision 0.1.25.42 at the
   reviewed cycles-protocol commit that defines the request-side minimum.
+
+### Internal
+
+- Refresh the SHA-pinned `actions/setup-java` and
+  `github/codeql-action/upload-sarif` workflow dependencies. These changes do
+  not affect the published server image or API behavior.
 
 ## [0.1.25.54] — 2026-07-18
 


### PR DESCRIPTION
## Summary

- align the v0.1.25.55 CHANGELOG and AUDIT dates with the July 21 release
- record the two SHA-pinned workflow dependency updates merged since v0.1.25.54
- close the repository's pre-tag provenance checklist before publishing the release

## Why

The v0.1.25.55 implementation is already merged and green, but the pre-release drift check found that the setup-java and CodeQL upload action updates had no home in the release notes. Publishing without this documentation would violate the release runbook.

## Validation

- `git diff --check`
- pom revision, CHANGELOG version/date, and AUDIT version/date all align at `0.1.25.55` / `2026-07-21`
- all application CI on merged PR #224 and `main` is green; this follow-up changes documentation only
